### PR TITLE
Fix interpolation not resolved on instantiation

### DIFF
--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -595,7 +595,7 @@ def _get_kwargs(config: Union[ObjectConf, DictConfig], **kwargs: Any) -> Any:
     with read_write(params):
         params.merge_with(config_overrides)
 
-    for k, v in params.items_ex(resolve=False):
+    for k, v in params.items_ex(resolve=True):
         if k == "_target_":
             continue
         final_kwargs[k] = v


### PR DESCRIPTION
#  Motivation

Fix issue #1001 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

** Minimal Code/Config snippet to reproduce **
(Taken from original Issue)

demo.py:
```python
import hydra

class Test:

    def __init__(self, string):
        print("init: " + string)

@hydra.main(config_path='conf', config_name='test')
def main(cfg):
    print("main: " + cfg['test']['string'])
    hydra.utils.instantiate(cfg['test'])

if __name__ == "__main__":
    main()
```

conf/test.yaml:
```yaml
# @package _global_
foo: 42
test:
  _target_: demo.Test
  string: "21 * 2 = ${foo}"
```

Result without fix:
```bash
main: 21 * 2 = 42
init: 21 * 2 = ${foo}
```

Without the fix, when referencing test.string directly from the python code, foo gets resolved correctly to 42 (first line). However, when passing the interpolated string via instantiate() to the class Test, ${foo} does not get resolved (second line).

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)

Issue #1001 