### PR TITLE
Allow instantiation from class methods

### DIFF
--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -71,7 +71,7 @@ class Plugins(metaclass=Singleton):
     def _instantiate(self, config: PluginConf) -> Plugin:
         import hydra.utils as utils
 
-        classname = utils._get_class_name(config)
+        classname = utils._get_cls_name(config)
         try:
             if classname is None:
                 raise ImportError("class not configured")

--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -2,8 +2,8 @@
 import logging.config
 import warnings
 from pathlib import Path
-from typing import Any, Type, Optional, cast
 from types import ModuleType
+from typing import Any, Optional, Type, cast
 
 from omegaconf import DictConfig, OmegaConf, _utils
 
@@ -18,8 +18,8 @@ def _safeimport(path: str) -> Optional[ModuleType]:
     Import a module; handle errors; return None if the module isn't found.
     This is a typed simplified version of the `pydoc` function `safeimport`.
     """
-    import sys
     from importlib import import_module
+
     try:
         module = import_module(path)
     except ImportError as e:
@@ -31,7 +31,7 @@ def _safeimport(path: str) -> Optional[ModuleType]:
     except Exception as e:
         log.error(f"Non-ImportError while importing module {path}: {e}")
         raise ValueError(f"Non-ImportError while importing module {path}: {e}")
-    for part in path.replace(module.__name__, "").split('.'):
+    for part in path.replace(module.__name__, "").split("."):
         if not hasattr(module, part):
             break
         module = getattr(module, part)
@@ -42,14 +42,14 @@ def _locate(path: str) -> ModuleType:
     """
     Locate an object by name or dotted path, importing as necessary.
     This is similar to the pydoc function `locate`, except that it checks for
-    the module from the end of the path to the beginning.
+    the module from the given path from back to front.
     """
-    parts = [part for part in path.split('.') if part]
+    parts = [part for part in path.split(".") if part]
     module = None
     for n in reversed(range(len(parts))):
         try:
-            module = _safeimport('.'.join(parts[:n]))
-        except:
+            module = _safeimport(".".join(parts[:n]))
+        except Exception:
             continue
         if module:
             break
@@ -60,8 +60,12 @@ def _locate(path: str) -> ModuleType:
         raise ValueError(f"Module not found: {path}")
     for part in parts[n:]:
         if not hasattr(obj, part):
-            log.error(f"Error finding attribute ({part}) in class ({obj.__name__}): {path}")
-            raise ValueError(f"Error finding attribute ({part}) in class ({obj.__name__}): {path}")
+            log.error(
+                f"Error finding attribute ({part}) in class ({obj.__name__}): {path}"
+            )
+            raise ValueError(
+                f"Error finding attribute ({part}) in class ({obj.__name__}): {path}"
+            )
         obj = getattr(obj, part)
     return obj
 

--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -2,8 +2,7 @@
 import logging.config
 import warnings
 from pathlib import Path
-from types import ModuleType
-from typing import Any, Optional, Type, cast
+from typing import Any, Callable, Type, Union
 
 from omegaconf import DictConfig, OmegaConf, _utils
 
@@ -13,92 +12,81 @@ from hydra.core.hydra_config import HydraConfig
 log = logging.getLogger(__name__)
 
 
-def _safeimport(path: str) -> Optional[ModuleType]:
-    """
-    Import a module; handle errors; return None if the module isn't found.
-    This is a typed simplified version of the `pydoc` function `safeimport`.
-    """
-    from importlib import import_module
-
-    try:
-        module = import_module(path)
-    except ImportError as e:
-        if e.name == path:
-            return None
-        else:
-            log.error(f"Error importing module: {path}")
-            raise e
-    except Exception as e:
-        log.error(f"Non-ImportError while importing module {path}: {e}")
-        raise ValueError(f"Non-ImportError while importing module {path}: {e}")
-    for part in path.replace(module.__name__, "").split("."):
-        if not hasattr(module, part):
-            break
-        module = getattr(module, part)
-    return module
-
-
-def _locate(path: str) -> ModuleType:
+def _locate(path: str) -> Union[type, Callable[..., Any]]:
     """
     Locate an object by name or dotted path, importing as necessary.
     This is similar to the pydoc function `locate`, except that it checks for
     the module from the given path from back to front.
     """
+    import builtins
+    from importlib import import_module
+
     parts = [part for part in path.split(".") if part]
     module = None
     for n in reversed(range(len(parts))):
         try:
-            module = _safeimport(".".join(parts[:n]))
-        except Exception:
+            module = import_module(".".join(parts[:n]))
+        except Exception as e:
+            if n == 0:
+                log.error(f"Error loading module {path} : {e}")
+                raise e
             continue
         if module:
             break
     if module:
         obj = module
     else:
-        log.error(f"Module not found: {path}")
-        raise ValueError(f"Module not found: {path}")
+        obj = builtins
     for part in parts[n:]:
         if not hasattr(obj, part):
-            log.error(
-                f"Error finding attribute ({part}) in class ({obj.__name__}): {path}"
-            )
             raise ValueError(
                 f"Error finding attribute ({part}) in class ({obj.__name__}): {path}"
             )
         obj = getattr(obj, part)
-    return obj
-
-
-def get_method(path: str) -> type:
-    return get_class(path)
+    if isinstance(obj, type):
+        obj_type: type = obj
+        return obj_type
+    elif callable(obj):
+        obj_callable: Callable[..., Any] = obj
+        return obj_callable
+    else:
+        # dummy case
+        raise ValueError(f"Invalid type ({type(obj)}) found for {path}")
 
 
 def get_class(path: str) -> type:
     try:
-        klass = cast(type, _locate(path))
+        klass = _locate(path)
+        if not isinstance(klass, type):
+            raise ValueError(f"Function or method found instead of class for {path}")
         return klass
     except Exception as e:
-        log.error(f"Error initializing class {path}")
+        log.error(f"Error initializing class {path} : {e}")
         raise e
 
 
-def get_static_method(full_method_name: str) -> type:
+def get_fn_or_method(path: str) -> Callable[..., Any]:
     try:
-        ret = get_class(full_method_name)
-        return ret
+        fn_or_method = _locate(path)
+        if isinstance(fn_or_method, type):
+            raise ValueError(f"Class found instead of function or method {path}")
+        return fn_or_method
     except Exception as e:
-        log.error(f"Error getting static method {full_method_name} : {e}")
+        log.error(f"Error getting static method {path} : {e}")
         raise e
 
 
-def instantiate(config: PluginConf, *args: Any, **kwargs: Any) -> Any:
-    classname = _get_class_name(config)
+def call(config: PluginConf, *args: Any, **kwargs: Any) -> Any:
+    clsname = _get_cls_name(config)
     try:
-        clazz = get_class(classname)
-        return _instantiate_class(clazz, config, *args, **kwargs)
+        type_or_callable = _locate(clsname)
+        if isinstance(type_or_callable, type):
+            return _instantiate_class(type_or_callable, config, *args, **kwargs)
+        else:
+            assert callable(type_or_callable)
+            return _call_callable(type_or_callable, config, *args, **kwargs)
     except Exception as e:
-        log.error(f"Error instantiating '{classname}' : {e}")
+        log.error(f"Error instantiating '{clsname}' : {e}")
         raise e
 
 
@@ -124,7 +112,7 @@ def to_absolute_path(path: str) -> str:
     return str(ret)
 
 
-def _get_class_name(config: PluginConf) -> str:
+def _get_cls_name(config: PluginConf) -> str:
     if "class" in config:
         warnings.warn(
             "\n"
@@ -144,9 +132,7 @@ def _get_class_name(config: PluginConf) -> str:
             raise ValueError("Input config does not have a cls field")
 
 
-def _instantiate_class(
-    clazz: Type[Any], config: PluginConf, *args: Any, **kwargs: Any
-) -> Any:
+def _get_kwargs(config: PluginConf, **kwargs: Any) -> Any:
     import copy
 
     # copy config to avoid mutating it when merging with kwargs
@@ -176,5 +162,25 @@ def _instantiate_class(
 
     for k, v in rest.items():
         final_kwargs[k] = v
+    return final_kwargs
 
+
+def _instantiate_class(
+    clazz: Type[Any], config: PluginConf, *args: Any, **kwargs: Any
+) -> Any:
+    final_kwargs = _get_kwargs(config, **kwargs)
     return clazz(*args, **final_kwargs)
+
+
+def _call_callable(
+    fn: Callable[..., Any], config: PluginConf, *args: Any, **kwargs: Any
+) -> Any:
+    final_kwargs = _get_kwargs(config, **kwargs)
+    return fn(*args, **final_kwargs)
+
+
+# aliases
+instantiate = call
+get_static_method = get_fn_or_method
+get_method = get_fn_or_method
+_get_class_name = _get_cls_name

--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -183,4 +183,3 @@ def _call_callable(
 instantiate = call
 get_static_method = get_fn_or_method
 get_method = get_fn_or_method
-_get_class_name = _get_cls_name

--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -35,7 +35,7 @@ def get_static_method(full_method_name: str) -> type:
         ret: type = get_class(full_method_name)
         return ret
     except Exception as e:
-        log.error("Error getting static method {} : {}".format(full_method_name, e))
+        log.error(f"Error getting static method {full_method_name} : {e}")
         raise e
 
 
@@ -108,9 +108,7 @@ def _instantiate_class(
     params = config.params if "params" in config else OmegaConf.create()
     assert isinstance(
         params, DictConfig
-    ), "Input config params are expected to be a mapping, found {}".format(
-        type(config.params)
-    )
+    ), f"Input config params are expected to be a mapping, found {type(config.params)}"
     primitives = {}
     rest = {}
     for k, v in kwargs.items():

--- a/news/498.feature
+++ b/news/498.feature
@@ -1,0 +1,1 @@
+Add `hydra.utils.call()` to call methods and functions as well as instantiate objects.  Search module paths more generically.

--- a/tests/test_plugin_interface.py
+++ b/tests/test_plugin_interface.py
@@ -28,6 +28,6 @@ search_path_plugins: List[str] = []
 )
 def test_discover(plugin_type: Type[Plugin], expected: List[str]) -> None:
     plugins = Plugins.instance().discover(plugin_type)
-    expected_classes = [get_class(c) for c in sorted(expected)]
-    for ex in expected_classes:
+    expected_class = [get_class(c) for c in expected]
+    for ex in expected_class:
         assert ex in plugins

--- a/tests/test_plugin_interface.py
+++ b/tests/test_plugin_interface.py
@@ -28,6 +28,6 @@ search_path_plugins: List[str] = []
 )
 def test_discover(plugin_type: Type[Plugin], expected: List[str]) -> None:
     plugins = Plugins.instance().discover(plugin_type)
-    expected_class = [get_class(c) for c in expected]
-    for ex in expected_class:
+    expected_classes = [get_class(c) for c in expected]
+    for ex in expected_classes:
         assert ex in plugins

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,6 +59,12 @@ class Foo:
         return False
 
 
+class Baz(Foo):
+    @classmethod
+    def class_method(self, y: int) -> None:
+        return self(y + 1)
+
+
 @pytest.mark.parametrize(  # type: ignore
     "path,expected_type", [("tests.test_utils.Bar", Bar)]
 )
@@ -117,6 +123,16 @@ def test_get_static_method(path: str, return_value: Any) -> None:
             None,
             {"a": 10, "d": 40},
             Bar(10, 200, 200, 40),
+        ),
+        (
+            {
+                "cls": "tests.test_utils.Baz",
+                "method": "class_method",
+                "params": {"y": 10},
+            },
+            None,
+            {},
+            Baz(11),
         ),
         # Check that default value is respected
         (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,6 +68,7 @@ class Baz(Foo):
     def static_method() -> Any:
         return 43
 
+
 @pytest.mark.parametrize(  # type: ignore
     "path,expected_type", [("tests.test_utils.Bar", Bar)]
 )
@@ -128,17 +129,12 @@ def test_get_static_method(path: str, return_value: Any) -> None:
             Bar(10, 200, 200, 40),
         ),
         (
-            {"cls": "tests.test_utils.Baz.class_method", "params": {"y": 10}, },
+            {"cls": "tests.test_utils.Baz.class_method", "params": {"y": 10}},
             None,
             {},
             Baz(11),
         ),
-        (
-            {"cls": "tests.test_utils.Baz.static_method", "params": {}, },
-            None,
-            {},
-            43,
-        ),
+        ({"cls": "tests.test_utils.Baz.static_method", "params": {}}, None, {}, 43,),
         # Check that default value is respected
         (
             {"cls": "tests.test_utils.Bar", "params": {"b": 200, "c": "${params.b}"}},

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -126,8 +126,7 @@ def test_get_static_method(path: str, return_value: Any) -> None:
         ),
         (
             {
-                "cls": "tests.test_utils.Baz",
-                "method": "class_method",
+                "cls": "tests.test_utils.Baz.class_method",
                 "params": {"y": 10},
             },
             None,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,9 +61,12 @@ class Foo:
 
 class Baz(Foo):
     @classmethod
-    def class_method(self, y: int) -> None:
+    def class_method(self, y: int) -> Any:
         return self(y + 1)
 
+    @staticmethod
+    def static_method() -> Any:
+        return 43
 
 @pytest.mark.parametrize(  # type: ignore
     "path,expected_type", [("tests.test_utils.Bar", Bar)]
@@ -125,13 +128,16 @@ def test_get_static_method(path: str, return_value: Any) -> None:
             Bar(10, 200, 200, 40),
         ),
         (
-            {
-                "cls": "tests.test_utils.Baz.class_method",
-                "params": {"y": 10},
-            },
+            {"cls": "tests.test_utils.Baz.class_method", "params": {"y": 10}, },
             None,
             {},
             Baz(11),
+        ),
+        (
+            {"cls": "tests.test_utils.Baz.static_method", "params": {}, },
+            None,
+            {},
+            43,
         ),
         # Check that default value is respected
         (

--- a/website/docs/patterns/objects.md
+++ b/website/docs/patterns/objects.md
@@ -53,8 +53,7 @@ conf/
 ├── config.yaml
 └── db
     ├── mysql.yaml
-    ├── postgresql.yaml
-    └── postgresql_default.yaml
+    └── postgresql.yaml
 ```
 
 Config file: `config.yaml`
@@ -81,13 +80,6 @@ db:
     password: 1234
     database: tutorial
 ```
-Config file: `db/postgres_default.yaml`
-```yaml
-db:
-  cls: tutorial.objects_example.objects.PostgreSQLConnection.default_init_method 
-  params:
-    database: tutorial
-```
 
 With this, you can instantiate the object from the configuration with a single line of code:
 ```python
@@ -106,9 +98,4 @@ Change the instantiated object class and override values from the command line:
 ```text
 $ python my_app.py db=postgresql db.params.password=abcde
 PostgreSQL connecting to localhost with user=root and password=abcde and database=tutorial
-```
-Instantiate an object from a class method:
-```text
-$ python my_app.py db=postgresql_default
-PostgreSQL connecting to localhost with user=admin and password=password and database=tutorial
 ```

--- a/website/docs/patterns/objects.md
+++ b/website/docs/patterns/objects.md
@@ -84,8 +84,7 @@ db:
 Config file: `db/postgres_default.yaml`
 ```yaml
 db:
-  cls: tutorial.objects_example.objects.PostgreSQLConnection
-  method: default_init_method
+  cls: tutorial.objects_example.objects.PostgreSQLConnection.default_init_method 
   params:
     database: tutorial
 ```

--- a/website/docs/patterns/objects.md
+++ b/website/docs/patterns/objects.md
@@ -153,4 +153,5 @@ def app(cfg):
   mystaticmethod = hydra.utils.call(cfg.mystaticmethod)
   myfunction = hydra.utils.call(cfg.myfunction)
 ```
-Note, the old `instantiate` function is now an alias of the `call` function used above.
+Note, `hydra.utils.instantiate()` is an alias for `hydra.utils.call()`. They are in fact
+the same function.

--- a/website/docs/patterns/objects.md
+++ b/website/docs/patterns/objects.md
@@ -148,10 +148,10 @@ import hydra
 
 @hydra.main(config_path="config.yaml")
 def app(cfg):
-  myobject = hydra.utils.call(cfg.myobject)
-  myclassmethod = hydra.utils.call(cfg.myclassmethod)
-  mystaticmethod = hydra.utils.call(cfg.mystaticmethod)
-  myfunction = hydra.utils.call(cfg.myfunction)
+  foo1: Foo = hydra.utils.call(cfg.myobject)
+  foo2: Foo = hydra.utils.call(cfg.myclassmethod)
+  ret1: int = hydra.utils.call(cfg.mystaticmethod)
+  ret2: int = hydra.utils.call(cfg.myfunction)
 ```
 Note, `hydra.utils.instantiate()` is an alias for `hydra.utils.call()`. They are in fact
 the same function.

--- a/website/docs/patterns/objects.md
+++ b/website/docs/patterns/objects.md
@@ -4,9 +4,25 @@ title: Creating objects and calling functions
 sidebar_label: Creating objects and calling functions
 ---
 ### Instantiating objects and calling methods and functions
-With `hydra.utils.call()` one can instantiate objects and call functions and methods. Create keys with a
-`cls`field with the full path to the class, method, or function and optionally use `params` to pass
-parameters to the call.
+Use `hydra.utils.call()` (or it's alias `hydra.utils.instantiate()`) to instantiate objects, call functions and call class methods.
+
+```python
+def call(config: PluginConf, *args: Any, **kwargs: Any) -> Any:
+```
+ - `config`: A config node describing the class to instantiate or function to call and the parameters to pass
+ - `args`: optional positional passthrough
+ - `kwargs`: optional named parameters passthrough
+
+Example config node:
+```yaml
+# target class name, function name or class method fully qualified name
+cls: foo.Bar
+# optional parameters dictionary to pass when calling the target
+params:
+  x: 10
+```
+
+#### Example usage
 
 models.py
 ```python
@@ -150,5 +166,3 @@ Change the instantiated object class and override values from the command line:
 $ python my_app.py db=postgresql db.params.password=abcde
 PostgreSQL connecting to localhost with user=root and password=abcde and database=tutorial
 ```
-Note, `hydra.utils.instantiate()` is an alias for `hydra.utils.call()`. They are in fact
-the same function.

--- a/website/docs/patterns/objects.md
+++ b/website/docs/patterns/objects.md
@@ -33,6 +33,10 @@ class PostgreSQLConnection(DBConnection):
         self.user = user
         self.password = password
         self.database = database
+    
+    @classmethod
+    def default_init_method(self, database):
+        return self("localhost", "admin", "password", database)
 
     def connect(self):
         print(
@@ -49,7 +53,8 @@ conf/
 ├── config.yaml
 └── db
     ├── mysql.yaml
-    └── postgresql.yaml
+    ├── postgresql.yaml
+    └── postgresql_default.yaml
 ```
 
 Config file: `config.yaml`
@@ -76,6 +81,14 @@ db:
     password: 1234
     database: tutorial
 ```
+Config file: `db/postgres_default.yaml`
+```yaml
+db:
+  cls: tutorial.objects_example.objects.PostgreSQLConnection
+  method: default_init_method
+  params:
+    database: tutorial
+```
 
 With this, you can instantiate the object from the configuration with a single line of code:
 ```python
@@ -94,4 +107,9 @@ Change the instantiated object class and override values from the command line:
 ```text
 $ python my_app.py db=postgresql db.params.password=abcde
 PostgreSQL connecting to localhost with user=root and password=abcde and database=tutorial
+```
+Instantiate an object from a class method:
+```text
+$ python my_app.py db=postgresql_default
+PostgreSQL connecting to localhost with user=admin and password=password and database=tutorial
 ```


### PR DESCRIPTION
* instantiate an object from a class method of that object
* add tests for this
* simplify get_static_method function

Signed-off-by: David Pollack <d.pollack@solvemate.com>

## Motivation

I wanted to use hydra with the huggingface transfromers library and they extensively use a class method named `from_pretrained`.  

Currently one could do this by using the `get_static_method` and then manually converting the `params` key and passing them to the gotten method.  However that's not very straight forward or intuitive and this doesn't add much logic to the utility function.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes - passed tests in test_utils.py and flake8

## Test Plan

I added a test that tests the basic case.  
