### PR TITLE
Sanitize error stack frames by default

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -141,6 +141,25 @@ class ConfigLoaderImpl(ConfigLoader):
         strict: Optional[bool] = None,
         from_shell: bool = True,
     ) -> DictConfig:
+        try:
+            return self._load_configuration(
+                config_name=config_name,
+                overrides=overrides,
+                run_mode=run_mode,
+                strict=strict,
+                from_shell=from_shell,
+            )
+        except OmegaConfBaseException as e:
+            raise HydraException() from e
+
+    def _load_configuration(
+        self,
+        config_name: Optional[str],
+        overrides: List[str],
+        run_mode: RunMode,
+        strict: Optional[bool] = None,
+        from_shell: bool = True,
+    ) -> DictConfig:
         if config_name is not None and not self.repository.config_exists(config_name):
             self.missing_config_error(
                 config_name=config_name,

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -6,8 +6,10 @@ import logging.config
 import os
 import sys
 import warnings
+from dataclasses import dataclass
 from os.path import dirname, join, normpath, realpath
-from traceback import print_exc
+from traceback import print_exc, print_exception
+from types import FrameType
 from typing import (
     Any,
     Callable,
@@ -21,7 +23,6 @@ from typing import (
 )
 
 from omegaconf import DictConfig, OmegaConf, read_write
-from omegaconf.errors import OmegaConfBaseException
 
 from hydra._internal.config_search_path_impl import ConfigSearchPathImpl
 from hydra.core.config_search_path import ConfigSearchPath
@@ -195,16 +196,74 @@ def create_config_search_path(search_path_dir: Optional[str]) -> ConfigSearchPat
 def run_and_report(func: Any) -> Any:
     try:
         return func()
-    except (HydraException, OmegaConfBaseException) as ex:
+    except Exception as ex:
         if "HYDRA_FULL_ERROR" in os.environ and os.environ["HYDRA_FULL_ERROR"] == "1":
             print_exc()
         else:
-            sys.stderr.write(str(ex) + "\n")
-            if ex.__cause__ is not None:
-                sys.stderr.write(str(ex.__cause__))
+            if isinstance(ex, HydraException):
+                sys.stderr.write(str(ex) + os.linesep)
+                if ex.__cause__ is not None:
+                    sys.stderr.write(str(ex.__cause__) + os.linesep)
 
+                sys.stderr.write(os.linesep)
+            else:
+                # Custom printing that strips the Hydra related stack frames from the top
+                # And any omegaconf frames from the bottom.
+                # It is possible to add additional libraries to sanitize from the bottom later,
+                # maybe even make it configurable.
+                tb: Any = ex.__traceback__
+                search_max = 10
+                # strip Hydra frames from start of stack
+                # will strip until it hits run_job()
+                while search_max > 0:
+                    frame = tb.tb_frame
+                    tb = tb.tb_next
+                    search_max = search_max - 1
+                    if inspect.getframeinfo(frame).function == "run_job":
+                        break
+                if search_max == 0:
+                    sys.stderr.write("WARNING, failed to detect relevant stack start\n")
+                    tb = ex.__traceback__
+
+                # strip OmegaConf frames from bottom of stack
+                end = tb
+                num_frames = 0
+                while end is not None:
+                    frame = end.tb_frame
+                    mdl = inspect.getmodule(frame)
+                    assert mdl is not None
+                    name = mdl.__name__
+                    if name.startswith("omegaconf."):
+                        break
+                    end = end.tb_next
+                    num_frames = num_frames + 1
+
+                @dataclass
+                class FakeTracebackType:
+                    tb_next: Any = None  # Optional[FakeTracebackType]
+                    tb_frame: Optional[FrameType] = None
+                    tb_lasti: Optional[int] = None
+                    tb_lineno: Optional[int] = None
+
+                iter_tb = tb
+                final_tb = FakeTracebackType()
+                cur = final_tb
+                added = 0
+                while True:
+                    cur.tb_lasti = iter_tb.tb_lasti
+                    cur.tb_lineno = iter_tb.tb_lineno
+                    cur.tb_frame = iter_tb.tb_frame
+
+                    if added == num_frames - 1:
+                        break
+                    added = added + 1
+                    cur.tb_next = FakeTracebackType()
+                    cur = cur.tb_next
+                    iter_tb = iter_tb.tb_next
+
+                print_exception(etype=None, value=ex, tb=final_tb)  # type: ignore
             sys.stderr.write(
-                "\nSet the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.\n"
+                "Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.\n"
             )
         sys.exit(1)
 

--- a/hydra/grammar/gen/.gitignore
+++ b/hydra/grammar/gen/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+

--- a/news/646.feature
+++ b/news/646.feature
@@ -1,0 +1,1 @@
+Sanitize exception messages by default, showing only interesting stack frames

--- a/tests/test_apps/app_with_runtime_config_error/config.yaml
+++ b/tests/test_apps/app_with_runtime_config_error/config.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+dataset:
+  name: imagenet
+  path: /datasets/imagenet

--- a/tests/test_apps/app_with_runtime_config_error/my_app.py
+++ b/tests/test_apps/app_with_runtime_config_error/my_app.py
@@ -1,0 +1,17 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from omegaconf import DictConfig
+
+import hydra
+
+
+def foo(cfg: DictConfig) -> None:
+    cfg.foo = "bar"  # does not exist in the config
+
+
+@hydra.main(config_name="config")
+def my_app(cfg: DictConfig) -> None:
+    foo(cfg)
+
+
+if __name__ == "__main__":
+    my_app()

--- a/tests/test_examples/test_patterns.py
+++ b/tests/test_examples/test_patterns.py
@@ -106,6 +106,5 @@ def test_frozen(tmpdir: Any) -> None:
         "data_bits=10",
     ]
 
-    expected = """Error merging override data_bits=10\nCannot change read-only config container"""
     err = run_with_error(cmd)
-    assert re.search(re.escape(expected), err) is not None
+    assert re.search(re.escape("Error merging override data_bits=10"), err) is not None


### PR DESCRIPTION
Improve printed stack trace to contain only interesting stack frames by default.
stripping hydra frames from the start and OmegaConf frames from the bottom.

closes #647 