### PR TITLE
[circle/website] deploy website when website subfolder has changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,18 +179,20 @@ jobs:
           name: Deploying to GitHub Pages
           command: |
             SUBDIR=website
-            if [[ $(git log --pretty=format:'%h' origin/master... $SUBDIR) ]]; then
+            REV=$(git log -1 --pretty=oneline origin/gh-pages | awk 'NF>1{print $NF}')
+            git diff-index --quiet $REV -- $SUBDIR
+            if [ $? -eq 0 ]; then
+              echo "No changes detected in directory $SUBDIR between origin/master and this diff"
+            else
               echo "Changes detected in directory $SUBDIR between origin/master and this diff"
 
-              cd website
+              cd $SUBDIR
               yarn --no-progress
 
               git config --global user.email omry@users.noreply.github.com
               git config --global user.name omry
               echo "machine github.com login docusaurus-bot password $GITHUB_TOKEN" > ~/.netrc
               yarn install && GIT_USER=docusaurus-bot yarn deploy
-            else
-              echo "No changes detected in directory $SUBDIR between origin/master and this diff"
             fi
 
 workflows:


### PR DESCRIPTION
## Motivation
Make sure the website is correctly deployed when deploy is needed, i.e., when there are changes to files in `website` subfolder.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan
Can't really test with circle and deployment -- it requires committing to master, not through pull request.

## Related Issues and PRs

Fixes #296 
Closes #307 