### PR TITLE
[CircleCI] Deploy site if last-known-good site rev is broken

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,10 @@ jobs:
           command: |
             SUBDIR=website
             REV=$(git log -5 --pretty=oneline origin/gh-pages | grep "Deploy website" |  awk 'NF>1{print $NF}'  | head -1)
-            if [[ $(git diff-index $REV -- $SUBDIR) ]]; then
+            # This condition passes in 2 conditions:
+            # 1. The revision does not exist (squash/force push happened)
+            # 2. There are changes between last deployed revision and HEAD
+            if [[ ! $(git rev-parse --verify -q "$REV^{commit}") ||  $(git diff-index $REV -- $SUBDIR) ]]; then
               echo "Changes detected in directory $SUBDIR between origin/master and this diff"
 
               cd $SUBDIR


### PR DESCRIPTION
## Motivation
The site is deployed only when there are differences between the last deployed version of the site and the latest commit.
If there was force push/history change, then this comparison might fail (last deployed revision might not exist). This PR fixes this problem by "failing open" -- to continue with deployment if it failed to find the previous site revision for comparison.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Tested locally, without pushing site

