### PR TITLE
Add support for --config-path style cli option

### DIFF
--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -352,21 +352,21 @@ def get_args_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
-        "--shell_completion",
+        "--shell-completion",
         "-sc",
         action="store_true",
         help=f"Install or Uninstall shell completion:\n{_get_completion_help()}",
     )
 
     parser.add_argument(
-        "--config_path",
+        "--config-path",
         "-cp",
         help="""Overrides the config_path specified in hydra.main().
                     The config_path is relative to the Python file declaring @hydra.main()""",
     )
 
     parser.add_argument(
-        "--config_name",
+        "--config-name",
         "-cn",
         help="Overrides the config_name specified in hydra.main()",
     )

--- a/news/653.plugin
+++ b/news/653.plugin
@@ -1,2 +1,1 @@
 Upgraded ax-platform in Ax Sweeper Plugin to 0.1.12
-

--- a/news/661.api_change
+++ b/news/661.api_change
@@ -1,1 +1,1 @@
-Unify the CLI parser keyword to dash-style
+Hydra argparse flags are now consistently using dash-style.

--- a/news/661.api_change
+++ b/news/661.api_change
@@ -1,0 +1,1 @@
+Unify the CLI parser keyword to dash-style

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -747,8 +747,8 @@ def test_config_name_and_path_overrides(
         sys.executable,
         "tests/test_apps/app_with_multiple_config_dirs/my_app.py",
         "hydra.run.dir=" + str(tmpdir),
-        f"--config_name={config_name}",
-        f"--config_path={config_path}",
+        f"--config-name={config_name}",
+        f"--config-path={config_path}",
     ]
     print(" ".join(cmd))
     result = str(subprocess.check_output(cmd).decode("utf-8")).strip()

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -539,7 +539,7 @@ def test_sweep_complex_defaults(
 --cfg,-c : Show config instead of running [job|hydra|all]
 --run,-r : Run a job
 --multirun,-m : Run multiple jobs with the configured launcher
---shell_completion,-sc : Install or Uninstall shell completion:
+--shell-completion,-sc : Install or Uninstall shell completion:
     Bash - Install:
     eval "$(python my_app.py -sc install=bash)"
     Bash - Uninstall:
@@ -550,9 +550,9 @@ def test_sweep_complex_defaults(
     Fish - Uninstall:
     python my_app.py -sc uninstall=fish | source
 
---config_path,-cp : Overrides the config_path specified in hydra.main().
+--config-path,-cp : Overrides the config_path specified in hydra.main().
                     The config_path is relative to the Python file declaring @hydra.main()
---config_name,-cn : Overrides the config_name specified in hydra.main()
+--config-name,-cn : Overrides the config_name specified in hydra.main()
 --info,-i : Print Hydra information
 Overrides : Any key=value arguments to override config values (use dots for.nested=overrides)
 """,
@@ -587,7 +587,7 @@ Overrides : Any key=value arguments to override config values (use dots for.nest
 --cfg,-c : Show config instead of running [job|hydra|all]
 --run,-r : Run a job
 --multirun,-m : Run multiple jobs with the configured launcher
---shell_completion,-sc : Install or Uninstall shell completion:
+--shell-completion,-sc : Install or Uninstall shell completion:
     Bash - Install:
     eval "$(python my_app.py -sc install=bash)"
     Bash - Uninstall:
@@ -598,9 +598,9 @@ Overrides : Any key=value arguments to override config values (use dots for.nest
     Fish - Uninstall:
     python my_app.py -sc uninstall=fish | source
 
---config_path,-cp : Overrides the config_path specified in hydra.main().
+--config-path,-cp : Overrides the config_path specified in hydra.main().
                     The config_path is relative to the Python file declaring @hydra.main()
---config_name,-cn : Overrides the config_name specified in hydra.main()
+--config-name,-cn : Overrides the config_name specified in hydra.main()
 --info,-i : Print Hydra information
 Overrides : Any key=value arguments to override config values (use dots for.nested=overrides)
 """,


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Support standard --xxx-xx style python cli option.

The original --xxx_xx is also supported automatically by argparser.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

It's totally BC.
No special tests required.

## Related Issues and PRs

None