### PR TITLE
Move deploy website action to github

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -4,6 +4,7 @@ on:
    push:
     branches:
       - master
+      - deploywebsite
 
 jobs:
   deploy:

--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -1,0 +1,38 @@
+name: Deploy website
+
+on:
+   push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Deploy website if diff exists
+      env:
+        GITHUB_TOKEN: ${{ secrets.WEBSITE_GITHUB_TOKEN }}
+      run: |
+        SUBDIR=website
+        git fetch
+        REV=$(git log -5 --pretty=oneline origin/gh-pages | grep "Deploy website" |  awk 'NF>1{print $NF}'  | head -1)
+        # This condition passes in 2 conditions:
+        # 1. The revision does not exist (squash/force push happened)
+        # 2. There are changes between last deployed revision and HEAD
+        if [[ ! $(git rev-parse --verify -q "$REV^{commit}") ||  $(git diff-index $REV -- $SUBDIR) ]]; then
+          echo "Changes detected in directory $SUBDIR between origin/master and this diff"
+
+          cd $SUBDIR
+          yarn --no-progress
+
+          git config --global user.email omry@users.noreply.github.com
+          git config --global user.name omry
+          echo "machine github.com login docusaurus-bot password $WEBSITE_GITHUB_TOKEN" > ~/.netrc
+          #  yarn install && GIT_USER=docusaurus-bot yarn deploy
+        else
+          echo "No changes detected in directory $SUBDIR between origin/master and this diff"
+        fi
+


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation
Step 1 in #973

I've verified the github actions runs ok in my own forked repo https://github.com/jieru-hu/hydra/pull/1/checks?check_run_id=1124728045


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan



Ran this action in my hydra-forked repo and verify the output looks OK, the job can be viewed here https://github.com/jieru-hu/hydra/pull/1/checks?check_run_id=1124728045

At this stage this action doesn't do anything  since I've commented out `#  yarn install && GIT_USER=docusaurus-bot yarn deploy`

The action right now only runs
```
yarn --no-progress
```
output:
![image](https://user-images.githubusercontent.com/4642412/93391154-97a5f100-f823-11ea-98ae-7cf53f0ef69a.png)

Compared to a successful job from circleCI on master
https://app.circleci.com/pipelines/github/facebookresearch/hydra/3407/workflows/88c37cf5-9d5b-43cd-9393-a39ff3287434/jobs/23511
![image](https://user-images.githubusercontent.com/4642412/93391380-e94e7b80-f823-11ea-9615-2853aba7cf49.png)

The output is the same from the same command.
## Related Issues and PRs

#973
