### PR TITLE
Skip certain files during plugin discovery

### DIFF
--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -160,9 +160,9 @@ class Plugins(metaclass=Singleton):
                 path=mdl.__path__, prefix=mdl.__name__ + ".", onerror=lambda x: None
             ):
                 try:
-                    file_name = modname.rsplit(".", 1)[-1]
-                    # If filename starts with "_", do not load the file.
-                    if file_name.startswith("_"):
+                    module_name = modname.rsplit(".", 1)[-1]
+                    # If module's name starts with "_", do not load the module.
+                    if module_name.startswith("_"):
                         continue
                     import_time = timer()
                     m = importer.find_module(modname)

--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -162,7 +162,9 @@ class Plugins(metaclass=Singleton):
                 try:
                     module_name = modname.rsplit(".", 1)[-1]
                     # If module's name starts with "_", do not load the module.
-                    if module_name.startswith("_"):
+                    # But if the module's name starts with a "__", then load the
+                    # module.
+                    if module_name.startswith("_") and not module_name.startswith("__"):
                         continue
                     import_time = timer()
                     m = importer.find_module(modname)

--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -160,6 +160,10 @@ class Plugins(metaclass=Singleton):
                 path=mdl.__path__, prefix=mdl.__name__ + ".", onerror=lambda x: None
             ):
                 try:
+                    file_name = modname.rsplit(".", 1)[-1]
+                    # If filename starts with "_", do not load the file.
+                    if file_name.startswith("_"):
+                        continue
                     import_time = timer()
                     m = importer.find_module(modname)
                     loaded_mod = m.load_module(modname)

--- a/news/494.feature
+++ b/news/494.feature
@@ -1,0 +1,1 @@
+Skip files starting with "_" during plugin discovery

--- a/news/494.feature
+++ b/news/494.feature
@@ -1,1 +1,1 @@
-Skip files starting with "_" during plugin discovery
+Modules whose name starts with "_" are skipped during plugin discovery

--- a/tests/test_plugins/discovery_test_plugin/hydra_plugins/discovery_test/__not_hidden_plugin.py
+++ b/tests/test_plugins/discovery_test_plugin/hydra_plugins/discovery_test/__not_hidden_plugin.py
@@ -1,0 +1,10 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from hydra.plugins.plugin import Plugin
+
+
+class NotHiddenTestPlugin(Plugin):
+    def __init__(self, v: int) -> None:
+        self.v = v
+
+    def add(self, x: int) -> int:
+        return self.v + x

--- a/tests/test_plugins/discovery_test_plugin/hydra_plugins/discovery_test/__not_hidden_plugin.py
+++ b/tests/test_plugins/discovery_test_plugin/hydra_plugins/discovery_test/__not_hidden_plugin.py
@@ -5,6 +5,3 @@ from hydra.plugins.plugin import Plugin
 class NotHiddenTestPlugin(Plugin):
     def __init__(self, v: int) -> None:
         self.v = v
-
-    def add(self, x: int) -> int:
-        return self.v + x

--- a/tests/test_plugins/discovery_test_plugin/hydra_plugins/discovery_test/__not_hidden_plugin.py
+++ b/tests/test_plugins/discovery_test_plugin/hydra_plugins/discovery_test/__not_hidden_plugin.py
@@ -3,5 +3,4 @@ from hydra.plugins.plugin import Plugin
 
 
 class NotHiddenTestPlugin(Plugin):
-    def __init__(self, v: int) -> None:
-        self.v = v
+    pass

--- a/tests/test_plugins/discovery_test_plugin/hydra_plugins/discovery_test/_hidden_plugin.py
+++ b/tests/test_plugins/discovery_test_plugin/hydra_plugins/discovery_test/_hidden_plugin.py
@@ -3,5 +3,4 @@ from hydra.plugins.plugin import Plugin
 
 
 class HiddenTestPlugin(Plugin):
-    def __init__(self, v: int) -> None:
-        self.v = v
+    pass

--- a/tests/test_plugins/discovery_test_plugin/hydra_plugins/discovery_test/_hidden_plugin.py
+++ b/tests/test_plugins/discovery_test_plugin/hydra_plugins/discovery_test/_hidden_plugin.py
@@ -1,0 +1,10 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from hydra.plugins.plugin import Plugin
+
+
+class HiddenTestPlugin(Plugin):
+    def __init__(self, v: int) -> None:
+        self.v = v
+
+    def add(self, x: int) -> int:
+        return self.v + x

--- a/tests/test_plugins/discovery_test_plugin/hydra_plugins/discovery_test/_hidden_plugin.py
+++ b/tests/test_plugins/discovery_test_plugin/hydra_plugins/discovery_test/_hidden_plugin.py
@@ -5,6 +5,3 @@ from hydra.plugins.plugin import Plugin
 class HiddenTestPlugin(Plugin):
     def __init__(self, v: int) -> None:
         self.v = v
-
-    def add(self, x: int) -> int:
-        return self.v + x

--- a/tests/test_plugins/discovery_test_plugin/tests/test_discovery.py
+++ b/tests/test_plugins/discovery_test_plugin/tests/test_discovery.py
@@ -18,3 +18,13 @@ def test_number_of_imports(tmpdir: Path) -> None:
     with Path(os.environ["TMP_FILE"]) as f:
         txt = str(f.read_text())
         assert txt.split("\n").count("imported") == 1
+
+
+def test_skipped_imports(tmpdir: Path) -> None:
+    # Tests that modules starting with an "_" are skipped
+    plugin_stats = Plugins.instance().stats
+    assert plugin_stats is not None
+    loaded_modules = list(plugin_stats.modules_import_time.keys())
+    for module in loaded_modules:
+        module_name = module.split(".")[-1]
+        assert not module_name.startswith("_")

--- a/tests/test_plugins/discovery_test_plugin/tests/test_discovery.py
+++ b/tests/test_plugins/discovery_test_plugin/tests/test_discovery.py
@@ -21,10 +21,9 @@ def test_number_of_imports(tmpdir: Path) -> None:
 
 
 def test_skipped_imports(tmpdir: Path) -> None:
-    # Tests that modules starting with an "_" are skipped
-    plugin_stats = Plugins.instance().stats
-    assert plugin_stats is not None
-    loaded_modules = list(plugin_stats.modules_import_time.keys())
-    for module in loaded_modules:
-        module_name = module.split(".")[-1]
-        assert not module_name.startswith("_")
+    # Tests that modules starting with an "_" (but not "__") are skipped
+
+    discovered_plugins = [x.__name__ for x in Plugins.instance().discover(Plugin)]
+    assert "HiddenTestPlugin" not in discovered_plugins
+
+    assert "NotHiddenTestPlugin" in discovered_plugins

--- a/website/docs/advanced/plugins.md
+++ b/website/docs/advanced/plugins.md
@@ -7,10 +7,13 @@ sidebar_label: Hydra plugins
 Hydra can be extended via plugins.
 You can see example plugins [here](https://github.com/facebookresearch/hydra/tree/master/plugins/examples).
 
-Note: When loading modules in a plugin, files starting with `_` (but not `__`) are not loaded but Hydra. This enables plugins developers to lazily load third party modules. This reduces the startup time associated with Hydra. For an example of how to use files starting with `_` for lazy-loading, check the [Ax Plugin](https://github.com/facebookresearch/hydra/tree/master/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper).
+## Plugin discovery
+During plugin discovery, Hydra looks up for plugins in all submodules of `hydra_plugins`. To do this, Hydra imports sub-modules defined under `hydra_plugins` to look for plugins that are defined in them.
+Since plugins are discovered whenever Hydra starts, any installed plugins that are slow to import will slow down the startup of _ALL_ Hydra applicaitons.
+Plugins with expensive imports can exclude individual files from this by prefixing them with `_` (but not `__`).
+For example, the file `_my_plugin_lib.py` would not be imported and scanned, while `my_plugin_lib.py` would be.
 
 ## Plugin types
-
 ### Sweeper
 A sweeper is responsible for converting command line arguments list into multiple jobs.
 For example, the basic built-in sweeper takes arguments like:

--- a/website/docs/advanced/plugins.md
+++ b/website/docs/advanced/plugins.md
@@ -7,6 +7,8 @@ sidebar_label: Hydra plugins
 Hydra can be extended via plugins.
 You can see example plugins [here](https://github.com/facebookresearch/hydra/tree/master/plugins/examples).
 
+Note: When loading modules in a plugin, files starting with `_` (but not `__`) are not loaded but Hydra. This enables plugins developers to lazily load third party modules. This reduces the startup time associated with Hydra. For an example of how to use files starting with `_` for lazy-loading, check the [Ax Plugin](https://github.com/facebookresearch/hydra/tree/master/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper).
+
 ## Plugin types
 
 ### Sweeper

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -59,6 +59,7 @@ module.exports = {
 
         'Advanced': [
             'advanced/app_packaging',
+            'advanced/plugins',
             'advanced/search_path',
 
         ],


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Plugin discovery imports all the modules in the plugins directory. This can slow down Hydra startup. One example is Ax plugin slowing down Hydra #476

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

No

## Test Plan

NA

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)

#494 