### PR TITLE
Save the sweep configuration in sweeps

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -55,7 +55,7 @@ class ConfigLoaderImpl(ConfigLoader):
         if config_name is not None and not self.exists_in_search_path(config_name):
             # TODO: handle schema as a special case
             descs = [
-                "\t{} (from {})".format(src.path, src.provider)
+                f"\t{src.path} (from {src.provider})"
                 for src in self.repository.get_sources()
             ]
             lines = "\n".join(descs)
@@ -336,7 +336,7 @@ class ConfigLoaderImpl(ConfigLoader):
     ) -> DictConfig:
         try:
             if family != "":
-                new_cfg = "{}/{}".format(family, name)
+                new_cfg = f"{family}/{name}"
             else:
                 new_cfg = name
 
@@ -344,16 +344,15 @@ class ConfigLoaderImpl(ConfigLoader):
             if loaded_cfg is None:
                 if required:
                     if family == "":
-                        msg = "Could not load {}".format(new_cfg)
+                        msg = f"Could not load {new_cfg}"
                         raise MissingConfigException(msg, new_cfg)
                     else:
                         options = self.get_group_options(family)
                         if options:
-                            msg = "Could not load {}, available options:\n{}:\n\t{}".format(
-                                new_cfg, family, "\n\t".join(options)
-                            )
+                            lst = "\n\t".join(options)
+                            msg = f"Could not load {new_cfg}, available options:\n{family}:\n\t{lst}"
                         else:
-                            msg = "Could not load {}".format(new_cfg)
+                            msg = f"Could not load {new_cfg}"
                         raise MissingConfigException(msg, new_cfg, options)
                 else:
                     return cfg

--- a/hydra/_internal/core_plugins/bash_completion.py
+++ b/hydra/_internal/core_plugins/bash_completion.py
@@ -84,7 +84,7 @@ COMP_WORDBREAKS=$COMP_WORDBREAKS complete -o nospace -o default -F hydra_bash_co
             if match:
                 return match.group(1)
             else:
-                raise RuntimeError("Error parsing line '{}'".format(line))
+                raise RuntimeError(f"Error parsing line '{line}'")
 
     def query(self, config_name: Optional[str]) -> None:
         line = os.environ["COMP_LINE"]

--- a/hydra/_internal/core_plugins/basic_launcher.py
+++ b/hydra/_internal/core_plugins/basic_launcher.py
@@ -48,11 +48,12 @@ class BasicLauncher(Launcher):
         configure_log(self.config.hydra.hydra_logging, self.config.hydra.verbose)
         sweep_dir = self.config.hydra.sweep.dir
         Path(str(sweep_dir)).mkdir(parents=True, exist_ok=True)
-        log.info("Launching {} jobs locally".format(len(job_overrides)))
+        log.info(f"Launching {job_overrides} jobs locally")
         runs: List[JobReturn] = []
         for idx, overrides in enumerate(job_overrides):
             idx = initial_job_idx + idx
-            log.info("\t#{} : {}".format(idx, " ".join(filter_overrides(overrides))))
+            lst = " ".join(filter_overrides(overrides))
+            log.info(f"\t#{idx} : {lst}")
             sweep_config = self.config_loader.load_sweep_config(
                 self.config, list(overrides)
             )

--- a/hydra/_internal/core_plugins/basic_launcher.py
+++ b/hydra/_internal/core_plugins/basic_launcher.py
@@ -48,7 +48,7 @@ class BasicLauncher(Launcher):
         configure_log(self.config.hydra.hydra_logging, self.config.hydra.verbose)
         sweep_dir = self.config.hydra.sweep.dir
         Path(str(sweep_dir)).mkdir(parents=True, exist_ok=True)
-        log.info(f"Launching {job_overrides} jobs locally")
+        log.info(f"Launching {len(job_overrides)} jobs locally")
         runs: List[JobReturn] = []
         for idx, overrides in enumerate(job_overrides):
             idx = initial_job_idx + idx

--- a/hydra/_internal/core_plugins/basic_sweeper.py
+++ b/hydra/_internal/core_plugins/basic_sweeper.py
@@ -15,9 +15,10 @@ Basic Sweeper would generate 6 jobs:
 """
 import itertools
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Iterable, List, Optional, Sequence
 
-from omegaconf import MISSING, DictConfig
+from omegaconf import MISSING, DictConfig, OmegaConf
 
 from hydra.core.config_loader import ConfigLoader
 from hydra.core.config_store import ConfigStore
@@ -104,6 +105,12 @@ class BasicSweeper(Sweeper):
         assert self.launcher is not None
         self.initialize_arguments(arguments)
         returns: List[Sequence[JobReturn]] = []
+
+        # Save sweep run config in top level sweep working directory
+        sweep_dir = Path(self.config.hydra.sweep.dir)
+        sweep_dir.mkdir(parents=True, exist_ok=True)
+        OmegaConf.save(self.config, sweep_dir / "multirun.yaml")
+
         initial_job_idx = 0
         while not self.is_done():
             batch = self.get_job_batch()

--- a/hydra/_internal/core_plugins/basic_sweeper.py
+++ b/hydra/_internal/core_plugins/basic_sweeper.py
@@ -88,7 +88,7 @@ class BasicSweeper(Sweeper):
         lists = []
         for s in arguments:
             key, value = s.split("=")
-            lists.append(["{}={}".format(key, val) for val in value.split(",")])
+            lists.append([f"{key}={val}" for val in value.split(",")])
 
         all_batches = list(itertools.product(*lists))
         assert self.max_batch_size is None or self.max_batch_size > 0

--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -162,11 +162,8 @@ class Hydra:
 
         for shell, plugins in shell_to_plugin.items():
             if len(plugins) > 1:
-                raise ValueError(
-                    "Multiple plugins installed for {} : {}".format(
-                        shell, ",".join([type(plugin).__name__ for plugin in plugins])
-                    )
-                )
+                lst = ",".join([type(plugin).__name__ for plugin in plugins])
+                raise ValueError(f"Multiple plugins installed for {shell} : {lst}")
 
         return shell_to_plugin
 
@@ -177,18 +174,15 @@ class Hydra:
         arguments = OmegaConf.from_dotlist(overrides)
         num_commands = sum(1 for key in subcommands if arguments[key] is not None)
         if num_commands != 1:
-            raise ValueError(
-                "Expecting one subcommand from {} to be set".format(subcommands)
-            )
+            raise ValueError(f"Expecting one subcommand from {subcommands} to be set")
 
         shell_to_plugin = self.get_shell_to_plugin_map(self.config_loader)
 
         def find_plugin(cmd: str) -> CompletionPlugin:
             if cmd not in shell_to_plugin:
+                lst = "\n".join(["\t" + x for x in shell_to_plugin.keys()])
                 raise ValueError(
-                    "No completion plugin for '{}' found, available : \n{}".format(
-                        cmd, "\n".join(["\t" + x for x in shell_to_plugin.keys()])
-                    )
+                    f"No completion plugin for '{cmd}' found, available : \n{lst}"
                 )
             return shell_to_plugin[cmd][0]
 

--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -90,9 +90,7 @@ class Plugins(metaclass=Singleton):
 
         except ImportError as e:
             raise ImportError(
-                "Could not instantiate plugin {} : {}\n\n\tIS THE PLUGIN INSTALLED?\n\n".format(
-                    config["class"], str(e)
-                )
+                f"Could not instantiate plugin {classname} : {str(e)}\n\n\tIS THE PLUGIN INSTALLED?\n\n"
             )
 
         return plugin

--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -86,7 +86,8 @@ def filter_overrides(overrides: Sequence[str]) -> Sequence[str]:
 
 
 def split_key_val(s: str) -> Tuple[str, str]:
-    assert "=" in s, "'{}' not a valid override, expecting key=value format".format(s)
+    if "=" not in s:
+        raise ValueError(f"'{s}' not a valid override, expecting key=value format")
 
     idx = s.find("=")
     assert idx != -1
@@ -177,11 +178,11 @@ class JobRuntime(metaclass=Singleton):
     def get(self, key: str) -> Any:
         ret = OmegaConf.select(self.conf, key)
         if ret is None:
-            raise KeyError("Key not found in {}: {}".format(type(self).__name__, key))
+            raise KeyError(f"Key not found in {type(self).__name__}: {key}")
         return ret
 
     def set(self, key: str, value: Any) -> None:
-        log.debug("Setting {}:{}={}".format(type(self).__name__, key, value))
+        log.debug(f"Setting {type(self).__name__}:{key}={value}")
         self.conf[key] = value
 
 

--- a/hydra/plugins/completion_plugin.py
+++ b/hydra/plugins/completion_plugin.py
@@ -49,7 +49,7 @@ class CompletionPlugin(Plugin):
             prefixes = [".", "/", "\\", "./", ".\\"]
             if sys.platform.startswith("win"):
                 for drive in range(ord("a"), ord("z")):
-                    prefixes.append("{}:".format(chr(drive)))
+                    prefixes.append(f"{chr(drive)}:")
 
             if not filename:
                 return None, None
@@ -108,7 +108,7 @@ class CompletionPlugin(Plugin):
                 else:
                     key_matches = []
 
-                matches.extend(["{}{}".format(word, match) for match in key_matches])
+                matches.extend([f"{word}{match}" for match in key_matches])
             else:
                 last_dot = word.rfind(".")
                 if last_dot != -1:
@@ -116,9 +116,7 @@ class CompletionPlugin(Plugin):
                     partial_key = word[last_dot + 1 :]
                     conf_node = OmegaConf.select(config, base_key)
                     key_matches = CompletionPlugin._get_matches(conf_node, partial_key)
-                    matches.extend(
-                        ["{}.{}".format(base_key, match) for match in key_matches]
-                    )
+                    matches.extend([f"{base_key}.{match}" for match in key_matches])
                 else:
                     if isinstance(config, DictConfig):
                         for key, value in config.items_ex(resolve=False):
@@ -135,9 +133,7 @@ class CompletionPlugin(Plugin):
                                 matches.append(str_rep(idx, ""))
 
         else:
-            assert False, "Object is not an instance of config : {}".format(
-                type(config)
-            )
+            assert False, f"Object is not an instance of config : {type(config)}"
 
         return matches
 
@@ -161,9 +157,7 @@ class CompletionPlugin(Plugin):
         matched_groups: List[str] = []
         if results_filter == ObjectType.CONFIG:
             for match in all_matched_groups:
-                name = (
-                    "{}={}".format(parent_group, match) if parent_group != "" else match
-                )
+                name = f"{parent_group}={match}" if parent_group != "" else match
                 if name.startswith(word):
                     matched_groups.append(name)
                 exact_match = True

--- a/hydra/test_utils/launcher_common_tests.py
+++ b/hydra/test_utils/launcher_common_tests.py
@@ -247,16 +247,15 @@ def sweep_2_jobs(sweep_runner: TSweepRunner, overrides: List[str]) -> None:
             expected_conf = OmegaConf.merge(
                 base, OmegaConf.from_dotlist(job_ret.overrides)
             )
-            assert job_ret.overrides == ["a={}".format(i)]
+            assert job_ret.overrides == [f"a={i}"]
             assert job_ret.cfg == expected_conf
             assert job_ret.hydra_cfg.hydra.job.name == "a_module", (
                 "Unexpected job name: " + job_ret.hydra_cfg.hydra.job.name
             )
             verify_dir_outputs(job_ret, job_ret.overrides)
             path = temp_dir / str(i)
-            assert path.exists(), "'{}' does not exist, dirs: {}".format(
-                path, [x for x in temp_dir.iterdir() if x.is_dir()]
-            )
+            lst = [x for x in temp_dir.iterdir() if x.is_dir()]
+            assert path.exists(), f"'{path}' does not exist, dirs: {lst}"
 
 
 def not_sweeping_hydra_overrides(
@@ -285,7 +284,7 @@ def not_sweeping_hydra_overrides(
             expected_conf = OmegaConf.merge(
                 base, OmegaConf.from_dotlist(job_ret.overrides)
             )
-            assert job_ret.overrides == ["a={}".format(i)]
+            assert job_ret.overrides == [f"a={i}"]
             assert job_ret.cfg == expected_conf
             verify_dir_outputs(job_ret, job_ret.overrides)
 

--- a/hydra/test_utils/test_utils.py
+++ b/hydra/test_utils/test_utils.py
@@ -103,7 +103,7 @@ class TaskTestFunction:
             self.temp_dir = tempfile.mkdtemp()
             overrides = copy.deepcopy(self.overrides)
             assert overrides is not None
-            overrides.append("hydra.run.dir={}".format(self.temp_dir))
+            overrides.append(f"hydra.run.dir={self.temp_dir}")
             self.job_ret = self.hydra.run(
                 config_name=config_name, task_function=self, overrides=overrides
             )
@@ -165,7 +165,7 @@ class SweepTaskFunction:
         self.temp_dir = tempfile.mkdtemp()
         overrides = copy.deepcopy(self.overrides)
         assert overrides is not None
-        overrides.append("hydra.sweep.dir={}".format(self.temp_dir))
+        overrides.append(f"hydra.sweep.dir={self.temp_dir}")
         try:
             config_dir, config_name = split_config_path(
                 self.config_path, self.config_name
@@ -227,7 +227,7 @@ def _chdir_to_dir_containing(target: str, max_up: int = 4) -> None:
         cur = os.path.relpath(os.path.join(cur, ".."))
         max_up = max_up - 1
     if max_up == 0:
-        raise IOError("Could not find {} in parents of {}".format(target, os.getcwd()))
+        raise IOError(f"Could not find {target} in parents of {os.getcwd()}")
     os.chdir(cur)
 
 
@@ -311,7 +311,7 @@ if __name__ == "__main__":
     if task_config is not None:
         cfg_file = tmpdir / "config.yaml"
         OmegaConf.save(task_config, str(cfg_file))
-        config_path = "config_path='{}'".format("config.yaml")
+        config_path = f"config_path='config.yaml'"
     output_file = str(tmpdir / "output.txt")
     # replace Windows path separator \ with an escaped version \\
     output_file = output_file.replace("\\", "\\\\")

--- a/noxfile.py
+++ b/noxfile.py
@@ -342,7 +342,8 @@ def test_jupyter_notebooks(session):
         session.skip(
             f"Not testing Jupyter notebook on Python {session.python}, supports [{','.join(versions)}]"
         )
-    session.install("jupyter", "nbval")
+    # pyzmq 19.0.1 has installation issues on Windows
+    session.install("jupyter", "nbval", "pyzmq==19.0.0")
     install_hydra(session, ["pip", "install", "-e"])
     args = pytest_args(
         session, "--nbval", "examples/notebook/hydra_notebook_example.ipynb"

--- a/noxfile.py
+++ b/noxfile.py
@@ -272,7 +272,7 @@ def test_plugins(session, install_cmd):
 
     # Test that we can import all installed plugins
     for plugin in selected_plugin:
-        session.run("python", "-c", "import {}".format(plugin["module"]))
+        session.run("python", "-c", f"import {plugin['module']}")
 
     # Run Hydra tests to verify installed plugins did not break anything
     if not SKIP_CORE_TESTS:

--- a/plugins/examples/example_launcher_plugin/hydra_plugins/example_launcher_plugin/example_launcher.py
+++ b/plugins/examples/example_launcher_plugin/hydra_plugins/example_launcher_plugin/example_launcher.py
@@ -78,16 +78,15 @@ class ExampleLauncher(Launcher):
         sweep_dir = Path(str(self.config.hydra.sweep.dir))
         sweep_dir.mkdir(parents=True, exist_ok=True)
         log.info(
-            "Example Launcher(foo={}, bar={}) is launching {} jobs locally".format(
-                self.foo, self.bar, len(job_overrides)
-            )
+            f"Example Launcher(foo={self.foo}, bar={self.bar}) is launching {len(job_overrides)} jobs locally"
         )
-        log.info("Sweep output dir : {}".format(sweep_dir))
+        log.info(f"Sweep output dir : {sweep_dir}")
         runs = []
 
         for idx, overrides in enumerate(job_overrides):
             idx = initial_job_idx + idx
-            log.info("\t#{} : {}".format(idx, " ".join(filter_overrides(overrides))))
+            lst = " ".join(filter_overrides(overrides))
+            log.info(f"\t#{idx} : {lst}")
             sweep_config = self.config_loader.load_sweep_config(
                 self.config, list(overrides)
             )
@@ -95,7 +94,7 @@ class ExampleLauncher(Launcher):
                 # This typically coming from the underlying scheduler (SLURM_JOB_ID for instance)
                 # In that case, it will not be available here because we are still in the main process.
                 # but instead should be populated remotely before calling the task_function.
-                sweep_config.hydra.job.id = "job_id_for_{}".format(idx)
+                sweep_config.hydra.job.id = f"job_id_for_{idx}"
                 sweep_config.hydra.job.num = idx
             HydraConfig.instance().set_config(sweep_config)
 

--- a/plugins/examples/example_launcher_plugin/hydra_plugins/example_launcher_plugin/example_launcher.py
+++ b/plugins/examples/example_launcher_plugin/hydra_plugins/example_launcher_plugin/example_launcher.py
@@ -23,6 +23,8 @@ from omegaconf import DictConfig, open_dict
 # Import the module lazily (typically inside launch()).
 # Installed plugins are imported during Hydra initialization and plugins that are slow to import plugins will slow
 # the startup of ALL hydra applications.
+# Another approach is to place heavy includes in a file prefixed by _, such as _core.py:
+# Hydra will not look for plugin in such files and will not import them during plugin discovery.
 
 
 log = logging.getLogger(__name__)

--- a/plugins/examples/example_sweeper_plugin/hydra_plugins/example_sweeper_plugin/example_sweeper.py
+++ b/plugins/examples/example_sweeper_plugin/hydra_plugins/example_sweeper_plugin/example_sweeper.py
@@ -1,8 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from pathlib import Path
-
 import itertools
 import logging
+from pathlib import Path
 from typing import Any, Iterable, List, Optional, Sequence
 
 from hydra.core.config_loader import ConfigLoader

--- a/plugins/examples/example_sweeper_plugin/hydra_plugins/example_sweeper_plugin/example_sweeper.py
+++ b/plugins/examples/example_sweeper_plugin/hydra_plugins/example_sweeper_plugin/example_sweeper.py
@@ -58,15 +58,15 @@ class ExampleSweeper(Sweeper):
     def sweep(self, arguments: List[str]) -> Any:
         assert self.config is not None
         assert self.launcher is not None
-        log.info("ExampleSweeper (foo={}, bar={}) sweeping".format(self.foo, self.bar))
-        log.info("Sweep output dir : {}".format(self.config.hydra.sweep.dir))
+        log.info(f"ExampleSweeper (foo={self.foo}, bar={self.bar}) sweeping")
+        log.info(f"Sweep output dir : {self.config.hydra.sweep.dir}")
         # Construct list of overrides per job we want to launch
         src_lists = []
         for s in arguments:
             key, value = s.split("=")
             # for each argument, create a list. if the argument has , (aka - is a sweep), add an element for each
             # option to that list, otherwise add a single element with the value
-            src_lists.append(["{}={}".format(key, val) for val in value.split(",")])
+            src_lists.append([f"{key}={val}" for val in value.split(",")])
 
         batches = list(itertools.product(*src_lists))
 

--- a/plugins/examples/example_sweeper_plugin/tests/test_example_sweeper_plugin.py
+++ b/plugins/examples/example_sweeper_plugin/tests/test_example_sweeper_plugin.py
@@ -64,6 +64,7 @@ class TestExampleSweeper(LauncherTestSuite):
         (
             "basic",
             [
+                # CHANGE THIS TO YOUR SWEEPER CONFIG NAME
                 "hydra/sweeper=example",
                 # This will cause the sweeper to split batches to at most 2 jobs each, which is what
                 # the tests in BatchedSweeperTestSuite are expecting.

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_earlystopper.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_earlystopper.py
@@ -42,9 +42,7 @@ class EarlyStopper:
             self.current_epochs_without_improvement = 0
             self.current_best_value = potential_best_value
             log.info(
-                "New best value: {}, best parameters: {}".format(
-                    potential_best_value, best_parameters
-                )
+                f"New best value: {potential_best_value}, best parameters: {best_parameters}"
             )
 
             return False
@@ -56,9 +54,8 @@ class EarlyStopper:
             >= self.max_epochs_without_improvement
         ):
             log.info(
-                "Early stopping, best known value {} did not improve for {} epochs".format(
-                    self.current_best_value, self.current_epochs_without_improvement
-                )
+                f"Early stopping, best known value {self.current_best_value}"
+                f" did not improve for {self.current_epochs_without_improvement} epochs"
             )
             return True
         return False

--- a/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
+++ b/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
@@ -240,3 +240,14 @@ def test_example_app(tmpdir: Path) -> None:
     result = subprocess.check_output(cmd).decode("utf-8").rstrip()
     assert "banana.x: range=[-5, 5], type = int" in result
     assert "banana.y: range=[-5.0, 10.1], type = float" in result
+
+
+# TODO: enable this and make sure it runs reasonable fast
+# # Run launcher test suite with the basic launcher and this sweeper
+# @pytest.mark.parametrize(
+#     "launcher_name, overrides",
+#     [("basic", ["hydra/sweeper=ax", "quadratic.x=-1.0:1.0", "quadratic.y=-1.0:1.0"])],
+# )
+# class TestAxSweeper(LauncherTestSuite):
+#     def task_function(self, cfg):
+#         return 100 * (cfg.quadratic.x ** 2) + 1 * cfg.quadratic.y

--- a/plugins/hydra_nevergrad_sweeper/tests/test_nevergrad_sweeper_plugin.py
+++ b/plugins/hydra_nevergrad_sweeper/tests/test_nevergrad_sweeper_plugin.py
@@ -101,3 +101,19 @@ def test_nevergrad_example(with_commandline: bool, tmpdir: Path) -> None:
     # check that all job folders are created
     last_job = max(int(fp.name) for fp in Path(tmpdir).iterdir() if fp.name.isdigit())
     assert last_job == budget - 1
+
+
+# # TODO: enable this and make sure it runs reasonable fast
+# # Run launcher test suite with the basic launcher and this sweeper
+# @pytest.mark.parametrize(
+#     "launcher_name, overrides",
+#     [
+#         (
+#             "basic",
+#             ["hydra/sweeper=nevergrad", "quadratic.x=-1.0:1.0", "quadratic.y=-1.0:1.0"],
+#         )
+#     ],
+# )
+# class TestAxSweeper(LauncherTestSuite):
+#     def task_function(self, cfg):
+#         return 100 * (cfg.quadratic.x ** 2) + 1 * cfg.quadratic.y

--- a/tests/test_basic_launcher.py
+++ b/tests/test_basic_launcher.py
@@ -41,5 +41,5 @@ class TestBasicLauncherIntegration(IntegrationTestSuite):
     "launcher_name, overrides",
     [("basic", ["hydra/sweeper=basic", "hydra.sweeper.params.max_batch_size=2"])],
 )
-class TesBasicSweeperWithBatching(BatchedSweeperTestSuite):
+class TestBasicSweeperWithBatching(BatchedSweeperTestSuite):
     ...


### PR DESCRIPTION
The sweep config file contains, among other things, the command line used in the run.
This run:
```
$ python examples/tutorial/3_config_groups/my_app.py -m db=mysql,postgresql hydra/help=default
```
Would result in this in `multirun/.../.../sweep.yaml`:
```yaml
hydra:
  overrides:
    hydra:
    - hydra/help=default
    task:
    - db=mysql,postgresql

```
Fixes #298 