### PR TITLE
creating objects: asserting on the `params` type; closes #231

### DIFF
--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import logging.config
 
-from omegaconf import OmegaConf
+from omegaconf import OmegaConf, DictConfig
 
 # pylint: disable=C0103
 log = logging.getLogger(__name__)
@@ -46,6 +46,11 @@ def instantiate(config, *args, **kwargs):
     try:
         clazz = get_class(config["class"])
         params = config.params if "params" in config else OmegaConf.create()
+        assert isinstance(
+            params, DictConfig
+        ), "Input config params are expected to be key-value items, found {}".format(
+            type(config.params)
+        )
         params.merge_with(OmegaConf.create(kwargs))
         return clazz(*args, **params)
     except Exception as e:

--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -48,7 +48,7 @@ def instantiate(config, *args, **kwargs):
         params = config.params if "params" in config else OmegaConf.create()
         assert isinstance(
             params, DictConfig
-        ), "Input config params are expected to be key-value items, found {}".format(
+        ), "Input config params are expected to be a mapping, found {}".format(
             type(config.params)
         )
         params.merge_with(OmegaConf.create(kwargs))


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Asserting on the `params` attribute when using common patterns and raising concise message is much more better than low level debugging messages to the user. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

I'm not yet sure how Hydra does validate the types or layers of architecture. 

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)

Fixes #231 
