### PR TITLE
[website] add algolia search

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -17,6 +17,11 @@ module.exports = {
         googleAnalytics: {
           trackingID: 'UA-149862507-1',
         },
+        algolia: {
+          apiKey: '8e04f3376c4e6e060f9d8d56734fa67b',
+          indexName: 'hydra',
+          algoliaOptions: {},
+        },
         navbar: {
             title: 'Hydra',
             logo: {


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation
Enable algolia search on the site (docs).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Ran locally with `yarn run start`

## Related Issues and PRs
closes #345
![hydra_search](https://user-images.githubusercontent.com/55730900/72642172-9af97d80-3920-11ea-85e1-cd910096e730.png)
