### PR TITLE
Fix bug with bash autocompletion for the users who has `.` in their PATH environment variable

### DIFF
--- a/hydra/_internal/core_plugins/bash_completion.py
+++ b/hydra/_internal/core_plugins/bash_completion.py
@@ -32,7 +32,7 @@ class BashCompletion(CompletionPlugin):
         helper="${words[0]}"
         true
     fi
-    
+
     EXECUTABLE=($(command -v $helper))
     if [ "$HYDRA_COMP_DEBUG" == "1" ]; then
         printf "\\n"

--- a/hydra/_internal/core_plugins/bash_completion.py
+++ b/hydra/_internal/core_plugins/bash_completion.py
@@ -32,8 +32,17 @@ class BashCompletion(CompletionPlugin):
         helper="${words[0]}"
         true
     fi
-
-    if ! [ -x "$(command -v $helper)" ]; then
+    
+    EXECUTABLE=($(command -v $helper))
+    if [ "$HYDRA_COMP_DEBUG" == "1" ]; then
+        printf "\\n"
+        printf "helper='$helper'\\n"
+        printf "EXECUTABLE='$EXECUTABLE'\\n"
+        printf "EXECUTABLE_FIRST='${EXECUTABLE[0]}'\\n"
+        printf "EXECUTABLE AS ARRAY:\\n"
+        printf "\\t%s\\n" ${EXECUTABLE[@]}
+    fi
+    if ! [ -x "${EXECUTABLE[0]}" ]; then
         false
     fi
 

--- a/hydra/_internal/core_plugins/bash_completion.py
+++ b/hydra/_internal/core_plugins/bash_completion.py
@@ -35,8 +35,7 @@ class BashCompletion(CompletionPlugin):
 
     EXECUTABLE=($(command -v $helper))
     if [ "$HYDRA_COMP_DEBUG" == "1" ]; then
-        printf "\\n"
-        printf "helper='$helper'\\n"
+        printf "\\nhelper='$helper'\\n"
         printf "EXECUTABLE='$EXECUTABLE'\\n"
         printf "EXECUTABLE_FIRST='${EXECUTABLE[0]}'\\n"
         printf "EXECUTABLE AS ARRAY:\\n"

--- a/hydra/_internal/core_plugins/bash_completion.py
+++ b/hydra/_internal/core_plugins/bash_completion.py
@@ -35,11 +35,7 @@ class BashCompletion(CompletionPlugin):
 
     EXECUTABLE=($(command -v $helper))
     if [ "$HYDRA_COMP_DEBUG" == "1" ]; then
-        printf "\\nhelper='$helper'\\n"
-        printf "EXECUTABLE='$EXECUTABLE'\\n"
         printf "EXECUTABLE_FIRST='${EXECUTABLE[0]}'\\n"
-        printf "EXECUTABLE AS ARRAY:\\n"
-        printf "\\t%s\\n" ${EXECUTABLE[@]}
     fi
     if ! [ -x "${EXECUTABLE[0]}" ]; then
         false

--- a/news/868.bugfix
+++ b/news/868.bugfix
@@ -1,1 +1,1 @@
-Fixes bug with bash autocompletion for the users who has `.` in their PATH environment variable
+Fix bug with bash autocompletion for the users who has `.` in their PATH environment variable

--- a/news/868.bugfix
+++ b/news/868.bugfix
@@ -1,0 +1,1 @@
+Fixes bug with bash autocompletion for the users who has `.` in their PATH environment variable

--- a/tests/scripts/test_bash_dot_in_path.bash
+++ b/tests/scripts/test_bash_dot_in_path.bash
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Navigate to app with minimal configuration
+cd tests/test_apps/app_with_cfg/
+
+# Locate python
+PYTHON=$(command -v python)
+
+# Setup hydra bash completion
+eval "$(python my_app.py -sc install=bash)"
+
+# Setup debugging
+export HYDRA_COMP_DEBUG=1
+export PATH=$PATH:.
+
+# Do actual test
+test=$(COMP_LINE='python my_app.py' hydra_bash_completion |\
+    grep EXECUTABLE_FIRST |\
+    awk '{split($0,a,"=");b=substr(a[2],2,length(a[2])-2);print b}')
+
+if [ $test == $PYTHON ]; then
+    echo TRUE
+else
+    echo FALSE
+fi

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -53,46 +53,48 @@ def create_config_loader() -> ConfigLoaderImpl:
         )
     )
 
+
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-def test_bash_completion_with_dot_in_path() -> None:
-    process = subprocess.Popen(
-        textwrap.dedent(
-            """
-        bash <<- 'HEREDOC'
-        # Navigate to app with minimal configuration
-        cd tests/test_apps/app_with_cfg/
+class TestDotInPathCompletion:
+    def test_bash_completion_with_dot_in_path(self) -> None:
+        process = subprocess.Popen(
+            textwrap.dedent(
+                """
+                bash <<- 'HEREDOC'
+                # Navigate to app with minimal configuration
+                cd tests/test_apps/app_with_cfg/
 
-        # Locate python
-        PYTHON=$(command -v python)
+                # Locate python
+                PYTHON=$(command -v python)
 
-        # Setup hydra bash completion
-        eval "$(python my_app.py -sc install=bash)"
+                # Setup hydra bash completion
+                eval "$(python my_app.py -sc install=bash)"
 
-        # Setup debugging
-        export HYDRA_COMP_DEBUG=1
-        export PATH=$PATH:.
+                # Setup debugging
+                export HYDRA_COMP_DEBUG=1
+                export PATH=$PATH:.
 
-        # Do actual test
-        test=$(COMP_LINE='python my_app.py' hydra_bash_completion |\
-               grep EXECUTABLE_FIRST |\
-               awk '{split($0,a,"=");b=substr(a[2],2,length(a[2])-2);print b}')
+                # Do actual test
+                test=$(COMP_LINE='python my_app.py' hydra_bash_completion |\
+                    grep EXECUTABLE_FIRST |\
+                    awk '{split($0,a,"=");b=substr(a[2],2,length(a[2])-2);print b}')
 
-        if [ $test == $PYTHON ]; then
-            echo TRUE
-        else
-            echo FALSE
-        fi
-        HEREDOC
-        """
-        ),
-        shell=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    stdout, stderr = process.communicate()
-    assert stderr == b""
-    assert stdout == b"TRUE\n"
-    return
+                if [ $test == $PYTHON ]; then
+                    echo TRUE
+                else
+                    echo FALSE
+                fi
+                HEREDOC
+                """
+            ),
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout, stderr = process.communicate()
+        assert stderr == b""
+        assert stdout == b"TRUE\n"
+        return
 
 
 base_completion_list: List[str] = [

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -58,30 +58,32 @@ def test_bash_completion_with_dot_in_path() -> None:
     process = subprocess.Popen(
         textwrap.dedent(
             """
-		bash <<- 'HEREDOC'
-		# Navigate to app with minimal configuration
-		cd tests/test_apps/app_with_cfg/
+        bash <<- 'HEREDOC'
+        # Navigate to app with minimal configuration
+        cd tests/test_apps/app_with_cfg/
 
-		# Locate python
-		PYTHON=$(command -v python)
+        # Locate python
+        PYTHON=$(command -v python)
 
-		# Setup hydra bash completion
-		eval "$(python my_app.py -sc install=bash)"
+        # Setup hydra bash completion
+        eval "$(python my_app.py -sc install=bash)"
 
-		# Setup debugging
-		export HYDRA_COMP_DEBUG=1
-		export PATH=$PATH:.
+        # Setup debugging
+        export HYDRA_COMP_DEBUG=1
+        export PATH=$PATH:.
 
-		# Do actual test
-		test=$(COMP_LINE='python my_app.py' hydra_bash_completion | grep EXECUTABLE_FIRST | awk '{split($0,a,"=");b=substr(a[2],2,length(a[2])-2);print b}')
+        # Do actual test
+        test=$(COMP_LINE='python my_app.py' hydra_bash_completion |\
+               grep EXECUTABLE_FIRST |\
+               awk '{split($0,a,"=");b=substr(a[2],2,length(a[2])-2);print b}')
 
-		if [ $test == $PYTHON ]; then
-		    echo TRUE
-		else
-		    echo FALSE
-		fi
-		HEREDOC
-		"""
+        if [ $test == $PYTHON ]; then
+            echo TRUE
+        else
+            echo FALSE
+        fi
+        HEREDOC
+        """
         ),
         shell=True,
         stdout=subprocess.PIPE,

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -57,20 +57,20 @@ def test_bash_completion_with_dot_in_path():
 """
 bash -l <<- 'HEREDOC'
 # Navigate to app with minimal configuration
-cd .
+cd ./test_apps/app_with_cfg/
 
 # Locate python
 PYTHON=$(command -v python)
 
 # Setup hydra bash completion
-eval "$(python simple.py -sc install=bash)"
+eval "$(python my_app.py -sc install=bash)"
 
 # Setup debugging
 export HYDRA_COMP_DEBUG=1
 export PATH=$PATH:.
 
 # Do actual test
-test=$(COMP_LINE='python simple.py' hydra_bash_completion | grep EXECUTABLE_FIRST | awk '{split($0,a,"=");b=substr(a[2],2,length(a[2])-2);print b}')
+test=$(COMP_LINE='python my_app.py' hydra_bash_completion | grep EXECUTABLE_FIRST | awk '{split($0,a,"=");b=substr(a[2],2,length(a[2])-2);print b}')
 
 if [ $test == $PYTHON ]; then
     echo TRUE

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -52,6 +52,42 @@ def create_config_loader() -> ConfigLoaderImpl:
         )
     )
 
+def test_bash_completion_with_dot_in_path():
+    process = subprocess.Popen(
+"""
+bash -l <<- 'HEREDOC'
+# Navigate to app with minimal configuration
+cd .
+
+# Locate python
+PYTHON=$(command -v python)
+
+# Setup hydra bash completion
+eval "$(python simple.py -sc install=bash)"
+
+# Setup debugging
+export HYDRA_COMP_DEBUG=1
+export PATH=$PATH:.
+
+# Do actual test
+test=$(COMP_LINE='python simple.py' hydra_bash_completion | grep EXECUTABLE_FIRST | awk '{split($0,a,"=");b=substr(a[2],2,length(a[2])-2);print b}')
+
+if [ $test == $PYTHON ]; then
+    echo TRUE
+else
+    echo FALSE
+fi
+HEREDOC
+"""
+    ,
+    shell=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    )
+    stdout, stderr = process.communicate()
+    assert stderr == b''
+    assert stdout == b'TRUE\n'
+    return
 
 base_completion_list: List[str] = [
     "dict.",

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import List
+import textwrap
 
 import pytest
 from packaging import version
@@ -52,42 +53,45 @@ def create_config_loader() -> ConfigLoaderImpl:
         )
     )
 
-def test_bash_completion_with_dot_in_path():
+
+def test_bash_completion_with_dot_in_path() -> None:
     process = subprocess.Popen(
-"""
-bash -l <<- 'HEREDOC'
-# Navigate to app with minimal configuration
-cd tests/test_apps/app_with_cfg/
+        textwrap.dedent(
+            """
+		bash <<- 'HEREDOC'
+		# Navigate to app with minimal configuration
+		cd tests/test_apps/app_with_cfg/
 
-# Locate python
-PYTHON=$(command -v python)
+		# Locate python
+		PYTHON=$(command -v python)
 
-# Setup hydra bash completion
-eval "$(python my_app.py -sc install=bash)"
+		# Setup hydra bash completion
+		eval "$(python my_app.py -sc install=bash)"
 
-# Setup debugging
-export HYDRA_COMP_DEBUG=1
-export PATH=$PATH:.
+		# Setup debugging
+		export HYDRA_COMP_DEBUG=1
+		export PATH=$PATH:.
 
-# Do actual test
-test=$(COMP_LINE='python my_app.py' hydra_bash_completion | grep EXECUTABLE_FIRST | awk '{split($0,a,"=");b=substr(a[2],2,length(a[2])-2);print b}')
+		# Do actual test
+		test=$(COMP_LINE='python my_app.py' hydra_bash_completion | grep EXECUTABLE_FIRST | awk '{split($0,a,"=");b=substr(a[2],2,length(a[2])-2);print b}')
 
-if [ $test == $PYTHON ]; then
-    echo TRUE
-else
-    echo FALSE
-fi
-HEREDOC
-"""
-    ,
-    shell=True,
-    stdout=subprocess.PIPE,
-    stderr=subprocess.PIPE,
+		if [ $test == $PYTHON ]; then
+		    echo TRUE
+		else
+		    echo FALSE
+		fi
+		HEREDOC
+		"""
+        ),
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
     stdout, stderr = process.communicate()
-    assert stderr == b''
-    assert stdout == b'TRUE\n'
+    assert stderr == b""
+    assert stdout == b"TRUE\n"
     return
+
 
 base_completion_list: List[str] = [
     "dict.",

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -4,9 +4,9 @@ import os
 import re
 import subprocess
 import sys
+import textwrap
 from pathlib import Path
 from typing import List
-import textwrap
 
 import pytest
 from packaging import version

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -53,7 +53,7 @@ def create_config_loader() -> ConfigLoaderImpl:
         )
     )
 
-
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_bash_completion_with_dot_in_path() -> None:
     process = subprocess.Popen(
         textwrap.dedent(

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -4,7 +4,6 @@ import os
 import re
 import subprocess
 import sys
-import textwrap
 from pathlib import Path
 from typing import List
 
@@ -58,36 +57,8 @@ def create_config_loader() -> ConfigLoaderImpl:
 class TestDotInPathCompletion:
     def test_bash_completion_with_dot_in_path(self) -> None:
         process = subprocess.Popen(
-            textwrap.dedent(
-                """
-                bash <<- 'HEREDOC'
-                # Navigate to app with minimal configuration
-                cd tests/test_apps/app_with_cfg/
-
-                # Locate python
-                PYTHON=$(command -v python)
-
-                # Setup hydra bash completion
-                eval "$(python my_app.py -sc install=bash)"
-
-                # Setup debugging
-                export HYDRA_COMP_DEBUG=1
-                export PATH=$PATH:.
-
-                # Do actual test
-                test=$(COMP_LINE='python my_app.py' hydra_bash_completion |\
-                    grep EXECUTABLE_FIRST |\
-                    awk '{split($0,a,"=");b=substr(a[2],2,length(a[2])-2);print b}')
-
-                if [ $test == $PYTHON ]; then
-                    echo TRUE
-                else
-                    echo FALSE
-                fi
-                HEREDOC
-                """
-            ),
-            shell=True,
+            "tests/scripts/test_bash_dot_in_path.bash",
+            shell=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -57,7 +57,7 @@ def test_bash_completion_with_dot_in_path():
 """
 bash -l <<- 'HEREDOC'
 # Navigate to app with minimal configuration
-cd ./test_apps/app_with_cfg/
+cd tests/test_apps/app_with_cfg/
 
 # Locate python
 PYTHON=$(command -v python)


### PR DESCRIPTION
## Motivation

This should address issue of builtins to consider local files as executables during parsing of the command.
This will fix issues with PATH having "." and script being executable.

## Test Plan

Need to figure out how to make this into a test here - need some help.

```python
# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
import subprocess
#import textwrap

def test_bash_completion():
    process = subprocess.Popen(
#            textwrap.dedent(
"""
bash -l <<- 'HEREDOC'
# Navigate to app with minimal configuration
cd .

# Locate python
PYTHON=$(command -v python)

# Setup hydra bash completion
eval "$(python simple.py -sc install=bash)"

# Setup debugging
export HYDRA_COMP_DEBUG=1

# Do actual test
test=$(COMP_LINE='python simple.py' hydra_bash_completion | grep EXECUTABLE_FIRST | awk '{split($0,a,"=");b=substr(a[2],2,length(a[2])-2);print b}')

if [ $test == $PYTHON ]; then
    echo TRUE
else
    echo FALSE
fi
HEREDOC
"""
#           )
    ,
    shell=True,
    stdout=subprocess.PIPE,
    stderr=subprocess.PIPE,
    )
    stdout, stderr = process.communicate()
    assert stderr == b''
    assert stdout == b'TRUE\n'
    return
```

## Related Issues and PRs
Look here: https://github.com/facebookresearch/hydra/issues/858