### PR TITLE
Ax plugin : Remove unused config files

### DIFF
--- a/plugins/hydra_ax_sweeper/tests/config/defaults/default.yaml
+++ b/plugins/hydra_ax_sweeper/tests/config/defaults/default.yaml
@@ -1,3 +1,0 @@
-# @package _global_
-defaults:
-  - hydra/sweeper: ax


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

While updating the Ax plugin[https://github.com/facebookresearch/hydra/pull/567], I commited some unused config files

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Removing these config files did not break the tests

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
