### PR TITLE
Add test for % being allowed in unquoted strings

### DIFF
--- a/hydra/grammar/OverrideLexer.g4
+++ b/hydra/grammar/OverrideLexer.g4
@@ -12,9 +12,9 @@ fragment DIGIT: [0-9];
 fragment INT_UNSIGNED: '0' | [1-9] (('_')? DIGIT)*;
 fragment ESC_BACKSLASH: '\\\\';  // escaped backslash
 
-/////////
-// KEY //
-/////////
+////////////////////////
+// DEFAULT_MODE (KEY) //
+////////////////////////
 
 EQUAL: '=' WS? -> mode(VALUE_MODE);
 
@@ -28,9 +28,9 @@ SLASH: '/';
 KEY_ID: ID -> type(ID);
 DOT_PATH: (ID | INT_UNSIGNED) ('.' (ID | INT_UNSIGNED))+;
 
-///////////
-// VALUE //
-///////////
+////////////////
+// VALUE_MODE //
+////////////////
 
 mode VALUE_MODE;
 

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -500,7 +500,7 @@ def test_key(value: str, expected: Any) -> None:
     "value,expected",
     [
         pytest.param("a", "a", id="a"),
-        pytest.param("/:-\\+.$*", "/:-\\+.$*", id="accepted_specials"),
+        pytest.param("/:-\\+.$%*", "/:-\\+.$%*", id="accepted_specials"),
         pytest.param("abc10", "abc10", id="abc10"),
         pytest.param("a.b.c", "a.b.c", id="a.b.c"),
         pytest.param("list.0.bar", "list.0.bar", id="list.0.bar"),


### PR DESCRIPTION
## Motivation

From #954:

> I think you missed a test for unquoted %, can you followup if so?

==> This PR adds that test

There is a 2nd unrelated commit in this PR (183dd5960) that I thought wasn't worth a PR on its own, just making mode names more explicit in the lexer grammar comments. I actually intended to include it in #954 but it got merged right before I did ;)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

`pytest "tests/test_overrides_parser.py::test_primitive[accepted_specials]"`

## Related Issues and PRs

Follow-up to #954 