### PR TITLE
Revert the use of _ to separate the path element in keys for the Ax sweeper plugin

### DIFF
--- a/news/913.api_change
+++ b/news/913.api_change
@@ -1,0 +1,1 @@
+Revert the use of "_" to separate the path element in keys for the Ax sweeper plugin.

--- a/plugins/hydra_ax_sweeper/example/conf/config.yaml
+++ b/plugins/hydra_ax_sweeper/example/conf/config.yaml
@@ -27,9 +27,9 @@ hydra:
         max_epochs_without_improvement: 10
 
       params:
-        banana_x:
+        banana.x:
           type: range
           bounds: [-5, 5]
-        banana_y:
+        banana.y:
           type: range
           bounds: [-5, 10.1]

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
@@ -169,10 +169,6 @@ class CoreAxSweeper(Sweeper):
 
             current_parallelism_index += 1
 
-        best_parameters = {
-            normalize_key(key, str_to_replace=".", str_to_replace_with="_"): value
-            for key, value in best_parameters.items()
-        }
         results_to_serialize = {"optimizer": "ax", "ax": best_parameters}
         OmegaConf.save(
             OmegaConf.create(results_to_serialize),
@@ -204,7 +200,6 @@ class CoreAxSweeper(Sweeper):
         """Method to setup the Ax Client"""
         parameters: List[Dict[str, Any]] = []
         for key, value in self.ax_params.items():
-            key = normalize_key(key, str_to_replace="_", str_to_replace_with=".")
             param = OmegaConf.to_container(value, resolve=True)
             assert isinstance(param, Dict)
             if param["type"] == "range":
@@ -268,20 +263,6 @@ class CoreAxSweeper(Sweeper):
             raise ValueError("n must be an integer greater than 0")
         for i in range(0, len(batch), n):
             yield batch[i : i + n]
-
-
-def normalize_key(key: str, str_to_replace: str, str_to_replace_with: str) -> str:
-    """Process the key by replacing "str_to_replace" with "str_to_replace_with".
-    The "str_to_replace" escaped using r"\\" are not replaced. Finally, the r"\\" is removed.
-    """
-    str_to_escape = "\\" + str_to_replace
-    splits_to_update = key.split(str_to_escape)
-    updated_splits = [
-        current_split.replace(str_to_replace, str_to_replace_with)
-        for current_split in splits_to_update
-    ]
-    new_key = str_to_escape.join(updated_splits).replace("\\", "")
-    return new_key
 
 
 def create_range_param_using_interval_override(override: Override) -> Dict[str, Any]:

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial.yaml
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial.yaml
@@ -18,6 +18,6 @@ hydra:
         max_epochs_without_improvement: 2
 
       params:
-        polynomial_x:
+        polynomial.x:
           type: range
           bounds: [-1, 1]

--- a/plugins/hydra_ax_sweeper/tests/config/params/basic.yaml
+++ b/plugins/hydra_ax_sweeper/tests/config/params/basic.yaml
@@ -1,8 +1,8 @@
 # @package hydra.sweeper.ax_config.params
-quadratic_x:
+quadratic.x:
   type: range
   bounds: [-1, 1]
 
-quadratic_y:
+quadratic.y:
   type: range
   bounds: [-1, 1]

--- a/plugins/hydra_ax_sweeper/tests/config/params/nested_with_escape_char.yaml
+++ b/plugins/hydra_ax_sweeper/tests/config/params/nested_with_escape_char.yaml
@@ -1,8 +1,0 @@
-# @package hydra.sweeper.ax_config.params
-quadratic.x_arg:
-  type: range
-  bounds: [-1, 1]
-
-quadratic.y_arg:
-  type: range
-  bounds: [-1, 1]

--- a/plugins/hydra_ax_sweeper/tests/config/params/nested_with_escape_char.yaml
+++ b/plugins/hydra_ax_sweeper/tests/config/params/nested_with_escape_char.yaml
@@ -1,8 +1,8 @@
 # @package hydra.sweeper.ax_config.params
-quadratic_x\_arg:
+quadratic.x_arg:
   type: range
   bounds: [-1, 1]
 
-quadratic_y\_arg:
+quadratic.y_arg:
   type: range
   bounds: [-1, 1]

--- a/plugins/hydra_ax_sweeper/tests/config/quadratic/nested_with_escape_char.yaml
+++ b/plugins/hydra_ax_sweeper/tests/config/quadratic/nested_with_escape_char.yaml
@@ -1,3 +1,0 @@
-# @package _group_
-x_arg: ???
-y_arg: ???

--- a/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
+++ b/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
@@ -104,8 +104,8 @@ def test_jobs_configured_via_config(hydra_sweep_runner: TSweepRunner) -> None:
         assert returns["optimizer"] == "ax"
         assert len(returns) == 2
         best_parameters = returns.ax
-        assert math.isclose(best_parameters.quadratic_x, 0.0, abs_tol=1e-4)
-        assert math.isclose(best_parameters.quadratic_y, -1.0, abs_tol=1e-4)
+        assert math.isclose(best_parameters["quadratic.x"], 0.0, abs_tol=1e-4)
+        assert math.isclose(best_parameters["quadratic.y"], -1.0, abs_tol=1e-4)
 
 
 def test_jobs_configured_via_cmd(hydra_sweep_runner: TSweepRunner) -> None:
@@ -129,8 +129,8 @@ def test_jobs_configured_via_cmd(hydra_sweep_runner: TSweepRunner) -> None:
         assert returns["optimizer"] == "ax"
         assert len(returns) == 2
         best_parameters = returns.ax
-        assert math.isclose(best_parameters.quadratic_x, -2.0, abs_tol=1e-4)
-        assert math.isclose(best_parameters.quadratic_y, 2.0, abs_tol=1e-4)
+        assert math.isclose(best_parameters["quadratic.x"], -2.0, abs_tol=1e-4)
+        assert math.isclose(best_parameters["quadratic.y"], 2.0, abs_tol=1e-4)
 
 
 def test_jobs_configured_via_cmd_and_config(hydra_sweep_runner: TSweepRunner) -> None:
@@ -154,8 +154,8 @@ def test_jobs_configured_via_cmd_and_config(hydra_sweep_runner: TSweepRunner) ->
         assert returns["optimizer"] == "ax"
         assert len(returns) == 2
         best_parameters = returns.ax
-        assert math.isclose(best_parameters.quadratic_x, -2.0, abs_tol=1e-4)
-        assert math.isclose(best_parameters.quadratic_y, 1.0, abs_tol=1e-4)
+        assert math.isclose(best_parameters["quadratic.x"], -2.0, abs_tol=1e-4)
+        assert math.isclose(best_parameters["quadratic.y"], 1.0, abs_tol=1e-4)
 
 
 def test_configuration_set_via_cmd_and_default_config(
@@ -185,8 +185,8 @@ def test_configuration_set_via_cmd_and_default_config(
         returns = OmegaConf.load(f"{sweep.temp_dir}/optimization_results.yaml")
         assert isinstance(returns, DictConfig)
         best_parameters = returns.ax
-        assert "quadratic_x" in best_parameters
-        assert "quadratic_y" in best_parameters
+        assert "quadratic.x" in best_parameters
+        assert "quadratic.y" in best_parameters
 
 
 @pytest.mark.parametrize(  # type: ignore
@@ -333,23 +333,5 @@ def test_jobs_configured_via_nested_config(
         assert returns.optimizer == "ax"
         assert len(returns) == 2
         best_parameters = returns.ax
-        assert math.isclose(best_parameters.quadratic_x_arg, 0.0, abs_tol=1e-4)
-        assert math.isclose(best_parameters.quadratic_y_arg, -1.0, abs_tol=1e-4)
-
-
-@pytest.mark.parametrize(  # type: ignore
-    "inp, str_to_replace, str_to_replace_with, expected",
-    [
-        ("apple", ".", "_", "apple"),
-        ("a.pple", ".", "_", "a_pple"),
-        ("a.p.ple", ".", "_", "a_p_ple"),
-        (r"a\.pple", ".", "_", "a.pple"),
-        (r"a.p\.pl.e", ".", "_", "a_p.pl_e"),
-    ],
-)
-def test_process_key_method(
-    inp: str, str_to_replace: str, str_to_replace_with: str, expected: str
-) -> None:
-    from hydra_plugins.hydra_ax_sweeper._core import normalize_key
-
-    assert normalize_key(inp, str_to_replace, str_to_replace_with) == expected
+        assert math.isclose(best_parameters["quadratic.x_arg"], 0.0, abs_tol=1e-4)
+        assert math.isclose(best_parameters["quadratic.y_arg"], -1.0, abs_tol=1e-4)

--- a/website/docs/plugins/ax_sweeper.md
+++ b/website/docs/plugins/ax_sweeper.md
@@ -61,11 +61,11 @@ In this example, we set the range of `x` parameter as an integer in the interval
 The values of the `x` and `y` parameters can also be set using the config file `plugins/hydra_ax_sweeper/example/conf/config.yaml`. For instance, the configuration corresponding to the commandline arguments is as follows:
 
 ```
-banana_x:
+banana.x:
  type: range
  bounds: [-5, 5]
 
-banana_y:
+banana.y:
  type: range
  bounds: [-5, 10.1]
 ```


### PR DESCRIPTION
Fixes #913.

<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Revert the use of _ to separate the path element in keys for the Ax

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

CI

## Related Issues and PRs

#913 
