### PR TITLE
Parent node's information is lost when performing deepcopy.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     rev: 3.7.9
     hooks:
       - id: flake8
-        additional_dependencies: [-e, git+git://github.com/pycqa/pyflakes.git@1911c20#egg=pyflakes]
+        additional_dependencies: [-e, "git+git://github.com/pycqa/pyflakes.git@1911c20#egg=pyflakes"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.761

--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -51,8 +51,7 @@ def instantiate(config: DictConfig, *args: Any, **kwargs: Any) -> Any:
     assert config is not None, "Input config is None"
     # copy config to avoid mutating it when merging with kwargs
     config_copy = copy.deepcopy(config)
-    if config._get_parent() is not None:
-        config_copy._set_parent(config._get_parent())
+    config_copy._set_parent(config._get_parent())
     config = config_copy
 
     try:

--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -50,7 +50,10 @@ def instantiate(config: DictConfig, *args: Any, **kwargs: Any) -> Any:
 
     assert config is not None, "Input config is None"
     # copy config to avoid mutating it when merging with kwargs
-    config = copy.deepcopy(config)
+    config_copy = copy.deepcopy(config)
+    if config._get_parent() is not None:
+        config_copy._set_parent(config._get_parent())
+    config = config_copy
 
     try:
         clazz = get_class(config["class"])

--- a/news/388.bugfix
+++ b/news/388.bugfix
@@ -1,0 +1,1 @@
+Fix a bug with utils.instantiate() failing if params contains interpolated values.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -105,6 +105,35 @@ def test_class_instantiate_passthrough(
     assert obj == expected
 
 
+@pytest.mark.parametrize(  # type: ignore
+    "input_conf, expected",
+    [
+        (
+            {
+                "all_params": {
+                    "main": {
+                        "class": "tests.test_utils.Bar",
+                        "params": {"a": 10, "b": 20, "c": "${all_params.aux.c}"},
+                    },
+                    "aux": {"c": 30},
+                }
+            },
+            Bar(10, 20, 30, 40),
+        ),
+    ],
+)
+def test_string_iterpolation_during_deepcopy(
+    input_conf: Dict[str, Any], expected: Any
+) -> None:
+    # Check if the instantiate method maintains the parent when making a deepcopy
+    conf = OmegaConf.create(input_conf)
+    orig = copy.deepcopy(conf)
+    assert isinstance(conf, DictConfig)
+    obj = utils.instantiate(conf.all_params.main, d=40)
+    assert orig == conf
+    assert obj == expected
+
+
 def test_get_original_cwd() -> None:
     orig = "/foo/bar"
     cfg = OmegaConf.create({"hydra": {"runtime": {"cwd": orig}}})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import copy
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pytest
 from omegaconf import DictConfig, OmegaConf
@@ -63,13 +62,15 @@ def test_get_static_method(path: str, return_value: Any) -> None:
 
 
 @pytest.mark.parametrize(  # type: ignore
-    "input_conf, expected",
+    "input_conf, key_to_get_config, kwargs_to_pass, expected",
     [
         (
             {
                 "class": "tests.test_utils.Bar",
                 "params": {"a": 10, "b": 20, "c": 30, "d": 40},
             },
+            None,
+            {},
             Bar(10, 20, 30, 40),
         ),
         (
@@ -82,41 +83,37 @@ def test_get_static_method(path: str, return_value: Any) -> None:
                     "aux": {"c": 30},
                 }
             },
+            "all_params.main",
+            {"d": 40},
             Bar(10, 20, 30, 40),
         ),
-    ],
-)
-def test_class_instantiate(input_conf: Dict[str, Any], expected: Any) -> Any:
-    conf = OmegaConf.create(input_conf)
-    assert isinstance(conf, DictConfig)
-    if "all_params" in conf:
-        obj = utils.instantiate(conf.all_params.main, d=40)
-    else:
-        obj = utils.instantiate(conf)
-    assert obj == expected
-
-
-@pytest.mark.parametrize(  # type: ignore
-    "input_conf, expected",
-    [
         (
             {"class": "tests.test_utils.Bar", "params": {"b": 20, "c": 30}},
+            None,
+            {"a": 10, "d": 40},
             Bar(10, 20, 30, 40),
         ),
         (
             {"class": "tests.test_utils.Bar", "params": {"b": 200, "c": "${params.b}"}},
+            None,
+            {"a": 10, "d": 40},
             Bar(10, 200, 200, 40),
         ),
     ],
 )
-def test_class_instantiate_passthrough(
-    input_conf: Dict[str, Any], expected: Any
-) -> None:
+def test_class_instantiate(
+    input_conf: Dict[str, Any],
+    key_to_get_config: Optional[str],
+    kwargs_to_pass: Dict[str, Any],
+    expected: Any,
+) -> Any:
     conf = OmegaConf.create(input_conf)
-    orig = copy.deepcopy(conf)
     assert isinstance(conf, DictConfig)
-    obj = utils.instantiate(conf, 10, d=40)
-    assert orig == conf
+    if key_to_get_config is None:
+        config_to_pass = conf
+    else:
+        config_to_pass = conf.select(key_to_get_config)
+    obj = utils.instantiate(config_to_pass, **kwargs_to_pass)
     assert obj == expected
 
 


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Parent node's information is lost when performing deepcopy.

OmegaConf misbehaves with the deepcopy function and the information about the parent (node) is lost. This leads to errors where a variable's value can not be resolved. The error message looks like this -
`KeyError: "str interpolation key 'hydra.ax.experiment' not found"`. This commit provides a temporary workaround for the problem, by setting the parent of the copied config as that of the original config.
One testcase is also added to check for this bug.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Added a testcase.


