### PR TITLE
fixed out of order composition in some cases

### DIFF
--- a/hydra/_internal/config_loader.py
+++ b/hydra/_internal/config_loader.py
@@ -187,9 +187,6 @@ class ConfigLoader:
                     idx = key_to_idx[key]
                     primary[idx] = d
                     merged_list.remove(d)
-            else:
-                primary.append(d)
-                merged_list.remove(d)
 
         for d in merged_list:
             primary.append(d)

--- a/hydra/test_utils/configs/mixed_compose.yaml
+++ b/hydra/test_utils/configs/mixed_compose.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - some_config
+  - group1: file1
+  - config

--- a/news/251.feature
+++ b/news/251.feature
@@ -1,1 +1,1 @@
-Adds hydra.utils.get_original_cwd() to access original working directory and hydra.utils.get_relative_path() to convert a path to absolute path
+Adds hydra.utils.get_original_cwd() to access original working directory and hydra.utils.to_absolute_path() to convert a path to absolute path

--- a/news/261.bugfix
+++ b/news/261.bugfix
@@ -1,0 +1,1 @@
+Fix a bug that caused out of order composition when mixing config-groups with non-config-group in the defaults block

--- a/tests/test_conf_loader.py
+++ b/tests/test_conf_loader.py
@@ -330,7 +330,11 @@ def test_non_config_group_default():
     ]
 
 
-def test_non_config_group_default():
+def test_mixed_composition_order():
+    """
+    Tests that the order of mixed composition (defaults contains both config group and non config group
+    items) is correct
+    """
     config_loader = ConfigLoader(
         config_search_path=create_search_path(["hydra/test_utils/configs"]),
         strict_cfg=False,

--- a/tests/test_conf_loader.py
+++ b/tests/test_conf_loader.py
@@ -328,3 +328,26 @@ def test_non_config_group_default():
         ("non_config_group_default.yaml", "hydra/test_utils/configs", "test"),
         ("some_config.yaml", "hydra/test_utils/configs", "test"),
     ]
+
+
+def test_non_config_group_default():
+    config_loader = ConfigLoader(
+        config_search_path=create_search_path(["hydra/test_utils/configs"]),
+        strict_cfg=False,
+        config_file="mixed_compose.yaml",
+    )
+    config_loader.load_configuration()
+    assert config_loader.get_load_history() == [
+        ("hydra.yaml", "pkg://hydra.conf", "hydra"),
+        ("hydra/hydra_logging/default.yaml", "pkg://hydra.conf", "hydra"),
+        ("hydra/job_logging/default.yaml", "pkg://hydra.conf", "hydra"),
+        ("hydra/launcher/basic.yaml", "pkg://hydra.conf", "hydra"),
+        ("hydra/sweeper/basic.yaml", "pkg://hydra.conf", "hydra"),
+        ("hydra/output/default.yaml", "pkg://hydra.conf", "hydra"),
+        ("hydra/help/default.yaml", "pkg://hydra.conf", "hydra"),
+        ("hydra/hydra_help/default.yaml", "pkg://hydra.conf", "hydra"),
+        ("mixed_compose.yaml", "hydra/test_utils/configs", "test"),
+        ("some_config.yaml", "hydra/test_utils/configs", "test"),
+        ("group1/file1.yaml", "hydra/test_utils/configs", "test"),
+        ("config.yaml", "hydra/test_utils/configs", "test"),
+    ]


### PR DESCRIPTION
When defaults block contains both config groups and non-config groups defaults, the composition order was wrong.
This PR fixes it.
closes #261 