### PR TITLE
Fixing 283

### DIFF
--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -99,7 +99,7 @@ class Hydra:
             )
 
     def run(self, overrides):
-        cfg = self._load_config(overrides)
+        cfg = self._load_config(overrides, strict=None)
         HydraConfig().set_config(cfg)
         return run_job(
             config=cfg,
@@ -109,7 +109,7 @@ class Hydra:
         )
 
     def multirun(self, overrides):
-        cfg = self._load_config(overrides)
+        cfg = self._load_config(overrides, strict=False)
         HydraConfig().set_config(cfg)
         sweeper = Plugins.instantiate_sweeper(
             config=cfg,
@@ -335,8 +335,14 @@ class Hydra:
         self._print_search_path()
         self._print_composition_trace()
 
-    def _load_config(self, overrides):
-        cfg = self.config_loader.load_configuration(overrides)
+    def _load_config(self, overrides, strict=None):
+        """
+        :param overrides:
+        :param strict: None for default behavior (default to true for config file, false if no config file).
+                       otherwise forces specific behavior.
+        :return:
+        """
+        cfg = self.config_loader.load_configuration(overrides, strict=strict)
         with open_dict(cfg):
             from .. import __version__
 

--- a/hydra/test_utils/configs/db_conf.yaml
+++ b/hydra/test_utils/configs/db_conf.yaml
@@ -1,5 +1,2 @@
 defaults:
   - db: mysql
-
-db:
-  user: ???

--- a/hydra/test_utils/launcher_common_tests.py
+++ b/hydra/test_utils/launcher_common_tests.py
@@ -183,7 +183,7 @@ def not_sweeping_hydra_overrides(sweep_runner, overrides):
     """
     Runs a sweep with two jobs
     """
-    overrides.extend(["a=0,1", "hydra.foo=1,2,3"])
+    overrides.extend(["a=0,1", "hydra.verbose=true,false"])
     sweep = sweep_runner(
         calling_file=None,
         calling_module="hydra.test_utils.a_module",

--- a/hydra/test_utils/launcher_common_tests.py
+++ b/hydra/test_utils/launcher_common_tests.py
@@ -78,20 +78,6 @@ class LauncherTestSuite:
     def test_sweep_and_override(
         self, sweep_runner, launcher_name, overrides
     ):  # noqa: F811
-        """
-        This test validates the behavior that happens in issue #283.
-        While constructing the main config, Hydra is skipping the db config group overrides as they are a part of a
-        sweep and will be loaded later.
-        when merging in db.user, there is no such node and this causes an error in strict mode.
-        This is expected behavior, solving it automatically will require validating that we can apply db.user to
-        each of the sweep configs. This can be very expensive for large sweeps so it's not a viable solution.
-        Instead, the solution is for the user to create scaffolding for db.user in the main config, for example:
-        db:
-          user: ???
-
-        This makes sense because overriding db.user in a sweep essentially calls out db.user as
-        existing in all sweep variants.
-        """
         base_overrides = [
             "hydra/launcher=" + launcher_name,
             "db=mysql,postgresql",


### PR DESCRIPTION
This is a tricky one.
When Sweeping, for example on db=mysql,postgresql, if the user wants to override something in the sweep - like db.user=foo, there is a problem:
When loading the initial config the db node is not yet populated so overriding db.user fails due to strict mode.
The solution is - in sweep, to disable strict mode while creating the initial config and enable it (per current logic) when creating individual configs for each sweep job.

Closes #283 