### PR TITLE
Docs missing a "self" in code example

### DIFF
--- a/website/docs/patterns/objects.md
+++ b/website/docs/patterns/objects.md
@@ -42,7 +42,7 @@ params:
 models.py
 ```python
 class Foo:
-  def __init__(x: int, y: int) -> None:
+  def __init__(self, x: int, y: int) -> None:
     self.x = x
     self.y = y
 


### PR DESCRIPTION
The `__init__` function needed a "self". I added it.

<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Correctness of docs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Common Python knowledge.

## Related Issues and PRs

None