### PR TITLE
docs: Fix simple typo, psuedo -> pseudo

### DIFF
--- a/website/docs/advanced/override_grammar/extended.md
+++ b/website/docs/advanced/override_grammar/extended.md
@@ -197,7 +197,7 @@ str([1,2,3])               # ['1','2','3']
 str({a:10})                # {a:'10'}
 ```
 
-Below are psuedo code snippets that illustrates the differences between Python's casting and Hydra's casting.
+Below are pseudo code snippets that illustrates the differences between Python's casting and Hydra's casting.
 
 #### Casting string to bool
 

--- a/website/versioned_docs/version-1.0/advanced/override_grammar/extended.md
+++ b/website/versioned_docs/version-1.0/advanced/override_grammar/extended.md
@@ -197,7 +197,7 @@ str([1,2,3])               # ['1','2','3']
 str({a:10})                # {a:'10'}
 ```
 
-Below are psuedo code snippets that illustrates the differences between Python's casting and Hydra's casting.
+Below are pseudo code snippets that illustrates the differences between Python's casting and Hydra's casting.
 
 #### Casting string to bool
 


### PR DESCRIPTION
There is a small typo in website/docs/advanced/override_grammar/extended.md, website/versioned_docs/version-1.0/advanced/override_grammar/extended.md.

Should read `pseudo` rather than `psuedo`.

