### PR TITLE
Clarify why `hydra.utils` supports both `call`  and  `instantiate` methods

### DIFF
--- a/website/docs/patterns/objects.md
+++ b/website/docs/patterns/objects.md
@@ -4,7 +4,7 @@ title: Creating objects and calling functions
 sidebar_label: Creating objects and calling functions
 ---
 ### Instantiating objects and calling methods and functions
-Use `hydra.utils.call()` (or its alias `hydra.utils.instantiate()`) to instantiate objects, call functions and call class methods.
+Use `hydra.utils.call()` (or its alias `hydra.utils.instantiate()`) to instantiate objects, call functions and call class methods. While `instantiate` is an alias for `call`, you may prefer to use `call` for invoking functions and class methods, and `instantiate` for creating objects.
 
 ```python
 def call(config: Union[ObjectConf, DictConfig], *args: Any, **kwargs: Any) -> Any:


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Clarify why `hydra.utils` have both `call`  and  `instantiate` methods

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

NA - Documentation change

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)

NA
