### PR TITLE
Unpin ax-platform

### DIFF
--- a/plugins/hydra_ax_sweeper/setup.py
+++ b/plugins/hydra_ax_sweeper/setup.py
@@ -22,6 +22,6 @@ with open("README.md", "r") as fh:
             "Operating System :: POSIX :: Linux",
             "Development Status :: 4 - Beta",
         ],
-        install_requires=["hydra-core==1.0.*", "ax-platform[mysql]==0.1.9"],
+        install_requires=["hydra-core==1.0.*", "ax-platform[mysql]>=0.1.9"],
         include_package_data=True,
     )


### PR DESCRIPTION
ax-platform was pinned to 0.1.9. This sets 0.1.9 as the minimum version required, instead.

<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
