### PR TITLE
typo in config file prevented AxSweeper from loading correctly

### DIFF
--- a/plugins/hydra_ax_sweeper/example/conf/config.yaml
+++ b/plugins/hydra_ax_sweeper/example/conf/config.yaml
@@ -10,7 +10,7 @@ banana:
 
 hydra:
   sweeper:
-    cls: hydra_plugins.hydra_ax_sweeper.AxSweeper
+    cls: hydra_plugins.hydra_ax_sweeper.ax_sweeper.AxSweeper
     params:
       # The following part of config is used to setup the Hydra Ax plugin and is optional
       ax_config:


### PR DESCRIPTION
this is a super mini PR.  The config file points to the wrong location.  I bashed my head against the wall for a while trying to figure out what was going wrong.