### PR TITLE
[outputs] Update hydra.yaml in outputs folder

### DIFF
--- a/hydra/plugins/common/utils.py
+++ b/hydra/plugins/common/utils.py
@@ -68,7 +68,8 @@ def run_job(config, task_function, verbose, job_dir_key, job_subdir_key):
         ret = JobReturn()
         ret.working_dir = working_dir
         task_cfg = copy.deepcopy(config)
-        hydra_cfg = task_cfg["hydra"]
+        # TODO: update this after https://github.com/omry/omegaconf/issues/42 is resolved
+        hydra_cfg = OmegaConf.create({"hydra": task_cfg["hydra"]});
         del task_cfg["hydra"]
         ret.cfg = task_cfg
         ret.hydra_cfg = copy.deepcopy(HydraConfig())


### PR DESCRIPTION
Update the generated `hydra.yaml` in `outputs` folder to be correctly rooted at `hydra:`

Testing:
ran `pytest` locally, on Python3


fixes #160 