### PR TITLE
0.11.0 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,35 @@
+0.11.0 (2019-11-19)
+===================
+
+Features
+--------
+
+- Add hydra.experimental API for composing configuration on demand (hydra.experimental.compose) (#219)
+- Add hydra.utils.get_original_cwd() to access original working directory and hydra.utils.to_absolute_path() to convert a path to absolute path (#251)
+- Change hydra logging format pattern, example: "[2019-10-22 16:13:10,769][HYDRA] Installed Hydra Plugins" (#254)
+- Change --cfg to require config type (one of 'job', 'hydra' or 'all') (#270)
+- Upgrade to OmegaConf 1.4.0, see full change log [here](https://github.com/omry/omegaconf/releases/tag/1.4.0) (#280)
+- Experimental support for Jupyter notebooks via compose API (#281)
+- Allow configuring override_dirname via hydra.job.config.override_dirname to exclude specific keys or change separator characters (#95)
+
+Bug Fixes
+---------
+
+- Fix a bug that caused out of order composition when mixing config-groups with non-config-group in the defaults block (#261)
+- Allow '=' to be used in the value of an override, eg. foo=bar=10 (key foo, value bar=10). (#266)
+- Allow composing config files with dot in their name (foo.bar.yaml) (#271)
+
+Plugins
+-------
+
+- hydra-colorlog plugin adds colored log output.
+
+Improved Documentation
+----------------------
+
+- Document utils.get_original_cwd() and utils.to_absolute_path("foo") (#251)
+
+
 0.10.0 (2019-10-19)
 ===================
 

--- a/hydra/__init__.py
+++ b/hydra/__init__.py
@@ -4,6 +4,6 @@ from .errors import MissingConfigException
 from .main import main
 
 # Source of truth for Hydra's version
-__version__ = "0.11.0-pre1"
+__version__ = "0.11.0"
 
 __all__ = ["__version__", "MissingConfigException", "main", "utils"]

--- a/news/219.feature
+++ b/news/219.feature
@@ -1,1 +1,0 @@
-Add hydra.experimental API for composing configuration on demand (hydra.experimental.compose)

--- a/news/251.docs
+++ b/news/251.docs
@@ -1,1 +1,0 @@
-Document utils.get_original_cwd() and utils.to_absolute_path("foo")

--- a/news/251.feature
+++ b/news/251.feature
@@ -1,1 +1,0 @@
-Adds hydra.utils.get_original_cwd() to access original working directory and hydra.utils.to_absolute_path() to convert a path to absolute path

--- a/news/254.feature
+++ b/news/254.feature
@@ -1,1 +1,0 @@
-Change hydra logging format pattern, example: "[2019-10-22 16:13:10,769][HYDRA] Installed Hydra Plugins"

--- a/news/261.bugfix
+++ b/news/261.bugfix
@@ -1,1 +1,0 @@
-Fix a bug that caused out of order composition when mixing config-groups with non-config-group in the defaults block

--- a/news/266.bugfix
+++ b/news/266.bugfix
@@ -1,1 +1,0 @@
-Allow '=' to be used in the value of an override, eg. foo=bar=10 (key foo, value bar=10).

--- a/news/270.feature
+++ b/news/270.feature
@@ -1,1 +1,0 @@
-Change --cfg to require config type (one of job, hydra or all)

--- a/news/271.bugfix
+++ b/news/271.bugfix
@@ -1,1 +1,0 @@
-Allow composing config files with dot in their name (foo.bar.yaml)

--- a/news/275.trivial
+++ b/news/275.trivial
@@ -1,1 +1,0 @@
-Document hydra.job in hydra.yaml and simplify handling of hydra.job.override_dirname

--- a/news/280.feature
+++ b/news/280.feature
@@ -1,1 +1,0 @@
-Upgrade to OmegaConf 1.4.0, see full change log [here](https://github.com/omry/omegaconf/releases/tag/1.4.0)

--- a/news/281.feature
+++ b/news/281.feature
@@ -1,1 +1,0 @@
-Add Jupiter notebook support via experimental compose API

--- a/news/53.plugin
+++ b/news/53.plugin
@@ -1,1 +1,0 @@
-hydra-colorlog plugin adds colored log output.

--- a/news/95.feature
+++ b/news/95.feature
@@ -1,2 +1,0 @@
-Allow configuring override_dirname via hydra.job.config.override_dirname to exclude specific keys or change separator characters
-


### PR DESCRIPTION
0.11.0 (2019-11-19)
===================

Features
--------

- Add hydra.experimental API for composing configuration on demand (hydra.experimental.compose) (#219)
- Add hydra.utils.get_original_cwd() to access original working directory and hydra.utils.to_absolute_path() to convert a path to absolute path (#251)
- Change hydra logging format pattern, example: "[2019-10-22 16:13:10,769][HYDRA] Installed Hydra Plugins" (#254)
- Change --cfg to require config type (one of 'job', 'hydra' or 'all') (#270)
- Upgrade to OmegaConf 1.4.0, see full change log [here](https://github.com/omry/omegaconf/releases/tag/1.4.0) (#280)
- Experimental support for Jupyter notebooks via compose API (#281)
- Allow configuring override_dirname via hydra.job.config.override_dirname to exclude specific keys or change separator characters (#95)

Bug Fixes
---------

- Fix a bug that caused out of order composition when mixing config-groups with non-config-group in the defaults block (#261)
- Allow '=' to be used in the value of an override, eg. foo=bar=10 (key foo, value bar=10). (#266)
- Allow composing config files with dot in their name (foo.bar.yaml) (#271)

Plugins
-------

- hydra-colorlog plugin adds colored log output.

Improved Documentation
----------------------

- Document utils.get_original_cwd() and utils.to_absolute_path("foo") (#251)


