### PR TITLE
[bugfixes] fix Python2.7 pathlib2 missing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ with open("README.md", "r") as fh:
             "Operating System :: MacOS",
             "Operating System :: Microsoft :: Windows",
         ],
-        install_requires=["omegaconf>=1.3.0"],
+        install_requires=["omegaconf>=1.3.0", 'pathlib2>=2.2.0;python_version<"3.6"'],
         # Install development dependencies with
         # pip install -e .[dev]
         extras_require={


### PR DESCRIPTION
## Motivation

Fix missing dependency.
Previously, `pathlib` was only used in tests, and it's pulled in from `pytest` dependencies. Now it's used outside of tests too, but nothing declares `pathlib2` as dependency for Python2.7.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan
Ran locally:
`nox -v -s test_plugin-2.7`

Since I cannot use circle :'(

