### PR TITLE
Fix instantiate to work correctly when parameters are interpolations into a parent node

### DIFF
--- a/news/904.bugfix
+++ b/news/904.bugfix
@@ -1,0 +1,1 @@
+Fix instantiate to work correctly when parameters are interpolations into a parent node


### PR DESCRIPTION
closes #904