### PR TITLE
Add option to omit `-Werror` flag for plugin test

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -29,6 +29,9 @@ INSTALL_COMMAND = (
 # The list ['ALL'] indicates all plugins
 PLUGINS = os.environ.get("PLUGINS", "ALL").split(",")
 
+# Allow skip checking for warnings for specific plugins
+PLUGINS_WITH_WARNINGS = os.environ.get("PLUGINS_WITH_WARNINGS", "").split(",")
+
 SKIP_CORE_TESTS = "0"
 SKIP_CORE_TESTS = os.environ.get("SKIP_CORE_TESTS", SKIP_CORE_TESTS) != "0"
 FIX = os.environ.get("FIX", "0") == "1"
@@ -53,6 +56,7 @@ def get_current_os() -> str:
 print(f"Operating system\t:\t{get_current_os()}")
 print(f"NOX_PYTHON_VERSIONS\t:\t{PYTHON_VERSIONS}")
 print(f"PLUGINS\t\t\t:\t{PLUGINS}")
+print(f"PLUGINS_WITH_WARNINGS\t:\t{PLUGINS_WITH_WARNINGS}")
 print(f"SKIP_CORE_TESTS\t\t:\t{SKIP_CORE_TESTS}")
 print(f"FIX\t\t\t:\t{FIX}")
 print(f"VERBOSE\t\t\t:\t{VERBOSE}")
@@ -404,7 +408,12 @@ def test_plugins_in_directory(
     for plugin in selected_plugin:
         # install all other plugins that are compatible with the current Python version
         session.chdir(os.path.join(BASE, directory, plugin.path))
-        run_pytest(session)
+        if plugin.path in PLUGINS_WITH_WARNINGS:
+            args = pytest_args(".")
+            args = [x for x in args if x != "-Werror"]
+            session.run(*args, silent=SILENT)
+        else:
+            run_pytest(session)
 
 
 @nox.session(python="3.8")


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Some plugins (ok only ray launcher for now :P )  have underlying dependency that yields warnings and there's not much the plugin can do. 
So for now i want to add this option to skip `-Werror` when warnings expected.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan
Test *with* the flag

```
$ PLUGINS_WITH_WARNINGS=hydra_colorlog PLUGINS=hydra_colorlog nox -s test_plugins-3.6
Operating system        :       MacOS
NOX_PYTHON_VERSIONS     :       ['3.6', '3.7', '3.8']
PLUGINS                 :       ['hydra_colorlog']
PLUGINS_WITH_WARNINGS   :       ['hydra_colorlog']
SKIP_CORE_TESTS         :       False
FIX                     :       False
VERBOSE                 :       0
INSTALL_EDITABLE_MODE   :       0
nox > Running session test_plugins-3.6
nox > Creating virtual environment (virtualenv) using python3.6 in .nox/test_plugins-3-6
nox > python -m pip install --upgrade setuptools pip
nox > pip install pytest
nox > cd /Users/jieru/workspace/hydra-fork/hydra
nox > pip install .
nox > python /Users/jieru/workspace/hydra-fork/hydra/plugins/hydra_colorlog/setup.py --name --classifiers
nox > Deselecting hydra_ax_sweeper: User request
nox > Deselecting hydra_joblib_launcher: User request
nox > Deselecting hydra_nevergrad_sweeper: User request
nox > Deselecting hydra_ray_launcher: User request
nox > Deselecting hydra_rq_launcher: User request
nox > Deselecting hydra_submitit_launcher: User request
nox > pip install plugins/hydra_colorlog
nox > python -c from hydra import main
nox > python -c import hydra_plugins.hydra_colorlog
nox > pytest -Werror tests
nox > cd /Users/jieru/workspace/hydra-fork/hydra/plugins/hydra_colorlog
nox > pytest .
nox > Session test_plugins-3.6 was successful.

```

Test *without* the flag

```
$ PLUGINS=hydra_colorlog nox -s test_plugins
\Operating system       :       MacOS
NOX_PYTHON_VERSIONS     :       ['3.6', '3.7', '3.8']
PLUGINS                 :       ['hydra_colorlog']
PLUGINS_WITH_WARNINGS   :       ['']
SKIP_CORE_TESTS         :       False
FIX                     :       False
VERBOSE                 :       0
INSTALL_EDITABLE_MODE   :       0
nox > Running session test_plugins-3.6
nox > Creating virtual environment (virtualenv) using python3.6 in .nox/test_plugins-3-6
nox > python -m pip install --upgrade setuptools pip
nox > pip install pytest
nox > cd /Users/jieru/workspace/hydra-fork/hydra
nox > pip install .
nox > python /Users/jieru/workspace/hydra-fork/hydra/plugins/hydra_colorlog/setup.py --name --classifiers
nox > Deselecting hydra_ax_sweeper: User request
nox > Deselecting hydra_joblib_launcher: User request
nox > Deselecting hydra_nevergrad_sweeper: User request
nox > Deselecting hydra_ray_launcher: User request
nox > Deselecting hydra_rq_launcher: User request
nox > Deselecting hydra_submitit_launcher: User request
nox > pip install plugins/hydra_colorlog
nox > python -c from hydra import main
nox > python -c import hydra_plugins.hydra_colorlog
nox > pytest -Werror tests
nox > cd /Users/jieru/workspace/hydra-fork/hydra/plugins/hydra_colorlog
nox > pytest -Werror .
nox > Session test_plugins-3.6 was successful.

```

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
