### PR TITLE
docs bug: hydra.job.num listed twice

### DIFF
--- a/website/docs/configure_hydra/workdir.md
+++ b/website/docs/configure_hydra/workdir.md
@@ -16,7 +16,7 @@ Sweep sub directory contains the the job number and the override parameters for 
 ```yaml
 hydra:
   sweep:
-    subdir: ${hydra.job.num}_${hydra.job.num}_${hydra.job.override_dirname}
+    subdir: ${hydra.job.num}_${hydra.job.override_dirname}
 ```
 
 Run output directory grouped by job name:


### PR DESCRIPTION
## Motivation

Was looking up directory customization in docs and saw this small typo. I couldn't think of any reason why you would want this listed twice, but it had me confused for a moment. Fired off a quick PR.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

No tests needed.



