### PR TITLE
Added Missing OmegaConf in Docs Intro

### DIFF
--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -49,7 +49,7 @@ db:
 Application:
 ```python {4-6} title="my_app.py"
 import hydra
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 @hydra.main(config_name="config")
 def my_app(cfg : DictConfig) -> None:


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Bug in Docs.

Missing OmegaConf in import statement 
```from omegaconf import DictConfig``` 
to 
```from omegaconf import DictConfig, OmegaConf```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes.

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

No.

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)

No.