### PR TITLE
Output subfolder

### DIFF
--- a/hydra/conf/hydra.yaml
+++ b/hydra/conf/hydra.yaml
@@ -23,7 +23,7 @@ hydra:
   # Output directory for produced configuration files and overrides.
   # E.g., hydra.yaml, overrides.yaml will go here. Useful for debugging
   # and extra context when looking at past runs.
-  output: ".hydra"
+  output_subdir: ".hydra"
 
   # Those lists will contain runtime overrides
   overrides:

--- a/hydra/plugins/common/utils.py
+++ b/hydra/plugins/common/utils.py
@@ -40,9 +40,9 @@ def configure_log(log_config, verbose_config):
             logging.getLogger(logger).setLevel(logging.DEBUG)
 
 
-def _save_config(cfg, filename, config_dir):
-    Path(str(config_dir)).mkdir(parents=True, exist_ok=True)
-    with open(os.path.join(config_dir, filename), "w") as file:
+def _save_config(cfg, filename, output_dir):
+    Path(str(output_dir)).mkdir(parents=True, exist_ok=True)
+    with open(str(output_dir / filename), "w") as file:
         file.write(cfg.pretty())
 
 
@@ -79,15 +79,15 @@ def run_job(config, task_function, job_dir_key, job_subdir_key):
         ret.cfg = task_cfg
         ret.hydra_cfg = copy.deepcopy(HydraConfig())
         ret.overrides = config.hydra.overrides.task.to_container()
+        # handle output directories here
         Path(str(working_dir)).mkdir(parents=True, exist_ok=True)
         os.chdir(working_dir)
+        hydra_output = Path(hydra_cfg.hydra.output_subdir)
 
         configure_log(hydra_cfg.hydra.job_logging, hydra_cfg.hydra.verbose)
-        _save_config(task_cfg, "config.yaml", hydra_cfg.hydra.output)
-        _save_config(hydra_cfg, "hydra.yaml", hydra_cfg.hydra.output)
-        _save_config(
-            config.hydra.overrides.task, "overrides.yaml", hydra_cfg.hydra.output
-        )
+        _save_config(task_cfg, "config.yaml", hydra_output)
+        _save_config(hydra_cfg, "hydra.yaml", hydra_output)
+        _save_config(config.hydra.overrides.task, "overrides.yaml", hydra_output)
         ret.return_value = task_function(task_cfg)
         ret.task_name = JobRuntime().get("name")
         return ret

--- a/hydra/test_utils/test_utils.py
+++ b/hydra/test_utils/test_utils.py
@@ -185,7 +185,10 @@ def verify_dir_outputs(job_return, overrides=None):
     assert os.path.exists(
         os.path.join(job_return.working_dir, job_return.task_name + ".log")
     )
-    hydra_dir = os.path.join(job_return.working_dir, ".hydra")
+
+    hydra_dir = os.path.join(
+        job_return.working_dir, job_return.hydra_cfg.hydra.output_subdir
+    )
     assert os.path.exists(os.path.join(hydra_dir, "config.yaml"))
     assert os.path.exists(os.path.join(hydra_dir, "overrides.yaml"))
     assert OmegaConf.load(

--- a/news/77.feature
+++ b/news/77.feature
@@ -1,0 +1,1 @@
+Move all Hydra configuration files to a subfolder (.hydra by default) under the output folder

--- a/website/docs/tutorial/100_working_directory.md
+++ b/website/docs/tutorial/100_working_directory.md
@@ -4,7 +4,7 @@ title: Output/Working directory
 sidebar_label: Output/Working directory
 ---
 
-Hydra solves the problem of you needing to specify a new output directory for each run, by 
+Hydra solves the problem of your needing to specify a new output directory for each run, by 
 creating a directory for each run and executing your code within that directory.
 
 The working directory is used to:


### PR DESCRIPTION
## Motivation

Moves all of hydra config files, overrides and current matadata to a subfolder in the working dir.
By default, the subfolder is called `.hydra`.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan
Ran tests locally.
Ran `black` and `flake8`, but not full nox
## Related Issues and PRs

Closes #77 