### PR TITLE
hydra 1.0 rc -> stable related docs changes

### DIFF
--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -34,8 +34,9 @@ This guide will show you some of the most important features of Hydra.
 Read the [tutorial](tutorials/basic/your_first_app/1_simple_cli.md) to gain a deeper understanding.
 
 ### Installation
-Install Hydra 1.0 with `pip install hydra-core --pre --upgrade`.  
-This version may contain nuts and bugs and might be incompatible with existing plugins.
+```commandline
+pip install hydra-core --upgrade
+```
 
 ### Basic example
 Config:

--- a/website/docs/plugins/ax_sweeper.md
+++ b/website/docs/plugins/ax_sweeper.md
@@ -13,9 +13,8 @@ sidebar_label: Ax Sweeper plugin
 This plugin provides a mechanism for Hydra applications to use the [Adaptive Experimentation Platform, aka Ax](https://ax.dev/). Ax can optimize any experiment - machine learning experiments, A/B tests, and simulations. 
 
 ### Installation
-This plugin requires Hydra 1.0 (Release candidate)
 ```commandline
-pip install hydra-ax-sweeper --pre
+pip install hydra-ax-sweeper --upgrade
 ```
 
 ### Usage

--- a/website/docs/plugins/colorlog.md
+++ b/website/docs/plugins/colorlog.md
@@ -14,14 +14,8 @@ Adds <a class="external" href="https://github.com/borntyping/python-colorlog" ta
 
 
 ### Installation
-#### Hydra 0.11 - stable
-```
-pip install hydra-colorlog --upgrade
-```
-
-#### Hydra 1.0 - Release candidate
-```
-pip install hydra_colorlog --upgrade --pre
+```commandline
+pip install hydra_colorlog --upgrade
 ```
 
 ### Usage

--- a/website/docs/plugins/joblib_launcher.md
+++ b/website/docs/plugins/joblib_launcher.md
@@ -13,9 +13,8 @@ sidebar_label: Joblib Launcher plugin
 The Joblib Launcher plugin provides a launcher for parallel tasks based on [`Joblib.Parallel`](https://joblib.readthedocs.io/en/latest/parallel.html).
 
 ### Installation
-This plugin requires Hydra 1.0 (Release candidate)
 ```commandline
-pip install hydra-joblib-launcher --pre
+pip install hydra-joblib-launcher --upgrade
 ```
 
 ### Usage

--- a/website/docs/plugins/nevergrad_sweeper.md
+++ b/website/docs/plugins/nevergrad_sweeper.md
@@ -15,9 +15,8 @@ sidebar_label: Nevergrad Sweeper plugin
 [Nevergrad](https://facebookresearch.github.io/nevergrad/) is a derivative-free optimization platform proposing a library of state-of-the art algorithms for hyperparameter search. This plugin provides a mechanism for Hydra applications to use [Nevergrad](https://facebookresearch.github.io/nevergrad/) algorithms for the optimization of experiments/applications parameters.
 
 ### Installation
-This plugin requires Hydra 1.0 (Release candidate)
 ```commandline
-pip install hydra-nevergrad-sweeper --pre
+pip install hydra-nevergrad-sweeper --upgrade
 ```
 
 ### Usage

--- a/website/docs/plugins/rq_launcher.md
+++ b/website/docs/plugins/rq_launcher.md
@@ -16,9 +16,8 @@ RQ launcher allows parallelizing across multiple nodes and scheduling jobs in qu
 
 
 ### Installation
-This plugin requires Hydra 1.0 (Release candidate)
 ```commandline
-pip install hydra-rq-launcher --pre
+pip install hydra-rq-launcher --upgrade
 ```
 Usage of this plugin requires a [Redis server](https://redis.io/topics/quickstart).
 

--- a/website/docs/plugins/submitit_launcher.md
+++ b/website/docs/plugins/submitit_launcher.md
@@ -14,9 +14,8 @@ The Submitit Launcher plugin provides a [SLURM ](https://slurm.schedmd.com/docum
 
 
 ### Installation
-This plugin requires Hydra 1.0 (Release candidate)
 ```commandline
-pip install hydra-submitit-launcher --pre
+pip install hydra-submitit-launcher --upgrade
 ```
 
 

--- a/website/docs/upgrades/0.11_to_1.0/object_instantiation_changes.md
+++ b/website/docs/upgrades/0.11_to_1.0/object_instantiation_changes.md
@@ -5,7 +5,7 @@ title: Object instantiation changes
 
 
 ## Overview
-Hydra 1.0.0rc3 is deprecating ObjectConf and the corresponding config structure to a simpler one without the params node.
+Hydra 1.0.0 is deprecating ObjectConf and the corresponding config structure to a simpler one without the params node.
 This removes a level of nesting from command line and configs overrides.
 
 <div className="row">

--- a/website/versioned_docs/version-1.0/intro.md
+++ b/website/versioned_docs/version-1.0/intro.md
@@ -34,8 +34,9 @@ This guide will show you some of the most important features of Hydra.
 Read the [tutorial](tutorials/basic/your_first_app/1_simple_cli.md) to gain a deeper understanding.
 
 ### Installation
-Install Hydra 1.0 with `pip install hydra-core --pre --upgrade`.  
-This version may contain nuts and bugs and might be incompatible with existing plugins.
+```commandline
+pip install hydra-core
+```
 
 ### Basic example
 Config:

--- a/website/versioned_docs/version-1.0/intro.md
+++ b/website/versioned_docs/version-1.0/intro.md
@@ -35,7 +35,7 @@ Read the [tutorial](tutorials/basic/your_first_app/1_simple_cli.md) to gain a de
 
 ### Installation
 ```commandline
-pip install hydra-core
+pip install hydra-core --upgrade
 ```
 
 ### Basic example

--- a/website/versioned_docs/version-1.0/plugins/ax_sweeper.md
+++ b/website/versioned_docs/version-1.0/plugins/ax_sweeper.md
@@ -14,7 +14,7 @@ This plugin provides a mechanism for Hydra applications to use the [Adaptive Exp
 
 ### Installation
 ```commandline
-pip install hydra-ax-sweeper
+pip install hydra-ax-sweeper --upgrade
 ```
 
 ### Usage

--- a/website/versioned_docs/version-1.0/plugins/ax_sweeper.md
+++ b/website/versioned_docs/version-1.0/plugins/ax_sweeper.md
@@ -13,7 +13,6 @@ sidebar_label: Ax Sweeper plugin
 This plugin provides a mechanism for Hydra applications to use the [Adaptive Experimentation Platform, aka Ax](https://ax.dev/). Ax can optimize any experiment - machine learning experiments, A/B tests, and simulations. 
 
 ### Installation
-This plugin requires Hydra >= 1.0.0
 ```commandline
 pip install hydra-ax-sweeper
 ```

--- a/website/versioned_docs/version-1.0/plugins/ax_sweeper.md
+++ b/website/versioned_docs/version-1.0/plugins/ax_sweeper.md
@@ -13,9 +13,9 @@ sidebar_label: Ax Sweeper plugin
 This plugin provides a mechanism for Hydra applications to use the [Adaptive Experimentation Platform, aka Ax](https://ax.dev/). Ax can optimize any experiment - machine learning experiments, A/B tests, and simulations. 
 
 ### Installation
-This plugin requires Hydra 1.0 (Release candidate)
+This plugin requires Hydra >= 1.0.0
 ```commandline
-pip install hydra-ax-sweeper --pre
+pip install hydra-ax-sweeper
 ```
 
 ### Usage

--- a/website/versioned_docs/version-1.0/plugins/colorlog.md
+++ b/website/versioned_docs/version-1.0/plugins/colorlog.md
@@ -15,7 +15,7 @@ Adds <a class="external" href="https://github.com/borntyping/python-colorlog" ta
 
 ### Installation
 ```commandline
-pip install hydra_colorlog
+pip install hydra_colorlog --upgrade
 ```
 
 ### Usage

--- a/website/versioned_docs/version-1.0/plugins/colorlog.md
+++ b/website/versioned_docs/version-1.0/plugins/colorlog.md
@@ -14,14 +14,8 @@ Adds <a class="external" href="https://github.com/borntyping/python-colorlog" ta
 
 
 ### Installation
-#### Hydra 0.11 - stable
-```
-pip install hydra-colorlog --upgrade
-```
-
-#### Hydra 1.0 - Release candidate
-```
-pip install hydra_colorlog --upgrade --pre
+```commandline
+pip install hydra_colorlog
 ```
 
 ### Usage

--- a/website/versioned_docs/version-1.0/plugins/joblib_launcher.md
+++ b/website/versioned_docs/version-1.0/plugins/joblib_launcher.md
@@ -15,7 +15,7 @@ The Joblib Launcher plugin provides a launcher for parallel tasks based on [`Job
 ### Installation
 This plugin requires Hydra >= 1.0.0
 ```commandline
-pip install hydra-joblib-launcher
+pip install hydra-joblib-launcher --upgrade
 ```
 
 ### Usage

--- a/website/versioned_docs/version-1.0/plugins/joblib_launcher.md
+++ b/website/versioned_docs/version-1.0/plugins/joblib_launcher.md
@@ -13,7 +13,6 @@ sidebar_label: Joblib Launcher plugin
 The Joblib Launcher plugin provides a launcher for parallel tasks based on [`Joblib.Parallel`](https://joblib.readthedocs.io/en/latest/parallel.html).
 
 ### Installation
-This plugin requires Hydra >= 1.0.0
 ```commandline
 pip install hydra-joblib-launcher --upgrade
 ```

--- a/website/versioned_docs/version-1.0/plugins/joblib_launcher.md
+++ b/website/versioned_docs/version-1.0/plugins/joblib_launcher.md
@@ -13,9 +13,9 @@ sidebar_label: Joblib Launcher plugin
 The Joblib Launcher plugin provides a launcher for parallel tasks based on [`Joblib.Parallel`](https://joblib.readthedocs.io/en/latest/parallel.html).
 
 ### Installation
-This plugin requires Hydra 1.0 (Release candidate)
+This plugin requires Hydra >= 1.0.0
 ```commandline
-pip install hydra-joblib-launcher --pre
+pip install hydra-joblib-launcher
 ```
 
 ### Usage

--- a/website/versioned_docs/version-1.0/plugins/nevergrad_sweeper.md
+++ b/website/versioned_docs/version-1.0/plugins/nevergrad_sweeper.md
@@ -15,7 +15,6 @@ sidebar_label: Nevergrad Sweeper plugin
 [Nevergrad](https://facebookresearch.github.io/nevergrad/) is a derivative-free optimization platform proposing a library of state-of-the art algorithms for hyperparameter search. This plugin provides a mechanism for Hydra applications to use [Nevergrad](https://facebookresearch.github.io/nevergrad/) algorithms for the optimization of experiments/applications parameters.
 
 ### Installation
-This plugin requires Hydra >= 1.0.0
 ```commandline
 pip install hydra-nevergrad-sweeper
 ```
@@ -141,4 +140,3 @@ or a combination of both (eg.: `batch_size=log:int:4:1024`)
   Providing only `lower` and `upper` bound will set the initial value to the middle of the range, and the step to a sixth of the range.
 
 **Note**: unbounded scalars (scalars with no upper and/or lower bounds) can only be defined through a config file.
-

--- a/website/versioned_docs/version-1.0/plugins/nevergrad_sweeper.md
+++ b/website/versioned_docs/version-1.0/plugins/nevergrad_sweeper.md
@@ -16,7 +16,7 @@ sidebar_label: Nevergrad Sweeper plugin
 
 ### Installation
 ```commandline
-pip install hydra-nevergrad-sweeper
+pip install hydra-nevergrad-sweeper --upgrade
 ```
 
 ### Usage

--- a/website/versioned_docs/version-1.0/plugins/nevergrad_sweeper.md
+++ b/website/versioned_docs/version-1.0/plugins/nevergrad_sweeper.md
@@ -15,9 +15,9 @@ sidebar_label: Nevergrad Sweeper plugin
 [Nevergrad](https://facebookresearch.github.io/nevergrad/) is a derivative-free optimization platform proposing a library of state-of-the art algorithms for hyperparameter search. This plugin provides a mechanism for Hydra applications to use [Nevergrad](https://facebookresearch.github.io/nevergrad/) algorithms for the optimization of experiments/applications parameters.
 
 ### Installation
-This plugin requires Hydra 1.0 (Release candidate)
+This plugin requires Hydra >= 1.0.0
 ```commandline
-pip install hydra-nevergrad-sweeper --pre
+pip install hydra-nevergrad-sweeper
 ```
 
 ### Usage

--- a/website/versioned_docs/version-1.0/plugins/rq_launcher.md
+++ b/website/versioned_docs/version-1.0/plugins/rq_launcher.md
@@ -16,7 +16,6 @@ RQ launcher allows parallelizing across multiple nodes and scheduling jobs in qu
 
 
 ### Installation
-This plugin requires Hydra >= 1.0.0
 ```commandline
 pip install hydra-rq-launcher
 ```

--- a/website/versioned_docs/version-1.0/plugins/rq_launcher.md
+++ b/website/versioned_docs/version-1.0/plugins/rq_launcher.md
@@ -17,7 +17,7 @@ RQ launcher allows parallelizing across multiple nodes and scheduling jobs in qu
 
 ### Installation
 ```commandline
-pip install hydra-rq-launcher
+pip install hydra-rq-launcher --upgrade
 ```
 Usage of this plugin requires a [Redis server](https://redis.io/topics/quickstart).
 

--- a/website/versioned_docs/version-1.0/plugins/rq_launcher.md
+++ b/website/versioned_docs/version-1.0/plugins/rq_launcher.md
@@ -16,9 +16,9 @@ RQ launcher allows parallelizing across multiple nodes and scheduling jobs in qu
 
 
 ### Installation
-This plugin requires Hydra 1.0 (Release candidate)
+This plugin requires Hydra >= 1.0.0
 ```commandline
-pip install hydra-rq-launcher --pre
+pip install hydra-rq-launcher
 ```
 Usage of this plugin requires a [Redis server](https://redis.io/topics/quickstart).
 

--- a/website/versioned_docs/version-1.0/plugins/submitit_launcher.md
+++ b/website/versioned_docs/version-1.0/plugins/submitit_launcher.md
@@ -15,7 +15,7 @@ The Submitit Launcher plugin provides a [SLURM ](https://slurm.schedmd.com/docum
 
 ### Installation
 ```commandline
-pip install hydra-submitit-launcher
+pip install hydra-submitit-launcher --upgrade
 ```
 
 

--- a/website/versioned_docs/version-1.0/plugins/submitit_launcher.md
+++ b/website/versioned_docs/version-1.0/plugins/submitit_launcher.md
@@ -14,9 +14,9 @@ The Submitit Launcher plugin provides a [SLURM ](https://slurm.schedmd.com/docum
 
 
 ### Installation
-This plugin requires Hydra 1.0 (Release candidate)
+This plugin requires Hydra >= 1.0.0
 ```commandline
-pip install hydra-submitit-launcher --pre
+pip install hydra-submitit-launcher
 ```
 
 

--- a/website/versioned_docs/version-1.0/plugins/submitit_launcher.md
+++ b/website/versioned_docs/version-1.0/plugins/submitit_launcher.md
@@ -14,7 +14,6 @@ The Submitit Launcher plugin provides a [SLURM ](https://slurm.schedmd.com/docum
 
 
 ### Installation
-This plugin requires Hydra >= 1.0.0
 ```commandline
 pip install hydra-submitit-launcher
 ```
@@ -105,4 +104,3 @@ $ cat 0/my_app.log
 [2020-05-28 15:05:23,511][__main__][INFO] - Process ID 15887 executing task 1 ...
 [2020-05-28 15:05:24,514][submitit][INFO] - Job completed successfully
 ```
-

--- a/website/versioned_docs/version-1.0/upgrades/0.11_to_1.0/object_instantiation_changes.md
+++ b/website/versioned_docs/version-1.0/upgrades/0.11_to_1.0/object_instantiation_changes.md
@@ -5,7 +5,7 @@ title: Object instantiation changes
 
 
 ## Overview
-Hydra 1.0.0rc3 is deprecating ObjectConf and the corresponding config structure to a simpler one without the params node.
+Hydra 1.0.0 is deprecating ObjectConf and the corresponding config structure to a simpler one without the params node.
 This removes a level of nesting from command line and configs overrides.
 
 <div className="row">


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Removed v1.0 release candidates references as the stable version is now available. (Thanks for the amazing work!)

From several install instructions `pip install <package> --pre --upgrade` removed:
- `--pre` since no longer needed, and
- `--upgrade`, In case the docs should provide instructions for installing the package version that matches the docs version this should probably be achieved though `pip install <package>==<version>`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

No

## Test Plan

N/A

## Related Issues and PRs

N/A
