### PR TITLE
Update hydra-core requirements spec

### DIFF
--- a/plugins/hydra_ax_sweeper/setup.py
+++ b/plugins/hydra_ax_sweeper/setup.py
@@ -22,6 +22,6 @@ with open("README.md", "r") as fh:
             "Operating System :: POSIX :: Linux",
             "Development Status :: 4 - Beta",
         ],
-        install_requires=["hydra-core==1.0.*", "ax-platform[mysql]==0.1.9"],
+        install_requires=["hydra-core~=1.0.0rc1", "ax-platform[mysql]==0.1.9"],
         include_package_data=True,
     )

--- a/plugins/hydra_colorlog/setup.py
+++ b/plugins/hydra_colorlog/setup.py
@@ -21,6 +21,6 @@ with open("README.md", "r") as fh:
             "Programming Language :: Python :: 3.8",
             "Operating System :: OS Independent",
         ],
-        install_requires=["colorlog", "hydra-core==1.0.*"],
+        install_requires=["colorlog", "hydra-core~=1.0.0rc1"],
         include_package_data=True,
     )

--- a/plugins/hydra_joblib_launcher/setup.py
+++ b/plugins/hydra_joblib_launcher/setup.py
@@ -22,6 +22,6 @@ with open("README.md", "r") as fh:
             "Operating System :: Microsoft :: Windows",
             "Operating System :: POSIX :: Linux",
         ],
-        install_requires=["hydra-core==1.0.*", "joblib>=0.14.0"],
+        install_requires=["hydra-core~=1.0.0rc1", "joblib>=0.14.0"],
         include_package_data=True,
     )

--- a/plugins/hydra_nevergrad_sweeper/setup.py
+++ b/plugins/hydra_nevergrad_sweeper/setup.py
@@ -22,6 +22,6 @@ with open("README.md", "r") as fh:
             "Operating System :: OS Independent",
             "Development Status :: 4 - Beta",
         ],
-        install_requires=["hydra-core==1.0.*", "nevergrad>=0.4.1.post4"],
+        install_requires=["hydra-core~=1.0.0rc1", "nevergrad>=0.4.1.post4"],
         include_package_data=True,
     )

--- a/plugins/hydra_submitit_launcher/setup.py
+++ b/plugins/hydra_submitit_launcher/setup.py
@@ -21,6 +21,6 @@ with open("README.md", "r") as fh:
             "Operating System :: POSIX :: Linux",
             "Development Status :: 4 - Beta",
         ],
-        install_requires=["hydra-core==1.0.*", "submitit>=1.0.0"],
+        install_requires=["hydra-core~=1.0.0rc1", "submitit>=1.0.0"],
         include_package_data=True,
     )


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

The requirements for hydra-core in plugins/**/setup.py were malformed. This fixes them so that the plugins are installable from PyPI with the 1.0.0rc1 version of hydra-core.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes.

## Test Plan

I manually tested building hydra-core with versions 1.0.0rc1, 1.0.0, 1.0.1rc1, 1.0.1 and installed hydra-ax-sweeper from pre-built wheels using only a local PyPI server. For each version listed, I had only that version available on my local PyPI server. And in all cases, that version was installed without an issue.

I also tested building hydra-core with versions 1.1.0rc1 and 1.1.0. In both cases, installation failed when installing hydra-px-sweeper, as one would expect.