### PR TITLE
Fixed import in intro.md

### DIFF
--- a/website/versioned_docs/version-1.0/intro.md
+++ b/website/versioned_docs/version-1.0/intro.md
@@ -49,7 +49,7 @@ db:
 Application:
 ```python {4-6} title="my_app.py"
 import hydra
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 @hydra.main(config_name="config")
 def my_app(cfg : DictConfig) -> None:


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation
The python example in the very first docs a user reads is not runnable.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan
- Run the master `my_app.py` from the intro, see `NameError: name 'OmegaConf' is not defined`
- Run the edited `my_app.py` from this branch that includes the `OmegaConf` import, runs okay
