### PR TITLE
[RQ launcher] Clear environment variable cache

### DIFF
--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
@@ -113,6 +113,12 @@ def launch(
             sweep_config.hydra.job.id = enqueue_keywords["job_id"]
             sweep_config.hydra.job.num = initial_job_idx + idx
 
+        # Remove environment variables from cache, e.g., used when resolving sweep_dir
+        config_cache = OmegaConf.get_cache(sweep_config)
+        if "env" in config_cache:
+            del config_cache["env"]
+            OmegaConf.set_cache(sweep_config, config_cache)
+
         job = queue.enqueue(
             execute_job,
             sweep_config=sweep_config,


### PR DESCRIPTION
# Motivation

This PR adds a condition to clear environment variables from the cache of the sweep config. If, say, `${env:HOME}` was part of `hydra.run.sweep.dir`, it would be set to the `$HOME` dir of the headnode otherwise, and resolution would fail on the worker.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Related Issues and PRs

https://github.com/facebookresearch/hydra/pull/741 changed the RQ launcher plugin such that it composes the sweep configuration in the launch function (e.g., on a headnode) rather than inside a worker process (e.g., remote).