### PR TITLE
correcting the tab completion command

### DIFF
--- a/website/docs/tutorial/7_tab_completion.md
+++ b/website/docs/tutorial/7_tab_completion.md
@@ -5,7 +5,7 @@ sidebar_label: Tab completion
 ---
 You can enable shell TAB completion, for example:
 ```
-eval "$(python my_app.py -sc install=SHELL_NAME)"
+eval "$(python my_app.py -sc hydra.shell.install=SHELL_NAME)"
 ```
 Get the exact command to install the completion from `--hydra-help`.
 


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Correcting the command used for enabling the tab completion, it was `install=SHELL_NAME` where `hydra.shell.install=SHELL_NAME` should be used. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
