### PR TITLE
moved version back to hydra/__init__.py

### DIFF
--- a/hydra/__init__.py
+++ b/hydra/__init__.py
@@ -1,7 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from . import version
 from . import utils
 from .errors import MissingConfigException
 from .main import main
 
-__all__ = ["version", "MissingConfigException", "main", "utils"]
+# Source of truth for Hydra's version
+__version__ = "0.9.0"
+
+__all__ = ["__version__", "MissingConfigException", "main", "utils"]

--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import copy
 import logging
 import os
-import copy
 import string
 from collections import defaultdict
 from os.path import realpath, dirname, splitext, basename
@@ -344,9 +344,9 @@ class Hydra:
     def _load_config(self, overrides):
         cfg = self.config_loader.load_configuration(overrides)
         with open_dict(cfg):
-            from .. import version
+            from .. import __version__
 
-            cfg.hydra.runtime.version = version.number
+            cfg.hydra.runtime.version = __version__
             cfg.hydra.runtime.cwd = os.getcwd()
         configure_log(cfg.hydra.hydra_logging, cfg.hydra.verbose)
         global log

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -74,14 +74,15 @@ def _get_exec_command():
         return executable
 
 
-def get_args_parser(version=None):
+def get_args_parser():
+    from hydra import __version__
+
     parser = argparse.ArgumentParser(add_help=False, description="Hydra")
     parser.add_argument("--help", "-h", action="store_true", help="Application's help")
     parser.add_argument("--hydra-help", action="store_true", help="Hydra's help")
-    if version is not None:
-        parser.add_argument(
-            "--version", action="version", version="Hydra {}".format(version)
-        )
+    parser.add_argument(
+        "--version", action="version", version="Hydra {}".format(__version__)
+    )
     parser.add_argument(
         "overrides",
         nargs="*",
@@ -126,5 +127,5 @@ def get_args_parser(version=None):
     return parser
 
 
-def get_args(args=None, version=None):
-    return get_args_parser(version=version).parse_args(args=args)
+def get_args(args=None):
+    return get_args_parser().parse_args(args=args)

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -75,7 +75,7 @@ def _get_exec_command():
 
 
 def get_args_parser():
-    from hydra import __version__
+    from .. import __version__
 
     parser = argparse.ArgumentParser(add_help=False, description="Hydra")
     parser.add_argument("--help", "-h", action="store_true", help="Application's help")

--- a/hydra/main.py
+++ b/hydra/main.py
@@ -1,7 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import functools
 import sys
-from hydra import version
 from ._internal.utils import run_hydra, get_args_parser
 
 
@@ -19,7 +18,7 @@ def main(config_path="", strict=None):
         def decorated_main():
             try:
                 run_hydra(
-                    args_parser=get_args_parser(version=version.number),
+                    args_parser=get_args_parser(),
                     task_function=task_function,
                     config_path=config_path,
                     strict=strict,

--- a/hydra/version.py
+++ b/hydra/version.py
@@ -1,3 +1,0 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-# Source of truth for Hydra's version
-number = "0.9.0"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def read(*parts):
 
 def find_version(*file_paths):
     version_file = read(*file_paths)
-    version_match = re.search(r"^number = ['\"]([^'\"]*)['\"]", version_file, re.M)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
@@ -83,7 +83,7 @@ with open("README.md", "r") as fh:
     setup(
         cmdclass={"clean": CleanCommand},
         name="hydra-core",
-        version=find_version("hydra", "version.py"),
+        version=find_version("hydra", "__init__.py"),
         author="Omry Yadan",
         author_email="omry@fb.com",
         description="Hydra is a library for writing flexible command line applications",


### PR DESCRIPTION
towncrier is relying on `__version__` in `hydra/__init__.py`.