### PR TITLE
[Submitit Plugin] Prevent default retry on timeout

### DIFF
--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/conf/hydra/launcher/submitit.yaml
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/conf/hydra/launcher/submitit.yaml
@@ -10,7 +10,7 @@ params:
     # slurm queue parameters
     slurm:
       nodes: 1
-      num_gpus: 1
+      gpus_per_node: 1
       ntasks_per_node: 1
       mem: ${hydra.launcher.mem_limit}GB
       cpus_per_task: 10

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/conf/hydra/launcher/submitit.yaml
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/conf/hydra/launcher/submitit.yaml
@@ -29,7 +29,9 @@ params:
       timeout_min: 60
     # auto queue parameters
     auto:
-      max_num_timeout: 1
+      slurm_max_num_timeout: 0
+      gpus_per_node: 1
+      timeout_min: 60
 
 # variables used by queues above
 mem_limit: 24

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/conf/hydra/launcher/submitit.yaml
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/conf/hydra/launcher/submitit.yaml
@@ -21,7 +21,7 @@ params:
       # Maximum number of retries on job timeout.
       # Change this only after you confirmed your code can handle re-submission
       # by properly resuming from the latest stored checkpoint.
-      max_num_timeout: 1
+      max_num_timeout: 0
     # local queue parameters
     local:
       gpus_per_node: 1

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
@@ -99,11 +99,11 @@ class SubmititLauncher(Launcher):
         queue_parameters = self.queue_parameters.copy()
         OmegaConf.set_struct(queue_parameters, True)
         if self.queue == "auto":
-            max_num_timeout = self.queue_parameters.auto.max_num_timeout
+            slurm_max_num_timeout = self.queue_parameters.auto.slurm_max_num_timeout
             with open_dict(queue_parameters):
-                del queue_parameters.auto["max_num_timeout"]
+                del queue_parameters.auto["slurm_max_num_timeout"]
             executor = submitit.AutoExecutor(
-                folder=self.folder, max_num_timeout=max_num_timeout
+                folder=self.folder, slurm_max_num_timeout=slurm_max_num_timeout
             )
         elif self.queue == "slurm":
             max_num_timeout = self.queue_parameters.slurm.max_num_timeout

--- a/website/docs/plugins/submitit_launcher.md
+++ b/website/docs/plugins/submitit_launcher.md
@@ -43,7 +43,7 @@ params:
     # slurm queue parameters
     slurm:
       nodes: 1
-      num_gpus: 1
+      gpus_per_node: 1
       ntasks_per_node: 1
       mem: ${hydra.launcher.mem_limit}GB
       cpus_per_task: 10

--- a/website/docs/plugins/submitit_launcher.md
+++ b/website/docs/plugins/submitit_launcher.md
@@ -62,7 +62,9 @@ params:
       timeout_min: 60
     # auto queue parameters
     auto:
-      max_num_timeout: 0
+      slurm_max_num_timeout: 0
+      gpus_per_node: 1
+      timeout_min: 60
 
 # variables used by queues above
 mem_limit: 24

--- a/website/docs/plugins/submitit_launcher.md
+++ b/website/docs/plugins/submitit_launcher.md
@@ -54,7 +54,7 @@ params:
       # Maximum number of retries on job timeout.
       # Change this only after you confirmed your code can handle re-submission
       # by properly resuming from the latest stored checkpoint.
-      max_num_timeout: 1
+      max_num_timeout: 0
     # local queue parameters
     local:
       gpus_per_node: 1
@@ -62,7 +62,7 @@ params:
       timeout_min: 60
     # auto queue parameters
     auto:
-      max_num_timeout: 1
+      max_num_timeout: 0
 
 # variables used by queues above
 mem_limit: 24


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

The current default configuration was retrying once when timed-out. This is an unexpected behavior in my opinion, jobs should be retried on timeouts only if the user explicitly ask for it (cc @alexholdenmiller ;) )

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

N/A
