### PR TITLE
[RQ launcher] Unpin RQ version

### DIFF
--- a/plugins/hydra_rq_launcher/setup.py
+++ b/plugins/hydra_rq_launcher/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     LONG_DESC = fh.read()
     setup(
         name="hydra-rq-launcher",
-        version="1.0.1",
+        version="1.0.2",
         author="Jan-Matthis Lueckmann, Omry Yadan",
         author_email="mail@jan-matthis.de, omry@fb.com",
         description="Redis Queue (RQ) Launcher for Hydra apps",
@@ -26,7 +26,7 @@ with open("README.md", "r") as fh:
             "cloudpickle",
             "fakeredis",
             "hydra-core>=1.0.0",
-            "rq==1.4.3",
+            "rq>=1.5.1",
         ],
         include_package_data=True,
     )

--- a/plugins/hydra_rq_launcher/setup.py
+++ b/plugins/hydra_rq_launcher/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     LONG_DESC = fh.read()
     setup(
         name="hydra-rq-launcher",
-        version="1.0.2",
+        version="1.0.1",
         author="Jan-Matthis Lueckmann, Omry Yadan",
         author_email="mail@jan-matthis.de, omry@fb.com",
         description="Redis Queue (RQ) Launcher for Hydra apps",


### PR DESCRIPTION
## Motivation

`rq` was pinned to version `1.4.3` since there was a problem with failing tests (related to fakeredis) in higher versions. Starting from `rq` version `1.5.1` this bug was fixed and tests pass again. This PR changes the requirement `rq==1.4.3` to `rq>=1.5.1` in `setup.py`.

Once the PR is merged, I'm planning to release  `hydra-rq-launcher` version `1.0.1` to PyPI. The PR already updates the version info to `1.0.2` to be one version ahead for the next release after that -- let me know if I should take it out.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

CI tests should pass (they did locally)

## Related Issues and PRs

- Commit with fix in `rq`: https://github.com/rq/rq/commit/6028a636073909c6472703f4c42b610a70b1f889
- Issue in `fakeredis` repo: https://github.com/jamesls/fakeredis/issues/273