### PR TITLE
[website] add google analytics tracking ID

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -14,6 +14,9 @@ module.exports = {
     organizationName: 'facebookresearch', // Usually your GitHub org/user name.
     projectName: 'hydra', // Usually your repo name.
     themeConfig: {
+        googleAnalytics: {
+          trackingID: 'UA-149862507-1',
+        },
         navbar: {
             title: 'Hydra',
             logo: {


### PR DESCRIPTION
## Motivation

As title

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan
I don't know whether it'll work or not.
I grepped the resulting site, and the tracking ID is definitely there.

## Related Issues and PRs
Closes #220 