### PR TITLE
Fixing CI failures due to a deprecation warning in nbval

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -388,7 +388,8 @@ def test_jupyter_notebooks(session):
             f"Not testing Jupyter notebook on Python {session.python}, supports [{','.join(versions)}]"
         )
     # pyzmq 19.0.1 has installation issues on Windows
-    session.install("jupyter", "nbval", "pyzmq==19.0.0")
+    # pytest 6.0 makes deprecation warnings wail on errors, breaking nbval due to a deprecated API usage
+    session.install("jupyter", "nbval", "pyzmq==19.0.0", "pytest==5.4.3")
     install_hydra(session, ["pip", "install", "-e"])
     args = pytest_args(
         "--nbval", "examples/jupyter_notebooks/compose_configs_in_notebook.ipynb",

--- a/tests/test_internal_utils.py
+++ b/tests/test_internal_utils.py
@@ -4,7 +4,7 @@ import sys
 from typing import Any, Union
 
 import pytest
-from _pytest.python_api import RaisesContext  # type: ignore
+from _pytest.python_api import RaisesContext
 from omegaconf import DictConfig, OmegaConf
 
 from hydra._internal import utils


### PR DESCRIPTION
pytest 6.0 made deprecation warnings fail by default, and nbval have had some deprecation warnings that went unfixed for months now.

This pins pytest to 5.4.3 when testing the Jupyter notebook.

https://github.com/computationalmodelling/nbval/issues/139