### PR TITLE
Changed default sweep subdir to ${hydra.job.num}

### DIFF
--- a/hydra/conf/hydra/output/default.yaml
+++ b/hydra/conf/hydra/output/default.yaml
@@ -3,4 +3,4 @@ hydra:
     dir: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
   sweep:
     dir: multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
-    subdir: ${hydra.job.num}_${hydra.job.id}
+    subdir: ${hydra.job.num}

--- a/hydra/test_utils/launcher_common_tests.py
+++ b/hydra/test_utils/launcher_common_tests.py
@@ -7,6 +7,7 @@ import pytest
 from omegaconf import OmegaConf
 from hydra.test_utils.test_utils import integration_test
 from hydra.test_utils.test_utils import verify_dir_outputs
+from hydra._internal.pathlib import Path
 
 
 class LauncherTestSuite:
@@ -119,6 +120,8 @@ def sweep_2_jobs(sweep_runner, overrides):
             assert job_ret.cfg == expected_conf
             assert job_ret.hydra_cfg.hydra.job.name == "a_module"
             verify_dir_outputs(job_ret, job_ret.overrides)
+            path = Path(sweep.temp_dir) / str(i)
+            assert path.exists()
 
 
 def not_sweeping_hydra_overrides(sweep_runner, overrides):

--- a/hydra/test_utils/test_utils.py
+++ b/hydra/test_utils/test_utils.py
@@ -116,13 +116,9 @@ def sweep_runner():
 
         def __init__(self):
             self.temp_dir = None
-            self.cfg = None
-            self.overrides = None
             self.hydra = None
             self.sweeps = None
             self.returns = None
-
-            self.all_configs = None
 
         def __call__(self, cfg):
             """

--- a/news/150.config
+++ b/news/150.config
@@ -1,0 +1,1 @@
+Change the default sweep subdir from NUM_ID to NUM

--- a/news/150.docs
+++ b/news/150.docs
@@ -1,0 +1,1 @@
+Describe news fragment types in more details in development/contributing

--- a/website/docs/development/contributing.md
+++ b/website/docs/development/contributing.md
@@ -75,9 +75,15 @@ such, but it is preferred to have a dedicated issue (for example, in case the
 PR ends up rejected due to code quality reasons).
 
 Once you have an issue or pull request, you take the number and you create a
-file inside of the ``news/`` directory named after that issue number with an
-extension of ``removal``, ``feature``, ``bugfix``, ``docs`` or ``plugin``. Thus if your
-issue or PR number is ``1234`` and this change is fixing a bug, then you would
+file inside of the ``news/`` directory named after that issue number with one of the following extensions:
+* `removal` : Removal of deprecation of a feature
+* `feature` : Addition of a new feature
+* `bugfix` : Fixing of a bug
+* `docs` : Addition or updates to documentation
+* `plugin` : Addition of changes to a plugin
+* `config` : Changes or addition to the configuration structure
+
+If your issue or PR number is ``1234`` and this change is fixing a bug, then you would
 create a file ``news/1234.bugfix``. PRs can span multiple categories by creating
 multiple files (for instance, if you added a feature and deprecated/removed the
 old feature at the same time, you would create ``news/NNNN.feature`` and


### PR DESCRIPTION
## Motivation
Using the job ID by default interfere with the ability to resume a job if it gets killed and re-queued because the job starts in a different directory.

## Test Plan

Unit tests
