### PR TITLE
Deprecated ObjectConf.cls in favor of ObjectConf.target

### DIFF
--- a/examples/advanced/hydra_app_example/tests/test_example.py
+++ b/examples/advanced/hydra_app_example/tests/test_example.py
@@ -2,9 +2,9 @@
 import unittest
 from typing import List
 
+import hydra_app.main
 import pytest
 
-import hydra_app.main
 from hydra.experimental import compose, initialize, initialize_config_module
 
 

--- a/examples/advanced/hydra_app_example/tests/test_example.py
+++ b/examples/advanced/hydra_app_example/tests/test_example.py
@@ -2,9 +2,9 @@
 import unittest
 from typing import List
 
-import hydra_app.main
 import pytest
 
+import hydra_app.main
 from hydra.experimental import compose, initialize, initialize_config_module
 
 

--- a/hydra/_internal/core_plugins/basic_sweeper.py
+++ b/hydra/_internal/core_plugins/basic_sweeper.py
@@ -29,7 +29,7 @@ from hydra.types import ObjectConf, TaskFunction
 
 @dataclass
 class BasicSweeperConf(ObjectConf):
-    cls: str = MISSING
+    target: str = MISSING
 
     @dataclass
     class Params:

--- a/hydra/conf/hydra/launcher/basic.yaml
+++ b/hydra/conf/hydra/launcher/basic.yaml
@@ -1,3 +1,3 @@
 # @package _group_
 
-cls: hydra._internal.core_plugins.basic_launcher.BasicLauncher
+target: hydra._internal.core_plugins.basic_launcher.BasicLauncher

--- a/hydra/conf/hydra/sweeper/basic.yaml
+++ b/hydra/conf/hydra/sweeper/basic.yaml
@@ -1,3 +1,3 @@
 # @package _group_
 
-cls: hydra._internal.core_plugins.basic_sweeper.BasicSweeper
+target: hydra._internal.core_plugins.basic_sweeper.BasicSweeper

--- a/hydra/types.py
+++ b/hydra/types.py
@@ -12,6 +12,14 @@ TaskFunction = Callable[[Any], Any]
 # Once support for class field removed this can stop extending Dict.
 class ObjectConf(Dict[str, Any]):
     # class, class method or function name
-    cls: str = MISSING
+    target: str = MISSING
+
     # parameters to pass to cls when calling it
     params: Any = field(default_factory=dict)
+
+    # cls is deprecated, use target, cls will be removed in Hydra 1.1
+    cls: str = MISSING
+
+    # class is deprecated, use target, class will be removed in Hydra 1.1
+    # (class is Python keyword and is only supported through DictConfig)
+    # class: str = MISSING

--- a/news/721.api_change
+++ b/news/721.api_change
@@ -1,0 +1,1 @@
+deprecated cls in favor of target in hydra.utils.{instantiate()/call{}}

--- a/noxfile.py
+++ b/noxfile.py
@@ -229,7 +229,10 @@ def lint(session):
         session.chdir(BASE)
 
     session.run(*_black_cmd(), silent=SILENT)
-    session.run(*_isort_cmd() + ["--skip=plugins", "--skip=.nox"], silent=SILENT)
+    skiplist = apps + ["plugins", ".nox"]
+    isort = _isort_cmd() + [f"--skip={skip}" for skip in skiplist]
+
+    session.run(*isort, silent=SILENT)
 
     session.run("mypy", ".", "--strict", silent=SILENT)
     session.run("flake8", "--config", ".flake8")

--- a/plugins/examples/example_launcher_plugin/README.md
+++ b/plugins/examples/example_launcher_plugin/README.md
@@ -7,7 +7,7 @@ The configuration for this launcher is in packages with the plugin:
 ```yaml
 hydra:
   launcher:
-    cls: hydra_plugins.example_launcher_plugin.ExampleLauncher
+    target: hydra_plugins.example_launcher_plugin.ExampleLauncher
     params:
       foo: 10
       bar: abcde

--- a/plugins/examples/example_launcher_plugin/hydra_plugins/example_launcher_plugin/conf/hydra/launcher/example.yaml
+++ b/plugins/examples/example_launcher_plugin/hydra_plugins/example_launcher_plugin/conf/hydra/launcher/example.yaml
@@ -1,5 +1,5 @@
 # @package _group_
-cls: hydra_plugins.example_launcher_plugin.example_launcher.ExampleLauncher
+target: hydra_plugins.example_launcher_plugin.example_launcher.ExampleLauncher
 params:
   foo: 10
   bar: abcde

--- a/plugins/examples/example_launcher_plugin/tests/test_example_launcher_plugin.py
+++ b/plugins/examples/example_launcher_plugin/tests/test_example_launcher_plugin.py
@@ -39,7 +39,7 @@ class TestExampleLauncher(LauncherTestSuite):
                 ],
                 "hydra": {
                     "launcher": {
-                        "cls": "hydra_plugins.example_launcher_plugin.example_launcher.ExampleLauncher",
+                        "target": "hydra_plugins.example_launcher_plugin.example_launcher.ExampleLauncher",
                         "params": {"foo": 10, "bar": "abcde"},
                     }
                 },

--- a/plugins/examples/example_sweeper_plugin/README.md
+++ b/plugins/examples/example_sweeper_plugin/README.md
@@ -5,7 +5,7 @@ The provided example has a custom configuration for the sweeper that takes two p
 ```yaml
 hydra:
   sweeper:
-    cls: hydra_plugins.example_sweeper.ExampleSweeper
+    target: hydra_plugins.example_sweeper.ExampleSweeper
     params:
       foo: 10
       bar: abcde

--- a/plugins/examples/example_sweeper_plugin/hydra_plugins/example_sweeper_plugin/conf/hydra/sweeper/example.yaml
+++ b/plugins/examples/example_sweeper_plugin/hydra_plugins/example_sweeper_plugin/conf/hydra/sweeper/example.yaml
@@ -1,5 +1,5 @@
 # @package _group_
-cls: hydra_plugins.example_sweeper_plugin.example_sweeper.ExampleSweeper
+target: hydra_plugins.example_sweeper_plugin.example_sweeper.ExampleSweeper
 params:
   # max number of jobs to run in the same batch.
   max_batch_size: null

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/config.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/config.py
@@ -62,7 +62,7 @@ class AxSweeperParams:
 
 @dataclass
 class AxSweeperConf(ObjectConf):
-    cls: str = "hydra_plugins.hydra_ax_sweeper.ax_sweeper.AxSweeper"
+    target: str = "hydra_plugins.hydra_ax_sweeper.ax_sweeper.AxSweeper"
     params: AxSweeperParams = AxSweeperParams()
 
 

--- a/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/config.py
+++ b/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/config.py
@@ -44,7 +44,7 @@ class JobLibConf:
 
 @dataclass
 class JobLibLauncherConf(ObjectConf):
-    cls: str = "hydra_plugins.hydra_joblib_launcher.joblib_launcher.JoblibLauncher"
+    target: str = "hydra_plugins.hydra_joblib_launcher.joblib_launcher.JoblibLauncher"
     params: JobLibConf = JobLibConf()
 
 

--- a/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/config.py
+++ b/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/config.py
@@ -84,7 +84,7 @@ class NevergradConf:
 
 @dataclass
 class NevergradSweeperConf(ObjectConf):
-    cls: str = "hydra_plugins.hydra_nevergrad_sweeper.core.NevergradSweeper"
+    target: str = "hydra_plugins.hydra_nevergrad_sweeper.core.NevergradSweeper"
     params: NevergradConf = NevergradConf()
 
 

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
@@ -55,7 +55,7 @@ class RQConf:
 
 @dataclass
 class RQLauncherConf(ObjectConf):
-    cls: str = "hydra_plugins.hydra_rq_launcher.rq_launcher.RQLauncher"
+    target: str = "hydra_plugins.hydra_rq_launcher.rq_launcher.RQLauncher"
     params: RQConf = RQConf()
 
 

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
@@ -68,7 +68,7 @@ ConfigStore.instance().store(
     group="hydra/launcher",
     name="submitit_local",
     node=ObjectConf(
-        cls="hydra_plugins.hydra_submitit_launcher.submitit_launcher.LocalLauncher",
+        target="hydra_plugins.hydra_submitit_launcher.submitit_launcher.LocalLauncher",
         params=LocalParams(),
     ),
     provider="submitit_launcher",
@@ -79,7 +79,7 @@ ConfigStore.instance().store(
     group="hydra/launcher",
     name="submitit_slurm",
     node=ObjectConf(
-        cls="hydra_plugins.hydra_submitit_launcher.submitit_launcher.SlurmLauncher",
+        target="hydra_plugins.hydra_submitit_launcher.submitit_launcher.SlurmLauncher",
         params=SlurmParams(),
     ),
     provider="submitit_launcher",

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -358,7 +358,7 @@ def test_app_with_sweep_cfg__override_to_basic_launcher(
         assert task.job_ret.hydra_cfg is not None
         hydra_cfg = task.job_ret.hydra_cfg
         assert (
-            hydra_cfg.hydra.launcher.cls
+            hydra_cfg.hydra.launcher.target
             == "hydra._internal.core_plugins.basic_launcher.BasicLauncher"
         )
         assert len(task.job_ret.hydra_cfg.hydra.launcher.params) == 0

--- a/tests/test_internal_utils.py
+++ b/tests/test_internal_utils.py
@@ -1,0 +1,80 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import sys
+from typing import Any, Union
+
+import pytest
+from omegaconf import DictConfig, OmegaConf
+
+from hydra._internal import utils
+from hydra.types import ObjectConf
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "matrix,expected",
+    [
+        ([["a"]], [1]),
+        ([["a", "bb"]], [1, 2]),
+        ([["a", "bb"], ["aa", "b"]], [2, 2]),
+        ([["a"], ["aa", "b"]], [2, 1]),
+        ([["a", "aa"], ["bb"]], [2, 2]),
+        ([["a"]], [1]),
+        ([["a"]], [1]),
+        ([["a"]], [1]),
+    ],
+)
+def test_get_column_widths(matrix: Any, expected: Any) -> None:
+    assert utils.get_column_widths(matrix) == expected
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "config, expected, warning",
+    [
+        pytest.param(ObjectConf(target="foo"), "foo", False, id="ObjectConf:target"),
+        pytest.param(
+            OmegaConf.create({"cls": "foo"}), "foo", "cls", id="DictConfig:cls"
+        ),
+        pytest.param(
+            OmegaConf.create({"class": "foo"}), "foo", "class", id="DictConfig:class"
+        ),
+        pytest.param(
+            OmegaConf.create({"target": "foo"}), "foo", False, id="DictConfig:target",
+        ),
+        pytest.param(
+            OmegaConf.create({"cls": "foo", "target": "bar"}),
+            "bar",
+            False,
+            id="DictConfig:cls_target",
+        ),
+        pytest.param(
+            OmegaConf.create({"class": "foo", "target": "bar"}),
+            "bar",
+            "class",
+            id="DictConfig:class_target",
+        ),
+    ],
+)
+def test_get_class_name(
+    config: Union[ObjectConf, DictConfig], expected: Any, warning: Any, recwarn: Any
+) -> None:
+    assert utils._get_cls_name(config) == expected
+    if warning is not False:
+        deprecated = "is deprecated since Hydra 1.0 and will be removed in Hydra 1.1"
+        if isinstance(config, DictConfig):
+            exp = f"""Config key '{config._get_full_key(warning)}' {deprecated}.
+Use 'target' instead of '{warning}'."""
+        else:
+            exp = f"""
+ObjectConf field '{warning}' {deprecated}.
+Use 'target' instead of '{warning}'."""
+
+        assert len(recwarn) == 1
+        assert recwarn[0].category == UserWarning
+        assert recwarn[0].message.args[0] == exp
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7")  # type: ignore
+def test_cls() -> None:
+    with pytest.warns(expected_warning=UserWarning):
+        assert utils._get_cls_name(ObjectConf(cls="foo")) == "foo"
+    with pytest.warns(expected_warning=UserWarning):
+        assert utils._get_cls_name(ObjectConf(cls="foo", target="bar")) == "bar"

--- a/website/docs/experimental/hydra_compose.md
+++ b/website/docs/experimental/hydra_compose.md
@@ -85,7 +85,7 @@ def initialize(
     - Unit tests
     - Jupyter notebooks.
     :param config_path: path relative to the parent of the caller
-    :param job_name: the value for hydra.job.name (default is 'app')
+    :param job_name: the value for hydra.job.name (By default it is automatically detected based on the caller)
     :param strict: (Deprecated), will be removed in the next major version
     :param caller_stack_depth: stack depth of the caller, defaults to 1 (direct caller).
     """


### PR DESCRIPTION
ObjectConf cls field is conflicting with Python 3.6.
This PR is deprecating it for ObjectConf.target

In addition, fixes bugs reported in 650.

Closes #650 
Closes #721


