### PR TITLE
Only copy timestamp to sweep config cache

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -322,8 +322,13 @@ class ConfigLoaderImpl(ConfigLoader):
         with open_dict(sweep_config):
             sweep_config.hydra.runtime.merge_with(master_config.hydra.runtime)
 
-        # Copy old config cache to ensure we get the same resolved values (for things like timestamps etc)
-        OmegaConf.copy_cache(from_config=master_config, to_config=sweep_config)
+        # Partial copy of master config cache, to ensure we get the same resolved values for timestamps
+        cache: Dict[str, Any] = defaultdict(dict, {})
+        cache_master_config = OmegaConf.get_cache(master_config)
+        for k in ["now"]:
+            if k in cache_master_config:
+                cache[k] = cache_master_config[k]
+        OmegaConf.set_cache(sweep_config, cache)
 
         return sweep_config
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -447,7 +447,7 @@ class TestConfigLoader:
         assert cfg == {"normal_yaml_config": True, "abc": None}
         assert len(recwarn) == 0
 
-    def test_sweep_config_cache(self, path: str) -> None:
+    def test_sweep_config_cache(self, path: str, monkeypatch: Any) -> None:
         setup_globals()
 
         config_loader = ConfigLoaderImpl(
@@ -476,8 +476,8 @@ class TestConfigLoader:
         sweep_cfg_cache = OmegaConf.get_cache(sweep_cfg)
         assert len(sweep_cfg_cache.keys()) == 1 and "now" in sweep_cfg_cache.keys()
         assert sweep_cfg_cache["now"] == master_cfg_cache["now"]
-        os.environ["HOME"] = "/another/home/dir/"
-        assert sweep_cfg.home == "/another/home/dir/"
+        monkeypatch.setenv("HOME", "/another/home/dir/")
+        assert sweep_cfg.home == os.getenv("HOME")
 
 
 @pytest.mark.parametrize(  # type:ignore


### PR DESCRIPTION
## Motivation

Changes `load_sweep_config` to only copy timestamp information from the master config cache. Previously, the full cache was copied, which could lead to unexpected resolution e.g. of environment variables on remote hosts.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes


## Test Plan

TBD


## Related Issues and PRs

https://github.com/facebookresearch/hydra/pull/744