### PR TITLE
Fix overriding of hydra.job.env_set from the command line

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -265,7 +265,6 @@ class ConfigLoaderImpl(ConfigLoader):
             )
             raise ConfigCompositionException(msg) from e
 
-        OmegaConf.set_struct(cfg.hydra, True)
         OmegaConf.set_struct(cfg, strict)
 
         # Apply command line overrides after enabling strict flag

--- a/hydra/test_utils/test_utils.py
+++ b/hydra/test_utils/test_utils.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from subprocess import PIPE, Popen, check_output
 from typing import Any, Dict, Iterator, List, Optional, Union
 
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import Container, DictConfig, OmegaConf
 from typing_extensions import Protocol
 
 from hydra._internal.hydra import Hydra
@@ -254,7 +254,7 @@ def _get_statements(indent: str, statements: Union[None, str, List[str]]) -> str
 
 def integration_test(
     tmpdir: Path,
-    task_config: DictConfig,
+    task_config: Any,
     overrides: List[str],
     prints: Union[str, List[str]],
     expected_outputs: Union[str, List[str]],
@@ -266,7 +266,7 @@ def integration_test(
     Path(tmpdir).mkdir(parents=True, exist_ok=True)
     if isinstance(expected_outputs, str):
         expected_outputs = [expected_outputs]
-    if isinstance(task_config, (list, dict)):
+    if not isinstance(task_config, Container):
         task_config = OmegaConf.create(task_config)
     if isinstance(prints, str):
         prints = [prints]

--- a/news/854.bugfix
+++ b/news/854.bugfix
@@ -1,0 +1,1 @@
+Fix overriding of hydra.job.env_set from the command line

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -727,12 +727,22 @@ def test_local_run_workdir(
     )
 
 
-def test_hydra_env_set(tmpdir: Path) -> None:
+def test_hydra_env_set_with_config(tmpdir: Path) -> None:
     cfg = OmegaConf.create({"hydra": {"job": {"env_set": {"foo": "bar"}}}})
     integration_test(
         tmpdir=tmpdir,
         task_config=cfg,
         overrides=[],
+        prints="os.environ['foo']",
+        expected_outputs="bar",
+    )
+
+
+def test_hydra_env_set_with_override(tmpdir: Path) -> None:
+    integration_test(
+        tmpdir=tmpdir,
+        task_config={},
+        overrides=["+hydra.job.env_set.foo=bar"],
         prints="os.environ['foo']",
         expected_outputs="bar",
     )


### PR DESCRIPTION
closes #854 