### PR TITLE
Move deploy website to github action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,33 +134,6 @@ jobs:
       - run: sudo pip install nox
       - run: nox -s coverage
 
-  deploy-website:
-    docker:
-      - image: circleci/node:12
-    steps:
-      - checkout
-      - deploy:
-          name: Deploying to GitHub Pages
-          command: |
-            SUBDIR=website
-            REV=$(git log -5 --pretty=oneline origin/gh-pages | grep "Deploy website" |  awk 'NF>1{print $NF}'  | head -1)
-            # This condition passes in 2 conditions:
-            # 1. The revision does not exist (squash/force push happened)
-            # 2. There are changes between last deployed revision and HEAD
-            if [[ ! $(git rev-parse --verify -q "$REV^{commit}") ||  $(git diff-index $REV -- $SUBDIR) ]]; then
-              echo "Changes detected in directory $SUBDIR between origin/master and this diff"
-
-              cd $SUBDIR
-              yarn --no-progress
-
-              git config --global user.email omry@users.noreply.github.com
-              git config --global user.name omry
-              echo "machine github.com login docusaurus-bot password $GITHUB_TOKEN" > ~/.netrc
-              yarn install && GIT_USER=docusaurus-bot yarn deploy
-            else
-              echo "No changes detected in directory $SUBDIR between origin/master and this diff"
-            fi
-
 workflows:
   version: 2
   build:
@@ -177,10 +150,6 @@ workflows:
           matrix:
             parameters:
               py_version: ["3.6", "3.7", "3.8"]
-      - deploy-website:
-          filters:
-            branches:
-              only: master
 
 orbs:
   win: circleci/windows@1.0.0

--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Deploy website
       env:
-        GITHUB_TOKEN: ${{ secrets.WEBSITE_GITHUB_TOKEN }}
+        WEBSITE_GITHUB_TOKEN: ${{ secrets.WEBSITE_GITHUB_TOKEN }}
       run: |
         SUBDIR=website
         git fetch
@@ -30,7 +30,7 @@ jobs:
           git config --global user.email omry@users.noreply.github.com
           git config --global user.name omry
           echo "machine github.com login docusaurus-bot password $WEBSITE_GITHUB_TOKEN" > ~/.netrc
-          #  yarn install && GIT_USER=docusaurus-bot yarn deploy
+          yarn install && GIT_USER=docusaurus-bot yarn deploy
         else
           echo "No changes detected in directory $SUBDIR between origin/master and this diff"
         fi

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -87,4 +87,4 @@ The [Config Search Path](advanced/search_path.md) is a list of paths that are se
 the Python [PYTHONPATH](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH).
 
 ### Plugins
-[Plugins](advanced/plugins.md) extend Hydra's capabilities. Some examples are Launcher, Sweeper and ConfigSource plugin.
+[Plugins](advanced/plugins.md) extend Hydra's capabilities. Some examples are Launcher and Sweeper.

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -87,4 +87,4 @@ The [Config Search Path](advanced/search_path.md) is a list of paths that are se
 the Python [PYTHONPATH](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH).
 
 ### Plugins
-[Plugins](advanced/plugins.md) extend Hydra's capabilities. Some examples are Launcher and Sweeper.
+[Plugins](advanced/plugins.md) extend Hydra's capabilities. Some examples are Launcher, Sweeper and ConfigSource plugin.


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

step 3 of  #973

 Remove deploy-website step from CircleCI, enable it in github.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan
The run can be viewed here https://github.com/facebookresearch/hydra/pull/979/checks?check_run_id=1125874069

And I can see that the doc was updated:
https://hydra.cc/docs/next/terminology/
![image](https://user-images.githubusercontent.com/4642412/93402365-6fc18800-f839-11ea-9448-e4a42be54335.png)



## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
