### PR TITLE
[website] add versions page

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -30,6 +30,7 @@ module.exports = {
             },
             links: [
                 {to: 'docs/intro', label: 'Docs', position: 'left'},
+                {to: 'versions', label: 'Versions', position: 'left'},
                 {to: 'https://github.com/facebookresearch/hydra', label: 'Hydra@GitHub', position: 'left'},
             ],
         },

--- a/website/src/pages/versions.js
+++ b/website/src/pages/versions.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import Layout from '@theme/Layout';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+import versions from '../../versions.json';
+
+function Versions() {
+  const context = useDocusaurusContext();
+  const {siteConfig = {}} = context;
+  const latestVersion = versions[0];
+
+  return (
+    <Layout permalink="/versions">
+      <div className="container margin-vert--xl">
+       <h1>{siteConfig.title} Versions</h1>
+        <div className="margin-bottom--lg">
+          <h3 id="latest">Current version (Stable)</h3>
+          <ul>
+      <li><b>{latestVersion}</b> <Link to={useBaseUrl('/docs/intro')}>Documentation</Link></li>
+          </ul>
+          <h3 id="rc">Latest Version</h3>
+          <p>Here you can find the latest documentation and unreleased code.</p>
+          <ul>
+      <li><b>Next Release</b> <Link to={useBaseUrl('/docs/next/intro')}>Documentation</Link></li>
+          </ul>
+          <h3 id="archive">Past Versions</h3>
+          <p>
+            Here you can find documentation for previous versions of Docusaurus.
+          </p>
+          <ul>
+              {versions.map(
+                version =>
+                  version !== latestVersion && (
+                      <li>{version} <Link to={useBaseUrl(`/docs/${version}/intro`)}>Documentation</Link></li>))}
+           </ul>
+         </div>
+      </div>
+   </Layout>
+  );
+};
+
+
+Versions.title = 'Versions';
+export default Versions;
+


### PR DESCRIPTION
## Motivation

Add a page with list of versions, highlighting the current, stable, version, the in-progress version and past versions (none right now).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Ran it locally with 
```
yarn start
```
Attaching a screenshot
![Screenshot_20200220_101831](https://user-images.githubusercontent.com/55730900/74965942-fceb4e00-53ca-11ea-8002-dbd35aec5a3b.png)


## Related Issues and PRs

This is for #343 
