### PR TITLE
Multiple joblib fixes

### DIFF
--- a/hydra/test_utils/launcher_common_tests.py
+++ b/hydra/test_utils/launcher_common_tests.py
@@ -511,7 +511,7 @@ class IntegrationTestSuite:
             task_config=cfg,
             overrides=overrides,
             prints="hydra.utils.to_absolute_path('/foo/bar')",
-            expected_outputs="/foo/bar",
+            expected_outputs=str(Path("/foo/bar")),
         )
         outputs = [str(tmpdir / "foo/bar"), str(tmpdir / expected_dir)]
         integration_test(

--- a/hydra/test_utils/launcher_common_tests.py
+++ b/hydra/test_utils/launcher_common_tests.py
@@ -506,12 +506,13 @@ class IntegrationTestSuite:
         task_config = OmegaConf.create()
         cfg = OmegaConf.merge(task_launcher_cfg, task_config)
         assert isinstance(cfg, DictConfig)
+        path = str(Path("/foo/bar").absolute())
         integration_test(
             tmpdir=tmpdir,
             task_config=cfg,
             overrides=overrides,
             prints="hydra.utils.to_absolute_path('/foo/bar')",
-            expected_outputs=str(Path("/foo/bar")),
+            expected_outputs=path,
         )
         outputs = [str(tmpdir / "foo/bar"), str(tmpdir / expected_dir)]
         integration_test(

--- a/hydra/test_utils/launcher_common_tests.py
+++ b/hydra/test_utils/launcher_common_tests.py
@@ -324,24 +324,27 @@ class IntegrationTestSuite:
     @pytest.mark.parametrize(  # type: ignore
         "task_config, overrides, filename, expected_name",
         [
-            (None, [], "no_config.py", "no_config"),
-            (
+            pytest.param(None, [], "no_config.py", "no_config", id="no_config"),
+            pytest.param(
                 None,
                 ["hydra.job.name=overridden_name"],
                 "no_config.py",
                 "overridden_name",
+                id="different_filename",
             ),
-            (
+            pytest.param(
                 {"hydra": {"job": {"name": "name_from_config_file"}}},
                 [],
                 "with_config.py",
                 "name_from_config_file",
+                id="different_filename_and_config_file_name_override",
             ),
-            (
+            pytest.param(
                 {"hydra": {"job": {"name": "name_from_config_file"}}},
                 ["hydra.job.name=overridden_name"],
                 "with_config.py",
                 "overridden_name",
+                id="different_filename_and_config_file_name_override_and_command_line_override",
             ),
         ],
     )
@@ -372,7 +375,7 @@ class IntegrationTestSuite:
     @pytest.mark.parametrize(  # type: ignore
         "task_config, overrides, expected_dir",
         [
-            (
+            pytest.param(
                 {
                     "hydra": {
                         "sweep": {
@@ -383,16 +386,18 @@ class IntegrationTestSuite:
                 },
                 [],
                 "task_cfg/task_cfg_0",
+                id="sweep_dir_config_override",
             ),
-            (
+            pytest.param(
                 {},
                 [
                     "hydra.sweep.dir=cli_dir",
                     "hydra.sweep.subdir=cli_dir_${hydra.job.num}",
                 ],
                 "cli_dir/cli_dir_0",
+                id="sweep_dir_cli_override",
             ),
-            (
+            pytest.param(
                 {
                     "hydra": {
                         "sweep": {
@@ -406,8 +411,9 @@ class IntegrationTestSuite:
                     "hydra.sweep.subdir=cli_dir_${hydra.job.num}",
                 ],
                 "cli_dir/cli_dir_0",
+                id="sweep_dir_cli_overridding_config",
             ),
-            (
+            pytest.param(
                 {
                     "hydra": {
                         "sweep": {
@@ -420,8 +426,9 @@ class IntegrationTestSuite:
                 },
                 ["a=1", "b=2"],
                 "hydra_cfg/a=1,b=2",
+                id="subdir:override_dirname",
             ),
-            (
+            pytest.param(
                 # Test override_dirname integration
                 {
                     "hydra": {
@@ -445,6 +452,7 @@ class IntegrationTestSuite:
                 },
                 ["a=1", "b=2", "seed=10"],
                 "hydra_cfg/a_1+b_2",
+                id="subdir:custom_override_dirname",
             ),
         ],
     )
@@ -484,4 +492,32 @@ class IntegrationTestSuite:
             overrides=overrides,
             prints="hydra.utils.get_original_cwd()",
             expected_outputs=str(tmpdir),
+        )
+
+    def test_to_absolute_path_multirun(
+        self, tmpdir: Path, task_launcher_cfg: DictConfig, extra_flags: List[str],
+    ) -> None:
+        expected_dir = "cli_dir/cli_dir_0"
+        overrides = extra_flags + [
+            "hydra.sweep.dir=cli_dir",
+            "hydra.sweep.subdir=cli_dir_${hydra.job.num}",
+        ]
+        task_launcher_cfg = OmegaConf.create(task_launcher_cfg or {})  # type: ignore
+        task_config = OmegaConf.create()
+        cfg = OmegaConf.merge(task_launcher_cfg, task_config)
+        assert isinstance(cfg, DictConfig)
+        integration_test(
+            tmpdir=tmpdir,
+            task_config=cfg,
+            overrides=overrides,
+            prints="hydra.utils.to_absolute_path('/foo/bar')",
+            expected_outputs="/foo/bar",
+        )
+        outputs = [str(tmpdir / "foo/bar"), str(tmpdir / expected_dir)]
+        integration_test(
+            tmpdir=tmpdir,
+            task_config=cfg,
+            overrides=overrides,
+            prints=["hydra.utils.to_absolute_path('foo/bar')", "os.getcwd()"],
+            expected_outputs=outputs,
         )

--- a/hydra/test_utils/test_utils.py
+++ b/hydra/test_utils/test_utils.py
@@ -279,7 +279,7 @@ from hydra.core.hydra_config import HydraConfig
 @hydra.main($CONFIG_PATH)
 def experiment(cfg):
     with open("$OUTPUT_FILE", "w") as f:
-        $PRINTS
+$PRINTS
 
 if __name__ == "__main__":
     experiment()
@@ -287,11 +287,13 @@ if __name__ == "__main__":
     )
 
     print_code = ""
+    print_indent = "        "
     if prints is None or len(prints) == 0:
         print_code = "pass"
     else:
         for p in prints:
-            print_code += 'f.write({} + "\\\n")'.format(p)
+            print_code += f"{print_indent}f.write({p})\n"
+            print_code += f'{print_indent}f.write("\\n")\n'
 
     config_path = ""
     if task_config is not None:
@@ -320,9 +322,13 @@ if __name__ == "__main__":
             output = str.splitlines(file_str)
 
         if expected_outputs is not None:
-            assert len(output) == len(expected_outputs)
+            assert len(output) == len(
+                expected_outputs
+            ), f"Unexpected number of output lines from {task_file}"
             for idx in range(len(output)):
-                assert output[idx] == expected_outputs[idx]
+                assert (
+                    output[idx] == expected_outputs[idx]
+                ), f"Unexpected output for {prints[idx]} : expected {expected_outputs[idx]}, got {output[idx]}"
         # some tests are parsing the file output for more specialized testing.
         return file_str
     finally:

--- a/news/536.api_change
+++ b/news/536.api_change
@@ -1,1 +1,1 @@
-Configuration directories that are packaged now requires an `__init__.py` file
+Packaged configuration directories now requires an `__init__.py` at their top level

--- a/plugins/hydra_joblib_launcher/setup.py
+++ b/plugins/hydra_joblib_launcher/setup.py
@@ -19,6 +19,7 @@ with open("README.md", "r") as fh:
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Operating System :: MacOS",
+            "Operating System :: Microsoft :: Windows",
             "Operating System :: POSIX :: Linux",
         ],
         install_requires=["hydra-core==1.0.*", "joblib>=0.14.0"],

--- a/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
+++ b/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
@@ -15,10 +15,6 @@ from hydra_plugins.hydra_joblib_launcher.joblib_launcher import JoblibLauncher
 chdir_plugin_root()
 
 
-win_msg = "Windows is unsupported, due to stability issues with JobLib"
-
-
-@pytest.mark.skipif(sys.platform.startswith("win"), reason=win_msg)  # type: ignore
 def test_discovery() -> None:
     # Tests that this plugin can be discovered via the plugins subsystem when looking for Launchers
     assert JoblibLauncher.__name__ in [
@@ -26,7 +22,6 @@ def test_discovery() -> None:
     ]
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason=win_msg)
 @pytest.mark.parametrize("launcher_name, overrides", [("joblib", [])])
 class TestJoblibLauncher(LauncherTestSuite):
     """
@@ -36,7 +31,6 @@ class TestJoblibLauncher(LauncherTestSuite):
     pass
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason=win_msg)
 @pytest.mark.parametrize(
     "task_launcher_cfg, extra_flags",
     [

--- a/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
+++ b/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
@@ -1,6 +1,4 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import sys
-
 import pytest  # type: ignore
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher

--- a/tests/test_basic_launcher.py
+++ b/tests/test_basic_launcher.py
@@ -16,7 +16,7 @@ class TestBasicLauncher(LauncherTestSuite):
 @pytest.mark.parametrize(
     "task_launcher_cfg, extra_flags",
     [
-        (
+        pytest.param(
             {
                 "defaults": [
                     {"hydra/launcher": "basic"},
@@ -25,6 +25,7 @@ class TestBasicLauncher(LauncherTestSuite):
                 ]
             },
             ["-m"],
+            id="basic_launcher_multirun",
         )
     ],
 )

--- a/tests/test_basic_launcher.py
+++ b/tests/test_basic_launcher.py
@@ -29,7 +29,7 @@ class TestBasicLauncher(LauncherTestSuite):
         )
     ],
 )
-class TestExampleLauncherIntegration(IntegrationTestSuite):
+class TestBasicLauncherIntegration(IntegrationTestSuite):
     """
     Run this launcher through the integration test suite.
     """
@@ -41,5 +41,5 @@ class TestExampleLauncherIntegration(IntegrationTestSuite):
     "launcher_name, overrides",
     [("basic", ["hydra/sweeper=basic", "hydra.sweeper.params.max_batch_size=2"])],
 )
-class TestExampleSweeperWithBatching(BatchedSweeperTestSuite):
+class TesBasicSweeperWithBatching(BatchedSweeperTestSuite):
     ...

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,27 +5,7 @@ from typing import List
 import pytest
 from omegaconf import DictConfig, OmegaConf
 
-from hydra.test_utils.launcher_common_tests import IntegrationTestSuite
 from hydra.test_utils.test_utils import integration_test
-
-
-@pytest.mark.parametrize(
-    "task_launcher_cfg, extra_flags",
-    [
-        (
-            {
-                "defaults": [
-                    {"hydra/hydra_logging": "hydra_debug"},
-                    {"hydra/job_logging": "disabled"},
-                    {"hydra/launcher": "basic"},
-                ]
-            },
-            ["-m"],
-        )
-    ],
-)
-class TestBasicLauncherIntegration(IntegrationTestSuite):
-    pass
 
 
 @pytest.mark.parametrize(  # type: ignore

--- a/tests/test_plugins/namespace_pkg_config_source_test/namespace_test/test_namespace.py
+++ b/tests/test_plugins/namespace_pkg_config_source_test/namespace_test/test_namespace.py
@@ -25,7 +25,6 @@ class TestCoreConfigSources(ConfigSourceTestSuite):
     pass
 
 
-# TODO : ensure that if there is a missing __init__.py file in the dir a proper error is provided
 def test_config_in_dir(hydra_global_context: Any) -> None:
     with hydra_global_context(config_dir="../some_namespace/namespace_test/dir"):
         config_loader = GlobalHydra.instance().config_loader()


### PR DESCRIPTION
1. Enable Windows testing for the Joblib plugin
2. Added a test_to_absolute_path_multirun, running for all launchers (including the Joblib launcher).