### PR TITLE
Add resolver for runtime python version

### DIFF
--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -154,9 +154,9 @@ def setup_globals() -> None:
 
     vi = sys.version_info
     version_dict = {
-        "major": f"{vi.major}",
-        "minor": f"{vi.major}.{vi.minor}",
-        "micro": f"{vi.major}.{vi.minor}.{vi.micro}",
+        "major": f"{vi[0]}",
+        "minor": f"{vi[0]}.{vi[1]}",
+        "micro": f"{vi[0]}.{vi[1]}.{vi[2]}",
     }
     register("python_version", lambda level="minor": version_dict.get(level))
 

--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -152,6 +152,14 @@ def setup_globals() -> None:
         lambda path: OmegaConf.select(cast(DictConfig, HydraConfig.get()), path),
     )
 
+    vi = sys.version_info
+    version_dict = {
+        "major": f"{vi.major}",
+        "minor": f"{vi.major}.{vi.minor}",
+        "micro": f"{vi.major}.{vi.minor}.{vi.micro}",
+    }
+    register("python_version", lambda level="minor": version_dict.get(level))
+
 
 @dataclass
 class JobReturn:

--- a/hydra/extra/pytest_plugin.py
+++ b/hydra/extra/pytest_plugin.py
@@ -3,13 +3,28 @@
 __version__ = "1.0.0rc1"
 import copy
 from pathlib import Path
-from typing import Callable, List, Optional
+from typing import Any, Callable, List, Optional
 
 import pytest
+from omegaconf.basecontainer import BaseContainer
 
 from hydra.core.singleton import Singleton
 from hydra.test_utils.test_utils import SweepTaskFunction, TaskTestFunction
 from hydra.types import TaskFunction
+
+
+@pytest.fixture(scope="function")  # type: ignore
+def restore_resolvers() -> Any:
+    """
+    A fixture to restore singletons state after this the function.
+    This is useful for functions that are making a one-off change to singlestons that should not effect
+    other tests
+
+    TODO this was copied from OmegaConf. Remove this when OmegaConf introduces a pytest plugin.
+    """
+    state = copy.deepcopy(BaseContainer._resolvers)
+    yield
+    BaseContainer._resolvers = state
 
 
 @pytest.fixture(scope="function")  # type: ignore

--- a/hydra/extra/pytest_plugin.py
+++ b/hydra/extra/pytest_plugin.py
@@ -3,20 +3,14 @@
 __version__ = "1.0.0rc1"
 import copy
 from pathlib import Path
-from typing import Any, Callable, List, Optional
+from typing import Callable, List, Optional
 
 import pytest
-from omegaconf import OmegaConf
+from omegaconf.basecontainer import BaseContainer
 
 from hydra.core.singleton import Singleton
 from hydra.test_utils.test_utils import SweepTaskFunction, TaskTestFunction
 from hydra.types import TaskFunction
-
-
-@pytest.fixture(scope="function")  # type: ignore
-def clear_resolvers() -> Any:
-    yield
-    OmegaConf.clear_resolvers()
 
 
 @pytest.fixture(scope="function")  # type: ignore
@@ -25,8 +19,10 @@ def hydra_restore_singletons() -> None:
     Restore singletons state after the function returns
     """
     state = copy.deepcopy(Singleton.get_state())
+    resolvers = copy.deepcopy(BaseContainer._resolvers)
     yield
     Singleton.set_state(state)
+    BaseContainer._resolvers = resolvers
 
 
 @pytest.fixture(scope="function")  # type: ignore

--- a/hydra/extra/pytest_plugin.py
+++ b/hydra/extra/pytest_plugin.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Callable, List, Optional
 
 import pytest
-from omegaconf.basecontainer import BaseContainer
+from omegaconf import OmegaConf
 
 from hydra.core.singleton import Singleton
 from hydra.test_utils.test_utils import SweepTaskFunction, TaskTestFunction
@@ -14,17 +14,9 @@ from hydra.types import TaskFunction
 
 
 @pytest.fixture(scope="function")  # type: ignore
-def restore_resolvers() -> Any:
-    """
-    A fixture to restore singletons state after this the function.
-    This is useful for functions that are making a one-off change to singlestons that should not effect
-    other tests
-
-    TODO this was copied from OmegaConf. Remove this when OmegaConf introduces a pytest plugin.
-    """
-    state = copy.deepcopy(BaseContainer._resolvers)
+def clear_resolvers() -> Any:
     yield
-    BaseContainer._resolvers = state
+    OmegaConf.clear_resolvers()
 
 
 @pytest.fixture(scope="function")  # type: ignore

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -443,7 +443,9 @@ class TestConfigLoader:
         assert cfg == {"normal_yaml_config": True, "abc": None}
         assert len(recwarn) == 0
 
-    def test_sweep_config_cache(self, path: str, monkeypatch: Any) -> None:
+    def test_sweep_config_cache(
+        self, hydra_restore_singletons: Any, path: str, monkeypatch: Any
+    ) -> None:
         setup_globals()
 
         config_loader = ConfigLoaderImpl(

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -28,15 +28,14 @@ def test_accessing_hydra_config(hydra_restore_singletons: Any) -> Any:
     assert cfg.config_name == "accessing_hydra_config"
 
 
-def test_py_version_resolver(hydra_restore_singletons: Any, monkeypatch: Any) -> Any:
+def test_py_version_resolver(
+    hydra_restore_singletons: Any, monkeypatch: Any, restore_resolvers: Any
+) -> Any:
     Version = namedtuple("Version", "major minor micro")
-    with monkeypatch.context() as m:
-        m.setattr(sys, "version_info", Version(3, 7, 2))
-        OmegaConf.clear_resolvers()
-        utils.setup_globals()
-        assert OmegaConf.create({"key": "${python_version:}"}).key == "3.7"
-        assert OmegaConf.create({"key": "${python_version:major}"}).key == "3"
-        assert OmegaConf.create({"key": "${python_version:minor}"}).key == "3.7"
-        assert OmegaConf.create({"key": "${python_version:micro}"}).key == "3.7.2"
-    # reset OmegaConf resolver with no patching
+    monkeypatch.setattr(sys, "version_info", Version(3, 7, 2))
+    OmegaConf.clear_resolvers()
     utils.setup_globals()
+    assert OmegaConf.create({"key": "${python_version:}"}).key == "3.7"
+    assert OmegaConf.create({"key": "${python_version:major}"}).key == "3"
+    assert OmegaConf.create({"key": "${python_version:minor}"}).key == "3.7"
+    assert OmegaConf.create({"key": "${python_version:micro}"}).key == "3.7.2"

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -13,7 +13,7 @@ from hydra.types import RunMode
 
 
 def test_accessing_hydra_config(
-    hydra_restore_singletons: Any, restore_resolvers: Any
+    hydra_restore_singletons: Any, clear_resolvers: Any
 ) -> Any:
     utils.setup_globals()
 
@@ -31,7 +31,7 @@ def test_accessing_hydra_config(
 
 
 def test_py_version_resolver(
-    hydra_restore_singletons: Any, monkeypatch: Any, restore_resolvers: Any
+    hydra_restore_singletons: Any, monkeypatch: Any, clear_resolvers: Any
 ) -> Any:
     Version = namedtuple("Version", "major minor micro")
     monkeypatch.setattr(sys, "version_info", Version(3, 7, 2))

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -1,6 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import sys
-from collections import namedtuple
 from typing import Any
 
 from omegaconf import OmegaConf, open_dict
@@ -29,8 +28,7 @@ def test_accessing_hydra_config(hydra_restore_singletons: Any) -> Any:
 
 
 def test_py_version_resolver(hydra_restore_singletons: Any, monkeypatch: Any) -> Any:
-    Version = namedtuple("Version", "major minor micro")
-    monkeypatch.setattr(sys, "version_info", Version(3, 7, 2))
+    monkeypatch.setattr(sys, "version_info", (3, 7, 2))
     utils.setup_globals()
     assert OmegaConf.create({"key": "${python_version:}"}).key == "3.7"
     assert OmegaConf.create({"key": "${python_version:major}"}).key == "3"

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -12,7 +12,9 @@ from hydra.core.hydra_config import HydraConfig
 from hydra.types import RunMode
 
 
-def test_accessing_hydra_config(hydra_restore_singletons: Any) -> Any:
+def test_accessing_hydra_config(
+    hydra_restore_singletons: Any, restore_resolvers: Any
+) -> Any:
     utils.setup_globals()
 
     config_loader = ConfigLoaderImpl(
@@ -33,7 +35,6 @@ def test_py_version_resolver(
 ) -> Any:
     Version = namedtuple("Version", "major minor micro")
     monkeypatch.setattr(sys, "version_info", Version(3, 7, 2))
-    OmegaConf.clear_resolvers()
     utils.setup_globals()
     assert OmegaConf.create({"key": "${python_version:}"}).key == "3.7"
     assert OmegaConf.create({"key": "${python_version:major}"}).key == "3"

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -12,9 +12,7 @@ from hydra.core.hydra_config import HydraConfig
 from hydra.types import RunMode
 
 
-def test_accessing_hydra_config(
-    hydra_restore_singletons: Any, clear_resolvers: Any
-) -> Any:
+def test_accessing_hydra_config(hydra_restore_singletons: Any) -> Any:
     utils.setup_globals()
 
     config_loader = ConfigLoaderImpl(
@@ -30,9 +28,7 @@ def test_accessing_hydra_config(
     assert cfg.config_name == "accessing_hydra_config"
 
 
-def test_py_version_resolver(
-    hydra_restore_singletons: Any, monkeypatch: Any, clear_resolvers: Any
-) -> Any:
+def test_py_version_resolver(hydra_restore_singletons: Any, monkeypatch: Any) -> Any:
     Version = namedtuple("Version", "major minor micro")
     monkeypatch.setattr(sys, "version_info", Version(3, 7, 2))
     utils.setup_globals()


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

(I'm breaking all the hydra core related changes introduced by Ray launcher into smaller PRs)

With this change we can detect runtime python version, this is helpful for configuring hydra when version info is important.

for example when launching on remote machines we will need ```cloudpickle``` which only works when pickle and unpickle with the same python version.

Testing
```
>>> import sys
>>> import omegaconf
>>> vi = sys.version_info
>>> version_dict = {
...         "major": vi.major,
...         "minor": f"{vi.major}.{vi.minor}",
...         "micro": f"{vi.major}.{vi.minor}.{vi.micro}",
...     }
>>> f=lambda level="minor": version_dict.get(level)
>>> from omegaconf import OmegaConf
>>> c = OmegaConf.create({'key': '${python_version:}'}).key
>>> c
'3.8'
>>> c = OmegaConf.create({'key': '${python_version:major}'}).key
>>> c
3
>>> c = OmegaConf.create({'key': '${python_version:minor}'}).key
>>> c
'3.8'
>>> c = OmegaConf.create({'key': '${python_version:micro}'}).key
>>> c
'3.8.2'
>>> 

```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
