### PR TITLE
[website] docusaurus alpha26: correct use of the classic presets

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -17,9 +17,6 @@ module.exports = {
         googleAnalytics: {
           trackingID: 'UA-149862507-1',
         },
-        showLastUpdateAuthor: true,
-        showLastUpdateTime: true,
-        editUrl: 'https://github.com/facebookresearch/hydra/edit/master/website/docs/',
         navbar: {
             title: 'Hydra',
             logo: {
@@ -68,6 +65,10 @@ module.exports = {
                 theme: {
                     customCss: require.resolve('./src/css/custom.css'),
                 },
+                showLastUpdateAuthor: true,
+                showLastUpdateTime: true,
+                editUrl: 'https://github.com/facebookresearch/hydra/edit/master/website/docs/',
+
             },
         ],
     ],


### PR DESCRIPTION
## Motivation

The current use of 3 parameters (show time, show author & url) is incorrect. Place them in their correct location.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Tested locally, but didn't see the updated at/by footer.
This is the correct location for these properties, so it's better to make the change, or remove altogether.

## Related PRs

#224 