### PR TITLE
Ignore .nox directory in .yamllint .

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -34,3 +34,4 @@ ignore: |
   **/multirun.yaml
   website
   .*
+  .nox


### PR DESCRIPTION
Fixes #773
This directory should already be ignored because of wildcard matching (".*"). This dir is not ignored on CI (for Mac/Win), leading to failed lint tests. I could not reproduce this locally on a Mac (Python 3.8 ).

<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Fixes #773

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

CI
## Related Issues and PRs


(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)

#773 #761 #766 