### PR TITLE
Close queue when finished

### DIFF
--- a/hydra/fairtask_launcher.py
+++ b/hydra/fairtask_launcher.py
@@ -75,8 +75,7 @@ class FAIRTaskLauncher(Launcher):
         print("Sweep output dir : {}".format(self.hydra_cfg.hydra.sweep.dir))
         os.makedirs(self.hydra_cfg.hydra.sweep.dir, exist_ok=True)
         loop = asyncio.get_event_loop()
-        queue = self.create_queue(self.hydra_cfg.hydra, len(self.sweep_configs))
-        loop.run_until_complete(self.run_sweep(queue, self.sweep_configs))
-        queue.close()
+        with self.create_queue(self.hydra_cfg.hydra, len(self.sweep_configs)) as queue:
+            loop.run_until_complete(self.run_sweep(queue, self.sweep_configs))
 
         return self.sweep_configs


### PR DESCRIPTION
Prevents extra jobs from being created.

When I tested on the sweep example before rebasing to master, it prevented a job from being submitted at exit. After rebasing I get this:
```bash
[calebh@devfair020] 13:12 $ python demos/6_sweep/sweep_example.py --sweep
Traceback (most recent call last):
  File "demos/6_sweep/sweep_example.py", line 17, in <module>
    sys.exit(experiment())
  File "/private/home/calebh/hydra/hydra/hydra.py", line 172, in decorated_main
    run_hydra(task_function, config_path)
  File "/private/home/calebh/hydra/hydra/hydra.py", line 144, in run_hydra
    hydra.sweep(overrides=args.overrides)
  File "/private/home/calebh/hydra/hydra/hydra.py", line 80, in sweep
    hydra_cfg = self._create_hydra_cfg(overrides)
  File "/private/home/calebh/hydra/hydra/hydra.py", line 66, in _create_hydra_cfg
    return utils.create_hydra_cfg(cfg_dir=self.conf_dir, hydra_cfg_defaults=defaults, overrides=overrides)
  File "/private/home/calebh/hydra/hydra/utils.py", line 148, in create_hydra_cfg
    hydra_cfg = OmegaConf.merge(hydra_cfg_defaults, hydra_cfg)
  File "/private/home/calebh/miniconda3/envs/hydra/lib/python3.7/site-packages/omegaconf/omegaconf.py", line 639, in merge
    target.merge_with(*others[1:])
  File "/private/home/calebh/miniconda3/envs/hydra/lib/python3.7/site-packages/omegaconf/omegaconf.py", line 301, in merge_with
    self.__dict__['content'] = Config.map_merge(self, other)
  File "/private/home/calebh/miniconda3/envs/hydra/lib/python3.7/site-packages/omegaconf/omegaconf.py", line 286, in map_merge
    dest[key].merge_with(value)
  File "/private/home/calebh/miniconda3/envs/hydra/lib/python3.7/site-packages/omegaconf/omegaconf.py", line 301, in merge_with
    self.__dict__['content'] = Config.map_merge(self, other)
  File "/private/home/calebh/miniconda3/envs/hydra/lib/python3.7/site-packages/omegaconf/omegaconf.py", line 286, in map_merge
    dest[key].merge_with(value)
  File "/private/home/calebh/miniconda3/envs/hydra/lib/python3.7/site-packages/omegaconf/omegaconf.py", line 301, in merge_with
    self.__dict__['content'] = Config.map_merge(self, other)
  File "/private/home/calebh/miniconda3/envs/hydra/lib/python3.7/site-packages/omegaconf/omegaconf.py", line 290, in map_merge
    dest[key] = src[key]
  File "/private/home/calebh/miniconda3/envs/hydra/lib/python3.7/site-packages/omegaconf/omegaconf.py", line 437, in __getitem__
    return self.__getattr__(key)
  File "/private/home/calebh/miniconda3/envs/hydra/lib/python3.7/site-packages/omegaconf/omegaconf.py", line 429, in __getattr__
    return self._resolve_with_default(key=key, value=self.get(key), default_value=None)
  File "/private/home/calebh/miniconda3/envs/hydra/lib/python3.7/site-packages/omegaconf/omegaconf.py", line 440, in get
    return self._resolve_with_default(key=key, value=self.content.get(key), default_value=default_value)
  File "/private/home/calebh/miniconda3/envs/hydra/lib/python3.7/site-packages/omegaconf/omegaconf.py", line 90, in _resolve_with_default
    return self._resolve_single(value) if isinstance(value, str) else value
  File "/private/home/calebh/miniconda3/envs/hydra/lib/python3.7/site-packages/omegaconf/omegaconf.py", line 361, in _resolve_single
    new_val = Config.resolve_value(root, match.group(1), match.group(2))
  File "/private/home/calebh/miniconda3/envs/hydra/lib/python3.7/site-packages/omegaconf/omegaconf.py", line 334, in resolve_value
    ret = resolver(inter_key)
  File "/private/home/calebh/miniconda3/envs/hydra/lib/python3.7/site-packages/omegaconf/omegaconf.py", line 652, in caching
    val = cache[key] if key in cache else resolver(key)
  File "/private/home/calebh/hydra/hydra/utils.py", line 34, in get
    raise KeyError("Key not found in JobRuntime: {}".format(key))
KeyError: 'Key not found in JobRuntime: num'
```