### PR TITLE
Fix pip install command to make it work on zsh

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ with open("README.md", "r") as fh:
         ],
         install_requires=["omegaconf==2.0.0rc4", "typing_extensions"],
         # Install development dependencies with
-        # pip install -e .[dev]
+        # pip install -e ".[dev]"
         extras_require={
             "dev": [
                 "black",

--- a/website/docs/development/contributing.md
+++ b/website/docs/development/contributing.md
@@ -26,7 +26,7 @@ conda activate hydra38
 ```
 From the source tree, install Hydra in development mode with the following command:
 ```
-pip install -e .[dev] -e .
+pip install -e ".[dev]" -e .
 ```
 ## Nox
 Hydra is using a test automation tool called [nox](https://github.com/theacodes/nox) to manage tests, linting, code coverage etc.

--- a/website/versioned_docs/version-0.11/development/contributing.md
+++ b/website/versioned_docs/version-0.11/development/contributing.md
@@ -26,7 +26,7 @@ conda activate hydra38
 ```
 From the source tree, install Hydra in development mode with the following command:
 ```
-pip install -e .[dev] -e .
+pip install -e ".[dev]" -e .
 ```
 ## Nox
 Hydra is using a test automation tool called [nox](https://github.com/theacodes/nox) to manage tests, linting, code coverage etc. 


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

The current command to install dev dependencies is:
```
pip install -e .[dev] -e .
```

On zsh, this command causes:
```
zsh: no matches found: .[dev]
```

This PR fixes it as follows and makes it work on zsh.
```
pip install -e ".[dev]" -e .
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

No

## Related Issues and PRs

https://github.com/fastai/fastai2/pull/80