### PR TITLE
Expanding instructions for list CLI override

### DIFF
--- a/website/docs/advanced/command_line_syntax.md
+++ b/website/docs/advanced/command_line_syntax.md
@@ -134,7 +134,7 @@ Constants (null, true, false, inf, nan) are case insensitive.
 foo=[1,2,3]
 nested=[a,[b,[c]]]
 ```
-**IMPORTANT** Always single-quote overrides that contains lists in the shell.
+**IMPORTANT** Always single-quote overrides that contains lists in the shell.  Also, note the *no spaces* between list elements, otherwise you might get a `hydra.errors.OverrideParseException: no viable alternative at input` error.
 
 ### Dictionaries
 ```python


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

I just spent a bunch of time debugging a command line override that involved nested lists (something like `param='[["a", 1, 2], ["b", 2, 3]]'`, which gave me a `hydra.errors.OverrideParseException: no viable alternative at input` error until I removed the space between the 2 sublists. So this tip might help future users.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan
Not needed

