### PR TITLE
[RQ plugin] Compose sweep config in launch function

### DIFF
--- a/plugins/hydra_rq_launcher/setup.py
+++ b/plugins/hydra_rq_launcher/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     LONG_DESC = fh.read()
     setup(
         name="hydra-rq-launcher",
-        version="1.0.0rc1",
+        version="1.0.0rc2",
         author="Jan-Matthis Lueckmann, Omry Yadan",
         author_email="mail@jan-matthis.de, omry@fb.com",
         description="Redis Queue (RQ) Launcher for Hydra apps",


### PR DESCRIPTION
## Motivation

This PR moves composition of the sweep config from `execute_job` into `launch`: `launch` is executed on the submitting node while `execute_job` will be forked processes on the worker. This way, config files only need to be accessibly by the submitting node which will handle the composition.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes