### PR TITLE
Correct pip package names for hydra plugins in documentation

### DIFF
--- a/website/docs/plugins/joblib_launcher.md
+++ b/website/docs/plugins/joblib_launcher.md
@@ -15,7 +15,7 @@ The Joblib Launcher plugin provides a launcher for parallel tasks based on [`Job
 ### Installation
 This plugin requires Hydra 1.0 (Release candidate)
 ```commandline
-$ pip install hydra-jobliblauncher --pre
+$ pip install hydra-joblib-launcher --pre
 ```
 
 ### Usage

--- a/website/docs/plugins/nevergrad_sweeper.md
+++ b/website/docs/plugins/nevergrad_sweeper.md
@@ -17,7 +17,7 @@ sidebar_label: Nevergrad Sweeper plugin
 ### Installation
 This plugin requires Hydra 1.0 (Release candidate)
 ```commandline
-$ pip install hydra-joblib-launcher --pre
+$ pip install hydra-nevergrad-sweeper --pre
 ```
 
 ### Usage


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

This is just a minor improvement by correcting the names of the packages for nevergrad-sweeper and joblib-launcher. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

