### PR TITLE
Support converting parameters to primitive containers during instantiate

### DIFF
--- a/examples/instantiate/object/my_app.py
+++ b/examples/instantiate/object/my_app.py
@@ -2,6 +2,7 @@
 from omegaconf import DictConfig
 
 import hydra
+from hydra.utils import instantiate
 
 
 class DBConnection:
@@ -32,7 +33,7 @@ class PostgreSQLConnection(DBConnection):
 
 @hydra.main(config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
-    connection = hydra.utils.instantiate(cfg.db)
+    connection = instantiate(cfg.db)
     connection.connect()
 
 

--- a/news/1015.feature
+++ b/news/1015.feature
@@ -1,0 +1,1 @@
+Support for converting parameters to primitive containers during instantiation

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
-omegaconf>=2.1.0dev6
+omegaconf>=2.1.0dev7
 antlr4-python3-runtime==4.8
 importlib-resources;python_version<'3.9'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -267,3 +267,53 @@ class MappingConf:
 
     def __init__(self, dictionary: Optional[Dict[str, "MappingConf"]] = None):
         self.dictionary = dictionary
+
+
+@dataclass
+class SimpleDataClass:
+    a: Any = None
+    b: Any = None
+
+
+class SimpleClass:
+    a: Any = None
+    b: Any = None
+
+    def __init__(self, a: Any, b: Any) -> None:
+        self.a = a
+        self.b = b
+
+    def __eq__(self, other: Any) -> Any:
+        if isinstance(other, SimpleClass):
+            return self.a == other.a and self.b == other.b
+        return False
+
+
+@dataclass
+class SimpleClassPrimitiveConf:
+    _target_: str = "tests.SimpleClass"
+    _convert_: str = "partial"
+    a: Any = None
+    b: Any = None
+
+
+@dataclass
+class SimpleClassNonPrimitiveConf:
+    _target_: str = "tests.SimpleClass"
+    _convert_: str = "none"
+    a: Any = None
+    b: Any = None
+
+
+@dataclass
+class SimpleClassDefaultPrimitiveConf:
+    _target_: str = "tests.SimpleClass"
+    a: Any = None
+    b: Any = None
+
+
+@dataclass
+class NestedConf:
+    _target_: str = "tests.SimpleClass"
+    a: Any = User(name="a", age=1)
+    b: Any = User(name="b", age=2)

--- a/website/docs/patterns/instantiate_objects/overview.md
+++ b/website/docs/patterns/instantiate_objects/overview.md
@@ -15,28 +15,38 @@ Call/instantiate supports:
 - Constructing an object by calling the `__init__` method
 - Calling functions, static functions, class methods and other callable global objects
 
+<details><summary>Instantiate API (Expand for details)</summary>
+
 ```python
 def instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
     """
     :param config: An config object describing what to call and what params to use.
                    In addition to the parameters, the config must contain:
                    _target_ : target class or callable name (str)
+                   And may contain:
                    _recursive_: Construct nested objects as well (bool).
                                 True by default.
                                 may be overridden via a _recursive_ key in
                                 the kwargs
+                   _convert_: Conversion strategy
+                        none    : Passed objects are DictConfig and ListConfig, default
+                        partial : Passed objects are converted to dict and list, with
+                                  the exception of Structured Configs (and their fields).
+                        all     : Passed objects are dicts, lists and primitives without
+                                  a trace of OmegaConf containers
     :param args: Optional positional parameters pass-through
-    :param kwargs: Optional named parameters to override 
+    :param kwargs: Optional named parameters to override
                    parameters in the config object. Parameters not present
                    in the config objects are being passed as is to the target.
     :return: if _target_ is a class name: the instantiated object
              if _target_ is a callable: the return value of the call
     """
-    ...
 
 # Alias for instantiate
 call = instantiate
 ```
+
+</details><br/>
 
 The config passed to these functions must have a key called `_target_`, with the value of a fully qualified class name, class method, static method or callable.   
 Any additional parameters are passed as keyword arguments to the target.
@@ -90,7 +100,7 @@ print(opt)
 
 
 ### Recursive instantiation
- 
+Let's add a Dataset and a Trainer class. The trainer holds a Dataset and an Optimizer instances.
 ```python title="Additional classes"
 class Dataset:
     name: str
@@ -107,7 +117,7 @@ class Trainer:
         self.dataset = dataset
 ```
 
-
+With the following config, you can instantiate the whole thing with a single call:
 ```yaml title="Example config"
 trainer:
   _target_: my_app.Trainer
@@ -125,15 +135,11 @@ Hydra will instantiate nested objects recursively by default.
 ```python
 trainer = instantiate(cfg.trainer)
 print(trainer)
+# Trainer(
+#  optimizer=Optimizer(algo=SGD,lr=0.01),
+#  dataset=Dataset(name=Imagenet, path=/datasets/imagenet)
+# )
 ```
-Output:
-```python
-Trainer(
-  optimizer=Optimizer(algo=SGD,lr=0.01),
-  dataset=Dataset(name=Imagenet, path=/datasets/imagenet)
-)
-```
-
 You can override parameters for nested objects:
 ```python
 trainer = instantiate(
@@ -142,18 +148,15 @@ trainer = instantiate(
     dataset={"name": "cifar10", "path": "/datasets/cifar10"},
 )
 print(trainer)
-```
-Output:
-```python
-Trainer(
-  optimizer=Optimizer(algo=SGD,lr=0.3),
-  dataset=Dataset(name=cifar10, path=/datasets/cifar10)
-)
+# Trainer(
+#   optimizer=Optimizer(algo=SGD,lr=0.3),
+#   dataset=Dataset(name=cifar10, path=/datasets/cifar10)
+# )
 ```
 
 ### Disable recursive instantiation
 You can disable recursive instantiation by setting `_recursive_` to `False` in the config node or in the call-site
-Note that in that case you will receive an OmegaConf DictConfig instead of the real object.
+In that case the Trainer object will receive an OmegaConf DictConfig for nested dataset and optimizer instead of the instantiated objects.
 ```python
 optimizer = instantiate(cfg.trainer, _recursive_=False)
 print(optimizer)
@@ -169,3 +172,19 @@ Trainer(
     '_target_': 'my_app.Dataset', 'name': 'Imagenet', 'path': '/datasets/imagenet'
   }
 )
+```
+
+## Parameter conversion strategies
+By default, the parameters passed to the target are either primitives (int, float, bool etc) or                                                                                                 
+OmegaConf containers (DictConfig, ListConfig).
+OmegaConf containers have many advantages over primitive dicts and lists but in some cases 
+it's desired to pass a real dicts and lists (for example, for performance reasons).
+
+You can change the parameter conversion strategy using the `_convert_` parameter (in your config or the call-site).
+Supported values are:
+
+- `none` : Default behavior, Use OmegaConf containers
+- `partial` : Convert OmegaConf containers to dict and list, except Structured Configs.
+- `all` : Convert everything to primitive containers
+
+Note that the conversion strategy applies to all the parameters passed to the target.


### PR DESCRIPTION
Closes #1015 

There is an optional new `_convert_` override per node that can change this behavior. see description in #1015.
The default behavior is to convert to a primitive container (ListConfig, DictConfig -> list, dict).