### PR TITLE
Remove "$" from some installation related commands.

### DIFF
--- a/website/docs/plugins/ax_sweeper.md
+++ b/website/docs/plugins/ax_sweeper.md
@@ -15,7 +15,7 @@ This plugin provides a mechanism for Hydra applications to use the [Adaptive Exp
 ### Installation
 This plugin requires Hydra 1.0 (Release candidate)
 ```commandline
-$ pip install hydra-ax-sweeper --pre
+pip install hydra-ax-sweeper --pre
 ```
 
 ### Usage

--- a/website/docs/plugins/joblib_launcher.md
+++ b/website/docs/plugins/joblib_launcher.md
@@ -15,7 +15,7 @@ The Joblib Launcher plugin provides a launcher for parallel tasks based on [`Job
 ### Installation
 This plugin requires Hydra 1.0 (Release candidate)
 ```commandline
-$ pip install hydra-joblib-launcher --pre
+pip install hydra-joblib-launcher --pre
 ```
 
 ### Usage

--- a/website/docs/plugins/nevergrad_sweeper.md
+++ b/website/docs/plugins/nevergrad_sweeper.md
@@ -17,7 +17,7 @@ sidebar_label: Nevergrad Sweeper plugin
 ### Installation
 This plugin requires Hydra 1.0 (Release candidate)
 ```commandline
-$ pip install hydra-nevergrad-sweeper --pre
+pip install hydra-nevergrad-sweeper --pre
 ```
 
 ### Usage

--- a/website/docs/plugins/rq_launcher.md
+++ b/website/docs/plugins/rq_launcher.md
@@ -18,7 +18,7 @@ RQ launcher allows parallelizing across multiple nodes and scheduling jobs in qu
 ### Installation
 This plugin requires Hydra 1.0 (Release candidate)
 ```commandline
-$ pip install hydra-rq-launcher --pre
+pip install hydra-rq-launcher --pre
 ```
 Usage of this plugin requires a [Redis server](https://redis.io/topics/quickstart).
 
@@ -71,7 +71,7 @@ export REDIS_PASSWORD=""
 Assuming configured environment variables, workers connecting to the Redis server can be launched using:
 
 ```commandline
-$ rq worker --url redis://:$REDIS_PASSWORD@$REDIS_HOST:$REDIS_PORT/$REDIS_DB
+rq worker --url redis://:$REDIS_PASSWORD@$REDIS_HOST:$REDIS_PORT/$REDIS_DB
 ```
 
 An [example application](https://github.com/facebookresearch/hydra/tree/master/plugins/hydra_rq_launcher/example) using this launcher is provided in the plugin repository.

--- a/website/docs/plugins/submitit_launcher.md
+++ b/website/docs/plugins/submitit_launcher.md
@@ -16,7 +16,7 @@ The Submitit Launcher plugin provides a [SLURM ](https://slurm.schedmd.com/docum
 ### Installation
 This plugin requires Hydra 1.0 (Release candidate)
 ```commandline
-$ pip install hydra-submitit-launcher --pre
+pip install hydra-submitit-launcher --pre
 ```
 
 


### PR DESCRIPTION
Now the commands can be copied using the "copy" button. Fixes #846.

<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

The installation commands can be copied using the "copy" button. Fixes #846.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Tested locally by building the website.

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)

#846 
