### PR TITLE
[circleci/website] deploy website on website folder changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,10 +179,11 @@ jobs:
           name: Deploying to GitHub Pages
           command: |
             SUBDIR=website
-            if [[ $(git log --pretty=format:'%h' origin/master... $SUBDIR) ]]; then
+            REV=$(git log -1 --pretty=oneline origin/gh-pages | awk 'NF>1{print $NF}')
+            if [[ $(git diff-index $REV -- $SUBDIR) ]]; then
               echo "Changes detected in directory $SUBDIR between origin/master and this diff"
 
-              cd website
+              cd $SUBDIR
               yarn --no-progress
 
               git config --global user.email omry@users.noreply.github.com


### PR DESCRIPTION
## Motivation
Fix of the previous diff.
The previous error was because of how CircleCI runs inline bash and handles error codes. I relied on the error status, and Circle terminated the script because of error status = 1.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Example: https://circleci.com/gh/facebookresearch/hydra/5748?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

This commit + removing the filter on "master" branch.
Deploy started, and stopped for the PR limitation

## Related Issues and PRs
