### PR TITLE
Document Hydra default OmegaConf resolver

### DIFF
--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -145,7 +145,7 @@ def setup_globals() -> None:
             # calling it again in no_workers mode will throw. safe to ignore.
             pass
 
-    # please add documentation when you add resolver
+    # please add documentation when you add a new resolver
     register("now", lambda pattern: strftime(pattern, localtime()))
     register(
         "hydra",

--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -145,6 +145,7 @@ def setup_globals() -> None:
             # calling it again in no_workers mode will throw. safe to ignore.
             pass
 
+    # please add documentation when you add resolver
     register("now", lambda pattern: strftime(pattern, localtime()))
     register(
         "hydra",

--- a/website/docs/configure_hydra/Intro.md
+++ b/website/docs/configure_hydra/Intro.md
@@ -68,13 +68,22 @@ You can see the full Hydra config using `--cfg hydra`:
 - *hydra.runtime.version*: Hydra's version
 - *hydra.runtime.cwd*: Original working directory the app was executed from
 
-## Hydra default OmegaConf resolvers
-OmegaConf supports [interpolations](https://omegaconf.readthedocs.io/en/latest/usage.html#variable-interpolation) via [resolvers](https://omegaconf.readthedocs.io/en/latest/usage.html#custom-interpolations). Hydra supports the following resolvers by default.
-```yaml title="resolver.yaml"
-current_date: ${now:%Y-%m-%d}                              # call time.localtime() with pattern "%Y-%m-%d", eg: 2020-07-15
-current_time: ${now:%H-%M-%S}                              # call time.localtime() with pattern "%H-%M-%S", eg: 17-04-11
-job_working_dir: ${hydra:runtime.cwd}                      # get hydra config "runtime.cwd"
-job_name: ${hydra:job.name}                                # get hydra config "job.name"
+## Hydra resolvers
+
+Hydra supports [several OmegaConf resolvers](https://github.com/facebookresearch/hydra/blob/master/hydra/core/utils.py) by default.
+
+### `now`
+Creates a string representing the current time using [strftime](https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior).
+For example, for formatting the time you can use something like`${now:%H-%M-%S}`.
+
+### `hydra`
+Returns a string from Hydra config.q
+For example, use `${hydra:job.name}` to get the Hydra job name.
+
+### `python_version`
+Return a string representing the runtime python version by calling `sys.version_info`.
+You can pass in a parameter to specify level of version returned. By default, the resolver returns the major and minor version.
+```yaml
 python_version: ${python_version:}                         # runtime python version, eg: 3.8
 major_version: ${python_version:major}                     # runtime python major version, eg: 3
 minor_version: ${python_version:minor}                     # runtime python version in the format major.minor, eg: 3.8

--- a/website/docs/configure_hydra/Intro.md
+++ b/website/docs/configure_hydra/Intro.md
@@ -77,7 +77,7 @@ Creates a string representing the current time using [strftime](https://docs.pyt
 For example, for formatting the time you can use something like`${now:%H-%M-%S}`.
 
 ### `hydra`
-Returns a string from Hydra config.q
+Interpolates into the `hydra` config node.
 For example, use `${hydra:job.name}` to get the Hydra job name.
 
 ### `python_version`

--- a/website/docs/configure_hydra/Intro.md
+++ b/website/docs/configure_hydra/Intro.md
@@ -68,3 +68,17 @@ You can see the full Hydra config using `--cfg hydra`:
 - *hydra.runtime.version*: Hydra's version
 - *hydra.runtime.cwd*: Original working directory the app was executed from
 
+## Hydra default OmegaConf resolvers
+OmegaConf supports [interpolations](https://omegaconf.readthedocs.io/en/latest/usage.html#variable-interpolation) via [resolvers](https://omegaconf.readthedocs.io/en/latest/usage.html#custom-interpolations). Hydra supports the following resolvers by default.
+```yaml title="resolver.yaml"
+current_date: ${now:%Y-%m-%d}                              # call time.localtime() with pattern "%Y-%m-%d", eg: 2020-07-15
+current_time: ${now:%H-%M-%S}                              # call time.localtime() with pattern "%H-%M-%S", eg: 17-04-11
+job_working_dir: ${hydra:runtime.cwd}                      # get hydra config "runtime.cwd"
+job_name: ${hydra:job.name}                                # get hydra config "job.name"
+python_version: ${python_version:}                         # runtime python version, eg: 3.8
+major_version: ${python_version:major}                     # runtime python major version, eg: 3
+minor_version: ${python_version:minor}                     # runtime python version in the format major.minor, eg: 3.8
+micro_version: ${python_version:micro}                     # runtime python version in the format major.minor.micro, eg: 3.8.2
+```
+
+You can learn more about OmegaConf <a class="external" href="https://omegaconf.readthedocs.io/en/latest/usage.html#access-and-manipulation" target="_blank">here</a>.


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Document all the hydra default omegaconf resolver 
https://github.com/facebookresearch/hydra/blob/123d7f044247330eee32dc65eb954be2b5834c17/hydra/core/utils.py#L140-L152

This is probably not the most sustainable way. I'm wondering if its possible to auto-generate doc here (when new resolvers are added.)?

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
