### PR TITLE
fix command line tokenization on fish version < 3.0.0

### DIFF
--- a/hydra/_internal/core_plugins/fish_completion.py
+++ b/hydra/_internal/core_plugins/fish_completion.py
@@ -16,7 +16,7 @@ class FishCompletion(CompletionPlugin):
     set -lx COMP_LINE (commandline -cp)
 
     # Find out how to call the underlying script
-    set -l parts (string split -n ' ' $COMP_LINE)
+    set -l parts (commandline -cpo)
     if test "$parts[1]" = "python" -o "$parts[1]" = "python3"
         set cmd "$parts[1] $parts[2]"
         if not grep -q "@hydra.main" $parts[2]

--- a/news/592.bugfix
+++ b/news/592.bugfix
@@ -1,0 +1,1 @@
+Fix command line tokenization on fish version < 3.0.0


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Fix #592 where command line tokenization breaks on fish version < 3.0.0

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

This change affects fish version < 3.0.0 and was manually tested.

## Related Issues and PRs

Fixes #592 