### PR TITLE
[RQ launcher] Change defaults for timeouts

### DIFF
--- a/plugins/hydra_rq_launcher/example/config.yaml
+++ b/plugins/hydra_rq_launcher/example/config.yaml
@@ -1,4 +1,3 @@
----
 defaults:
   - hydra/launcher: rq
 

--- a/plugins/hydra_rq_launcher/example/hydra/launcher/rq.yaml
+++ b/plugins/hydra_rq_launcher/example/hydra/launcher/rq.yaml
@@ -1,0 +1,4 @@
+# @package _group_
+params:
+  enqueue:
+    job_timeout: '1d'

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
@@ -101,6 +101,12 @@ def launch(
         description = " ".join(filter_overrides(overrides))
 
         enqueue_keywords = OmegaConf.to_container(rq_cfg.enqueue, resolve=True)
+        if enqueue_keywords["job_timeout"] is None:
+            enqueue_keywords["job_timeout"] = -1
+        if enqueue_keywords["result_ttl"] is None:
+            enqueue_keywords["result_ttl"] = -1
+        if enqueue_keywords["failure_ttl"] is None:
+            enqueue_keywords["failure_ttl"] = -1
         if enqueue_keywords["job_id"] is None:
             enqueue_keywords["job_id"] = str(uuid.uuid4())
         if enqueue_keywords["description"] is None:

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
@@ -23,14 +23,14 @@ class RedisConf:
 
 @dataclass
 class EnqueueConf:
-    # maximum runtime of the job before it's interrupted and marked as failed (in sec)
-    job_timeout: Optional[int] = None
-    # maximum queued time before the job before is discarded (in sec)
-    ttl: Optional[int] = None
-    # how long successful jobs and their results are kept (in sec), default: 10 days
-    result_ttl: int = 864000
-    # specifies how long failed jobs are kept (in sec), default: 100 days
-    failure_ttl: int = 8640000
+    # maximum runtime of the job before it's killed (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
+    job_timeout: Optional[str] = None
+    # maximum queued time before the job before is discarded (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
+    ttl: Optional[str] = None
+    # how long successful jobs and their results are kept (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
+    result_ttl: Optional[str] = None
+    # specifies how long failed jobs are kept (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
+    failure_ttl: Optional[str] = None
     # place job at the front of the queue, instead of the back
     at_front: bool = False
     # job id, will be overidden automatically by a uuid unless specified explicitly

--- a/website/docs/plugins/rq_launcher.md
+++ b/website/docs/plugins/rq_launcher.md
@@ -39,10 +39,10 @@ The configuration packaged with the plugin is defined [here](https://github.com/
 cls: hydra_plugins.hydra_rq_launcher.rq_launcher.RQLauncher
 params:
   enqueue:
-    job_timeout: null                  # maximum runtime of the job before it's interrupted and marked as failed (in sec)
-    ttl: null                          # maximum queued time before the job before is discarded (in sec)
-    result_ttl: 864000                 # how long successful jobs and their results are kept (in sec), default: 10 days
-    failure_ttl: 8640000               # specifies how long failed jobs are kept (in sec), default: 100 days
+    job_timeout: null                  # maximum runtime of the job before it's killed (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
+    ttl: null                          # maximum queued time before the job before is discarded (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
+    result_ttl: null                   # how long successful jobs and their results are kept (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
+    failure_ttl: null                  # specifies how long failed jobs are kept (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
     at_front: false                    # place job at the front of the queue, instead of the back
     job_id: null                       # job id, will be overidden automatically by a uuid unless specified explicitly
     description: null                  # description, will be overidden automatically unless specified explicitly


### PR DESCRIPTION
## Motivation

This PR changes the default configuration of the RQ launcher plugin regarding timeouts: Python RQ has four different timeout values, referred to job_timeout (maximum runtime of a job), ttl (maximum wait time in queue), result_ttl (how long results are kept), and failure_ttl (how long failed jobs are kept). 

Having low timeout values might lead to unexpected behaviour, e.g. jobs being interrupted unexpectedly, or results disappearing. RQ only allows setting timeouts to `None` for a subset of timeout values. This PR changes the default config so that all timeout values have a very high (100 days) default applied. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes
