### PR TITLE
Fix test failing when using pyenv

### DIFF
--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -170,7 +170,9 @@ class TestRunCompletion:
 
         # verify expect will be running the correct Python.
         # This preemptively detect a much harder to understand error from expect.
-        ret = subprocess.check_output(["which", "python"], env=os.environ)
+        ret = subprocess.check_output(
+            ["python", "-c", "import sys; print(sys.executable)"], env=os.environ
+        )
         assert os.path.realpath(ret.decode("utf-8").strip()) == os.path.realpath(
             sys.executable.strip()
         )


### PR DESCRIPTION
With pyenv `which python` is not the same as `sys.executable`

## Motivation

Support pyenv

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Setup pyenv and run `pytest tests/test_completion.py`

## Related Issues and PRs

Related to this comment: https://github.com/omry/omegaconf/pull/329#issuecomment-678551781