### PR TITLE
Update Basic Tutorial about missing @hydra.main return

### DIFF
--- a/website/versioned_docs/version-0.11/tutorial/1_simple_cli_app.md
+++ b/website/versioned_docs/version-0.11/tutorial/1_simple_cli_app.md
@@ -24,6 +24,7 @@ if __name__ == "__main__":
 The `cfg` is an <a class="external" href="https://omegaconf.readthedocs.io/en/latest/usage.html#access-and-manipulation" target="_blank">OmegaConf</a>
 object that holds the configuration for your function.
 You don't need a deep understanding of OmegaConf for this tutorial.
+Note that hydra does not preserve the return value of `@hydra.main()` functions for the sake of enabling more complex features, such as [multirun](https://hydra.cc/docs/tutorial/multi-run). 
 
 We can pass arbitrary command line arguments from which Hydra creates a hierarchical configuration object:
 ```yaml


### PR DESCRIPTION
Add info about lack of return value for @hydra.main due to ambiguity to the basics tutorial. See https://github.com/facebookresearch/hydra/issues/769

<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
