### PR TITLE
Recursive Defaults List support

### DIFF
--- a/examples/advanced/automatic_config_schema/conf/config.yaml
+++ b/examples/advanced/automatic_config_schema/conf/config.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - db: mysql

--- a/examples/advanced/automatic_config_schema/conf/db/mysql.yaml
+++ b/examples/advanced/automatic_config_schema/conf/db/mysql.yaml
@@ -1,0 +1,10 @@
+# @package _group_
+defaults:
+  - schema/db/mysql
+  - _self_
+
+host: localhost
+port: 3306
+driver: mysql
+user: omry
+password: secret

--- a/examples/advanced/automatic_config_schema/conf/db/postgresql.yaml
+++ b/examples/advanced/automatic_config_schema/conf/db/postgresql.yaml
@@ -1,0 +1,11 @@
+# @package _group_
+defaults:
+  - schema/db/postgresql
+  - _self_
+
+host: localhost
+port: 5432
+driver: postgresql
+user: postgre_user
+password: secret
+timeout: 10

--- a/examples/advanced/automatic_config_schema/my_app.py
+++ b/examples/advanced/automatic_config_schema/my_app.py
@@ -1,0 +1,40 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from dataclasses import dataclass
+
+from omegaconf import DictConfig, OmegaConf
+
+import hydra
+from hydra.core.config_store import ConfigStore
+
+
+@dataclass
+class MySQLConfig:
+    host: str
+    port: int
+    user: str
+    password: str
+    driver: str = "mysql"
+
+
+@dataclass
+class PostGreSQLConfig:
+    host: str
+    port: int
+    timeout: int
+    user: str
+    password: str
+    driver: str = "postgresql"
+
+
+cs = ConfigStore.instance()
+cs.store(group="schema/db", name="mysql", node=MySQLConfig, package="db")
+cs.store(group="schema/db", name="postgresql", node=PostGreSQLConfig, package="db")
+
+
+@hydra.main(config_path="conf", config_name="config")
+def my_app(cfg: DictConfig) -> None:
+    print(OmegaConf.to_yaml(cfg))
+
+
+if __name__ == "__main__":
+    my_app()

--- a/examples/patterns/specializing_config/conf/config.yaml
+++ b/examples/patterns/specializing_config/conf/config.yaml
@@ -1,5 +1,5 @@
 defaults:
   - dataset: imagenet
   - model: alexnet
-  - dataset_model: ${defaults.0.dataset}_${defaults.1.model}
+  - dataset_model: ${dataset}_${model}
     optional: true

--- a/hydra/_internal/core_plugins/file_config_source.py
+++ b/hydra/_internal/core_plugins/file_config_source.py
@@ -40,11 +40,15 @@ class FileConfigSource(ConfigSource):
             )
             f.seek(0)
             cfg = OmegaConf.load(f)
+            defaults_list = self._extract_defaults_list(
+                config_path=config_path, cfg=cfg
+            )
             return ConfigResult(
                 config=self._embed_config(cfg, header["package"]),
                 path=f"{self.scheme()}://{self.path}",
                 provider=self.provider,
                 header=header,
+                defaults_list=defaults_list,
             )
 
     def available(self) -> bool:

--- a/hydra/_internal/core_plugins/importlib_resources_config_source.py
+++ b/hydra/_internal/core_plugins/importlib_resources_config_source.py
@@ -41,11 +41,15 @@ class ImportlibResourcesConfigSource(ConfigSource):
             )
             f.seek(0)
             cfg = OmegaConf.load(f)
+            defaults_list = self._extract_defaults_list(
+                config_path=config_path, cfg=cfg
+            )
             return ConfigResult(
                 config=self._embed_config(cfg, header["package"]),
                 path=f"{self.scheme()}://{self.path}",
                 provider=self.provider,
                 header=header,
+                defaults_list=defaults_list,
             )
 
     def available(self) -> bool:

--- a/hydra/_internal/core_plugins/structured_config_source.py
+++ b/hydra/_internal/core_plugins/structured_config_source.py
@@ -50,12 +50,17 @@ class StructuredConfigSource(ConfigSource):
             is_primary_config=is_primary_config,
             package_override=package_override,
         )
+        defaults_list = self._extract_defaults_list(
+            config_path=config_path, cfg=ret.node
+        )
         cfg = self._embed_config(ret.node, header["package"])
+
         return ConfigResult(
             config=cfg,
             path=f"{self.scheme()}://{self.path}",
             provider=provider,
             header=header,
+            defaults_list=defaults_list,
         )
 
     def available(self) -> bool:

--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -1,0 +1,538 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import copy
+from dataclasses import dataclass
+from itertools import filterfalse
+from textwrap import dedent
+from typing import Dict, List, Optional, Union
+
+from omegaconf import II, DictConfig, OmegaConf
+
+from hydra._internal.config_repository import IConfigRepository
+from hydra.core import DefaultElement
+from hydra.core.object_type import ObjectType
+from hydra.core.override_parser.types import Override
+from hydra.errors import ConfigCompositionException, MissingConfigException
+
+
+@dataclass(frozen=True, eq=True)
+class DeleteKey:
+    fqgn: str
+    config_name: Optional[str]
+    must_delete: bool
+
+    def __repr__(self) -> str:
+        if self.config_name is None:
+            return self.fqgn
+        else:
+            return f"{self.fqgn}={self.config_name}"
+
+
+@dataclass
+class DefaultsList:
+    original: List[DefaultElement]
+    effective: List[DefaultElement]
+
+
+def compute_element_defaults_list(
+    element: DefaultElement,
+    repo: IConfigRepository,
+    skip_missing: bool,
+) -> List[DefaultElement]:
+    group_to_choice = OmegaConf.create({})
+    delete_groups: Dict[DeleteKey, int] = {}
+    ret = _compute_element_defaults_list_impl(
+        element=element,
+        group_to_choice=group_to_choice,
+        delete_groups=delete_groups,
+        skip_missing=skip_missing,
+        repo=repo,
+    )
+
+    _post_process_deletes(ret, delete_groups)
+    return ret
+
+
+def _post_process_deletes(
+    ret: List[DefaultElement],
+    delete_groups: Dict[DeleteKey, int],
+) -> None:
+    # verify all deletions deleted something
+    for g, c in delete_groups.items():
+        if c == 0 and g.must_delete:
+            raise ConfigCompositionException(
+                f"Could not delete. No match for '{g}' in the defaults list."
+            )
+
+    # remove delete overrides
+    ret[:] = filterfalse(lambda x: x.is_delete, ret)
+
+
+def expand_defaults_list(
+    defaults: List[DefaultElement],
+    skip_missing: bool,
+    repo: IConfigRepository,
+) -> List[DefaultElement]:
+    return _expand_defaults_list(
+        self_element=None,
+        defaults=defaults,
+        skip_missing=skip_missing,
+        repo=repo,
+    )
+
+
+def _update_known_state(
+    d: DefaultElement,
+    group_to_choice: DictConfig,
+    delete_groups: Dict[DeleteKey, int],
+) -> None:
+    fqgn = d.fully_qualified_group_name()
+    if fqgn is None:
+        return
+
+    is_overridden = fqgn in group_to_choice
+
+    if d.config_group is not None:
+        if (
+            fqgn not in group_to_choice
+            and not d.is_delete
+            and d.config_name not in ("_self_", "_keep_")
+            and not is_matching_deletion(delete_groups=delete_groups, d=d)
+        ):
+            group_to_choice[fqgn] = d.config_name
+
+    if d.is_delete:
+        if is_overridden:
+            d.is_delete = False
+            d.config_name = group_to_choice[fqgn]
+        else:
+            delete_key = DeleteKey(
+                fqgn,
+                d.config_name if d.config_name != "_delete_" else None,
+                must_delete=d.from_override,
+            )
+            if delete_key not in delete_groups:
+                delete_groups[delete_key] = 0
+
+
+def _expand_defaults_list(
+    self_element: Optional[DefaultElement],
+    defaults: List[DefaultElement],
+    skip_missing: bool,
+    repo: IConfigRepository,
+) -> List[DefaultElement]:
+    group_to_choice = OmegaConf.create({})
+    delete_groups: Dict[DeleteKey, int] = {}
+    for d in reversed(defaults):
+        _update_known_state(
+            d,
+            group_to_choice=group_to_choice,
+            delete_groups=delete_groups,
+        )
+
+    dl = DefaultsList(
+        original=copy.deepcopy(defaults),
+        effective=copy.deepcopy(defaults),
+    )
+    ret = _expand_defaults_list_impl(
+        self_element=self_element,
+        defaults_list=dl,
+        group_to_choice=group_to_choice,
+        delete_groups=delete_groups,
+        skip_missing=skip_missing,
+        repo=repo,
+    )
+
+    _post_process_deletes(ret, delete_groups)
+
+    return ret
+
+
+def _validate_self(element: DefaultElement, defaults: DefaultsList) -> None:
+    # check that self is present only once
+    has_self = False
+    for d in defaults.effective:
+        if d.config_name == "_self_":
+            if has_self is True:
+                raise ConfigCompositionException(
+                    f"Duplicate _self_ defined in {element.config_path()}"
+                )
+            has_self = True
+            assert d.config_group is None
+            d.config_group = element.config_group
+            d.package = element.package
+            d.parent = element.parent
+
+    if not has_self:
+        me = copy.deepcopy(element)
+        me.config_name = "_self_"
+        me.from_override = False
+        me.parent = element.parent
+        defaults.effective.insert(0, me)
+
+
+def _compute_element_defaults_list_impl(
+    element: DefaultElement,
+    group_to_choice: DictConfig,
+    delete_groups: Dict[DeleteKey, int],
+    skip_missing: bool,
+    repo: IConfigRepository,
+) -> List[DefaultElement]:
+    deleted = delete_if_matching(delete_groups, element)
+    if deleted:
+        return []
+
+    if element.config_name == "???":
+        if skip_missing:
+            element.set_skip_load("missing_skipped")
+            return [element]
+        else:
+            if element.config_group is not None:
+                options = repo.get_group_options(
+                    element.config_group, results_filter=ObjectType.CONFIG
+                )
+                opt_list = "\n".join(["\t" + x for x in options])
+                msg = (
+                    f"You must specify '{element.config_group}', e.g, {element.config_group}=<OPTION>"
+                    f"\nAvailable options:"
+                    f"\n{opt_list}"
+                )
+            else:
+                msg = f"You must specify '{element.config_group}', e.g, {element.config_group}=<OPTION>"
+
+            raise ConfigCompositionException(msg)
+
+    loaded = repo.load_config(
+        config_path=element.config_path(),
+        is_primary_config=element.primary,
+    )
+
+    if loaded is None:
+        if element.optional:
+            element.set_skip_load("missing_optional_config")
+            return [element]
+        else:
+            missing_config_error(repo=repo, element=element)
+    else:
+        original = copy.deepcopy(loaded.defaults_list)
+        effective = copy.deepcopy(loaded.defaults_list)
+
+    defaults = DefaultsList(original=original, effective=effective)
+    _validate_self(element, defaults)
+
+    return _expand_defaults_list_impl(
+        self_element=element,
+        defaults_list=defaults,
+        group_to_choice=group_to_choice,
+        delete_groups=delete_groups,
+        skip_missing=skip_missing,
+        repo=repo,
+    )
+
+
+def _find_match_before(
+    defaults: List[DefaultElement], like: DefaultElement
+) -> Optional[DefaultElement]:
+    fqgn = like.fully_qualified_group_name()
+    for d2 in defaults:
+        if d2 == like:
+            break
+        if d2.fully_qualified_group_name() == fqgn:
+            return d2
+    return None
+
+
+def _verify_no_add_conflicts(defaults: List[DefaultElement]) -> None:
+    for d in reversed(defaults):
+        if d.from_override and not d.skip_load and not d.is_delete:
+            fqgn = d.fully_qualified_group_name()
+            match = _find_match_before(defaults, d)
+            if d.is_add and match is not None:
+                raise ConfigCompositionException(
+                    f"Could not add '{fqgn}={d.config_name}'. '{fqgn}' is already in the defaults list."
+                )
+            if not d.is_add and match is None:
+                msg = (
+                    f"Could not override '{fqgn}'. No match in the defaults list."
+                    f"\nTo append to your default list use +{fqgn}={d.config_name}"
+                )
+                raise ConfigCompositionException(msg)
+
+
+def _process_renames(defaults: List[DefaultElement]) -> None:
+    while True:
+        last_rename_index = -1
+        for idx, d in reversed(list(enumerate(defaults))):
+            if d.is_package_rename():
+                last_rename_index = idx
+                break
+        if last_rename_index != -1:
+            rename = defaults.pop(last_rename_index)
+            renamed = False
+            for d in defaults:
+                if is_matching(rename, d):
+                    d.package = rename.get_subject_package()
+                    renamed = True
+            if not renamed:
+                raise ConfigCompositionException(
+                    f"Could not rename package. "
+                    f"No match for '{rename.config_group}@{rename.package}' in the defaults list"
+                )
+        else:
+            break
+
+
+def delete_if_matching(delete_groups: Dict[DeleteKey, int], d: DefaultElement) -> bool:
+    return is_matching_deletion(
+        delete_groups=delete_groups, d=d, mark_item_as_deleted=True
+    )
+
+
+def is_matching_deletion(
+    delete_groups: Dict[DeleteKey, int],
+    d: DefaultElement,
+    mark_item_as_deleted: bool = False,
+) -> bool:
+    matched = False
+    for delete in delete_groups:
+        if delete.fqgn == d.fully_qualified_group_name():
+            if delete.config_name is None:
+                # fqdn only
+                matched = True
+                if mark_item_as_deleted:
+                    delete_groups[delete] += 1
+                    d.is_deleted = True
+                    d.set_skip_load("deleted_from_list")
+            else:
+                if delete.config_name == d.config_name:
+                    matched = True
+                    if mark_item_as_deleted:
+                        delete_groups[delete] += 1
+                        d.is_deleted = True
+                        d.set_skip_load("deleted_from_list")
+    return matched
+
+
+def _expand_defaults_list_impl(
+    self_element: Optional[DefaultElement],
+    defaults_list: DefaultsList,
+    group_to_choice: DictConfig,
+    delete_groups: Dict[DeleteKey, int],
+    skip_missing: bool,
+    repo: IConfigRepository,
+) -> List[DefaultElement]:
+
+    # list order is determined by first instance from that config group
+    # selected config group is determined by the last override
+
+    deferred_overrides = []
+    defaults = defaults_list.effective
+
+    ret: List[Union[DefaultElement, List[DefaultElement]]] = []
+    for d in reversed(defaults):
+        _update_known_state(
+            d, group_to_choice=group_to_choice, delete_groups=delete_groups
+        )
+
+        fqgn = d.fully_qualified_group_name()
+        if d.config_name == "_self_":
+            if self_element is None:
+                raise ConfigCompositionException(
+                    "self_name is not specified and defaults list contains a _self_ item"
+                )
+            d = copy.deepcopy(d)
+            # override self_name
+            if fqgn is not None and fqgn in group_to_choice:
+                d.config_name = group_to_choice[fqgn]
+            else:
+                d.config_name = self_element.config_name
+            added_sublist = [d]
+        elif d.is_package_rename():
+            added_sublist = [d]  # defer rename
+        elif d.is_delete:
+            added_sublist = [d]
+        elif d.from_override:
+            added_sublist = [d]  # defer override processing
+            deferred_overrides.append(d)
+        elif d.is_interpolation():
+            deferred_overrides.append(d)
+            added_sublist = [d]  # defer interpolation
+        else:
+            if delete_if_matching(delete_groups, d):
+                added_sublist = [d]
+            else:
+                if fqgn is not None and fqgn in group_to_choice:
+                    d.config_name = group_to_choice[fqgn]
+                    if d.is_delete:
+                        d.is_delete = False
+
+                added_sublist = _compute_element_defaults_list_impl(
+                    element=d,
+                    group_to_choice=group_to_choice,
+                    delete_groups=delete_groups,
+                    skip_missing=skip_missing,
+                    repo=repo,
+                )
+
+        ret.append(added_sublist)
+
+    ret.reverse()
+    result: List[DefaultElement] = [item for sublist in ret for item in sublist]  # type: ignore
+
+    _process_renames(result)
+
+    # process deletes
+    for element in reversed(result):
+        if not element.is_delete:
+            delete_if_matching(delete_groups, element)
+
+    _verify_no_add_conflicts(result)
+
+    # prepare a local group_to_choice with the defaults to support
+    # legacy interpolations like ${defaults.1.a}
+    # Support for this will be removed in Hydra 1.2
+    group_to_choice2 = copy.deepcopy(group_to_choice)
+    group_to_choice2.defaults = []
+    for d in defaults_list.original:
+        if d.config_group is not None:
+            group_to_choice2.defaults.append({d.config_group: II(d.config_group)})
+        else:
+            group_to_choice2.defaults.append(d.config_name)
+
+    deferred_overrides = deduplicate_deferred(deferred_overrides, result)
+
+    # expand deferred
+    for d in deferred_overrides:
+        if d.is_interpolation():
+            d.resolve_interpolation(group_to_choice2)
+
+        item_defaults = _compute_element_defaults_list_impl(
+            element=d,
+            group_to_choice=group_to_choice,
+            delete_groups=delete_groups,
+            skip_missing=skip_missing,
+            repo=repo,
+        )
+        index = result.index(d)
+        result[index:index] = item_defaults
+
+    dedupped_defaults = _deduplicate(result)
+    return dedupped_defaults
+
+
+def deduplicate_deferred(
+    deferred: List[DefaultElement],
+    defaults_list: List[DefaultElement],
+) -> List[DefaultElement]:
+    # this is a bit hacky. deferred overrides that exists in current defaults list
+    # were already processed via the known state and should not be processed again
+    res = []
+    seen_groups = set()
+    for d in defaults_list:
+        if d.config_group is not None:
+            seen_groups.add(d.fully_qualified_group_name())
+
+    for de in deferred:
+        if not de.from_override or de.is_add:
+            res.append(de)
+        else:
+            if not de.fully_qualified_group_name() in seen_groups:
+                res.append(de)
+    return res
+
+
+def _deduplicate(defaults_list: List[DefaultElement]) -> List[DefaultElement]:
+    deduped = []
+    seen_groups = set()
+    for d in defaults_list:
+        if d.config_group is not None:
+            fqgn = d.fully_qualified_group_name()
+            if fqgn not in seen_groups:
+                seen_groups.add(fqgn)
+                deduped.append(d)
+        else:
+            deduped.append(d)
+    return deduped
+
+
+def missing_config_error(repo: IConfigRepository, element: DefaultElement) -> None:
+    options = None
+    if element.config_group is not None:
+        options = repo.get_group_options(element.config_group, ObjectType.CONFIG)
+        opt_list = "\n".join(["\t" + x for x in options])
+        msg = (
+            f"Could not find '{element.config_name}' in the config group '{element.config_group}'"
+            f"\nAvailable options:\n{opt_list}\n"
+        )
+    else:
+        msg = dedent(
+            f"""\
+        Could not load {element.config_path()}.
+        """
+        )
+
+    descs = []
+    for src in repo.get_sources():
+        descs.append(f"\t{repr(src)}")
+    lines = "\n".join(descs)
+    msg += "\nConfig search path:" + f"\n{lines}"
+
+    raise MissingConfigException(
+        missing_cfg_file=element.config_path(),
+        message=msg,
+        options=options,
+    )
+
+
+def is_matching(rename: DefaultElement, other: DefaultElement) -> bool:
+    if rename.config_group != other.config_group:
+        return False
+    if rename.package == other.package:
+        return True
+    return False
+
+
+def convert_overrides_to_defaults(
+    parsed_overrides: List[Override],
+) -> List[DefaultElement]:
+    ret = []
+    for override in parsed_overrides:
+        if override.is_add() and override.is_package_rename():
+            raise ConfigCompositionException(
+                "Add syntax does not support package rename, remove + prefix"
+            )
+
+        value = override.value()
+        if override.is_delete() and value is None:
+            value = "_delete_"
+
+        if not isinstance(value, str):
+            raise ConfigCompositionException(
+                "Defaults list supported delete syntax is in the form"
+                " ~group and ~group=value, where value is a group name (string)"
+            )
+
+        if override.is_package_rename():
+            default = DefaultElement(
+                config_group=override.key_or_group,
+                config_name=value,
+                package=override.pkg1,
+                rename_package_to=override.pkg2,
+                from_override=True,
+                parent="overrides",
+            )
+        else:
+            default = DefaultElement(
+                config_group=override.key_or_group,
+                config_name=value,
+                package=override.get_subject_package(),
+                from_override=True,
+                parent="overrides",
+            )
+
+        if override.is_delete():
+            default.is_delete = True
+
+        if override.is_add():
+            default.is_add = True
+        ret.append(default)
+    return ret

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -442,11 +442,16 @@ def get_args_parser() -> argparse.ArgumentParser:
         help="Run multiple jobs with the configured launcher and sweeper",
     )
 
+    # defer building the completion help string until we actually need to render it
+    class LazyCompletionHelp:
+        def __repr__(self) -> str:
+            return f"Install or Uninstall shell completion:\n{_get_completion_help()}"
+
     parser.add_argument(
         "--shell-completion",
         "-sc",
         action="store_true",
-        help=f"Install or Uninstall shell completion:\n{_get_completion_help()}",
+        help=LazyCompletionHelp(),  # type: ignore
     )
 
     parser.add_argument(

--- a/hydra/conf/__init__.py
+++ b/hydra/conf/__init__.py
@@ -106,6 +106,9 @@ class RuntimeConf:
 
 @dataclass
 class HydraConf:
+
+    defaults: List[Any] = field(default_factory=lambda: hydra_defaults.copy())
+
     # Normal run output configuration
     run: RunDir = RunDir()
     # Multi-run output configuration
@@ -134,6 +137,9 @@ class HydraConf:
     # Those lists will contain runtime overrides
     overrides: OverridesConf = OverridesConf()
 
+    # the resulting defaults list
+    composition_trace: List[Any] = MISSING
+
     job: JobConf = JobConf()
 
     # populated at runtime
@@ -150,13 +156,11 @@ class HydraConf:
     verbose: Any = False
 
 
-ConfigStore.instance().store(
+cstore = ConfigStore.instance()
+
+cstore.store(
     name="hydra_config",
-    node={
-        # Hydra composition defaults
-        "defaults": hydra_defaults,
-        # Hydra config
-        "hydra": HydraConf,
-    },
+    node=HydraConf,
+    package="hydra",
     provider="hydra",
 )

--- a/hydra/core/__init__.py
+++ b/hydra/core/__init__.py
@@ -1,1 +1,149 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import re
+import warnings
+from dataclasses import dataclass
+from textwrap import dedent
+from typing import Optional, Pattern
+
+from omegaconf import MISSING, AnyNode, DictConfig, OmegaConf
+
+_legacy_interpolation_pattern: Pattern[str] = re.compile(r"\${defaults\.\d\.")
+
+
+@dataclass
+class DefaultElement:
+    config_name: str
+    config_group: Optional[str] = None
+    optional: bool = False
+    package: Optional[str] = None
+
+    parent: Optional[str] = None
+
+    # used in package rename
+    rename_package_to: Optional[str] = None
+
+    # True for default elements that are from overrides.
+    # Those have somewhat different semantics
+    from_override: bool = False
+
+    # set to True for external overrides with +
+    is_add: bool = False
+
+    # is a delete indicator, used as input
+    is_delete: bool = False
+
+    # is this default deleted? used as output
+    is_deleted: bool = False
+
+    # True for the primary config (the one in compose() or @hydra.main())
+    primary: bool = False
+
+    skip_load: bool = False
+    skip_load_reason: str = ""
+
+    # If loaded, the search path it was loaded from
+    search_path: str = MISSING
+
+    def config_path(self) -> str:
+        assert self.config_name is not None
+        if self.config_group is not None:
+            return f"{self.config_group}/{self.config_name}"
+        else:
+            return self.config_name
+
+    def fully_qualified_group_name(self) -> Optional[str]:
+        if self.config_group is None:
+            return None
+        if self.package is not None:
+            return f"{self.config_group}@{self.package}"
+        else:
+            return f"{self.config_group}"
+
+    def __repr__(self) -> str:
+        package = self.package
+        if self.is_package_rename():
+            if self.package is not None:
+                package = f"{self.package}:{self.rename_package_to}"
+            else:
+                package = f":{self.rename_package_to}"
+
+        if self.config_group is None:
+            if package is not None:
+                ret = f"@{package}={self.config_name}"
+            else:
+                ret = f"{self.config_name}"
+        else:
+            if package is not None:
+                ret = f"{self.config_group}@{package}={self.config_name}"
+            else:
+                ret = f"{self.config_group}={self.config_name}"
+
+        if self.is_add:
+            ret = f"+{ret}"
+        if self.is_delete:
+            ret = f"~{ret}"
+
+        if self.parent is not None:
+            ret = f"{ret} (parent:{self.parent})"
+
+        flags = []
+        flag_names = [
+            "primary",
+            "is_delete",
+            "is_deleted",
+            "optional",
+            "from_override",
+            "is_add",
+        ]
+        for flag in flag_names:
+            if getattr(self, flag):
+                flags.append(flag)
+
+        if self.skip_load:
+            flags.append(f"skip-load:{self.skip_load_reason}")
+
+        if len(flags) > 0:
+            ret = f"{ret} ({','.join(flags)})"
+
+        return ret
+
+    def is_package_rename(self) -> bool:
+        return self.rename_package_to is not None
+
+    def get_subject_package(self) -> Optional[str]:
+        return (
+            self.package if self.rename_package_to is None else self.rename_package_to
+        )
+
+    def is_interpolation(self) -> bool:
+        """
+        True if config_name is an interpolation
+        """
+        if isinstance(self.config_name, str):
+            node = AnyNode(self.config_name)
+            return node._is_interpolation()
+        else:
+            return False
+
+    def resolve_interpolation(self, group_to_choice: DictConfig) -> None:
+        assert self.config_group is not None
+        if self.config_name is not None:
+            if re.match(_legacy_interpolation_pattern, self.config_name) is not None:
+                msg = dedent(
+                    f"""
+            Defaults list element '{self.fully_qualified_group_name()}={self.config_name}' \
+is using a deprecated interpolation form.
+            See http://hydra.cc/docs/next/upgrades/1.0_to_1.1/defaults_list_interpolation for migration information.
+            """
+                )
+                warnings.warn(
+                    category=UserWarning,
+                    message=msg,
+                )
+        node = OmegaConf.create({self.config_group: self.config_name})
+        node._set_parent(group_to_choice)
+        self.config_name = node[self.config_group]
+
+    def set_skip_load(self, reason: str) -> None:
+        self.skip_load = True
+        self.skip_load_reason = reason

--- a/hydra/core/config_loader.py
+++ b/hydra/core/config_loader.py
@@ -13,10 +13,14 @@ from hydra.types import RunMode
 
 @dataclass
 class LoadTrace:
-    filename: str
-    path: Optional[str]
-    provider: Optional[str]
+    config_group: Optional[str] = None
+    config_name: Optional[str] = None
+    package: Optional[str] = None
+    parent: Optional[str] = None
+    search_path: Optional[str] = None
+    provider: Optional[str] = None
     schema_provider: Optional[str] = None
+    skip_reason: Optional[str] = None
 
 
 class ConfigLoader(ABC):
@@ -46,10 +50,6 @@ class ConfigLoader(ABC):
         ...
 
     @abstractmethod
-    def get_load_history(self) -> List[LoadTrace]:
-        ...
-
-    @abstractmethod
     def get_sources(self) -> List[ConfigSource]:
         ...
 
@@ -61,8 +61,4 @@ class ConfigLoader(ABC):
     def get_group_options(
         self, group_name: str, results_filter: Optional[ObjectType] = ObjectType.CONFIG
     ) -> List[str]:
-        ...
-
-    @abstractmethod
-    def ensure_main_config_source_available(self) -> None:
         ...

--- a/hydra/core/hydra_config.py
+++ b/hydra/core/hydra_config.py
@@ -14,7 +14,8 @@ class HydraConfig(metaclass=Singleton):
     def set_config(self, cfg: DictConfig) -> None:
         assert cfg is not None
         OmegaConf.set_readonly(cfg.hydra, True)
-        assert OmegaConf.get_type(cfg, "hydra") == HydraConf
+        hydra_node_type = OmegaConf.get_type(cfg, "hydra")
+        assert hydra_node_type is not None and issubclass(hydra_node_type, HydraConf)
         # THis is emulating a node that is hidden.
         # It's quiet a hack but it will be much better once
         # https://github.com/omry/omegaconf/issues/280 is done

--- a/hydra/test_utils/configs/completion_test/config.yaml
+++ b/hydra/test_utils/configs/completion_test/config.yaml
@@ -1,5 +1,5 @@
 defaults:
-  - group: null
+  - ~group
 
 # a mapping item
 dict:

--- a/hydra/test_utils/configs/overriding_logging_default.yaml
+++ b/hydra/test_utils/configs/overriding_logging_default.yaml
@@ -1,4 +1,4 @@
 defaults:
-  - hydra/launcher: null
+  - ~hydra/launcher
   - hydra/hydra_logging: hydra_debug
   - hydra/job_logging: disabled

--- a/hydra/test_utils/configs/removing-hydra-launcher-default.yaml
+++ b/hydra/test_utils/configs/removing-hydra-launcher-default.yaml
@@ -1,2 +1,2 @@
 defaults:
-  - hydra/launcher: null
+  - ~hydra/launcher

--- a/news/1080.api_change
+++ b/news/1080.api_change
@@ -1,0 +1,1 @@
+ConfigSourcePlugins needs to be modified to support recursive defaults, see link for details

--- a/news/1089.api_change
+++ b/news/1089.api_change
@@ -1,0 +1,1 @@
+Changes to config group deletion syntax from the command line and config files. See link for details.

--- a/plugins/hydra_ax_sweeper/tests/config/config.yaml
+++ b/plugins/hydra_ax_sweeper/tests/config/config.yaml
@@ -1,7 +1,7 @@
 defaults:
   - hydra/sweeper: ax
-  - quadratic: null
-  - params: null
+  - ~quadratic
+  - ~params
 
 quadratic:
   x: ???

--- a/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
+++ b/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
@@ -1,4 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from typing import Any
+
 import pytest
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
@@ -53,14 +55,14 @@ class TestJoblibLauncherIntegration(IntegrationTestSuite):
     pass
 
 
-def test_example_app(hydra_sweep_runner: TSweepRunner) -> None:
+def test_example_app(hydra_sweep_runner: TSweepRunner, tmpdir: Any) -> None:
     with hydra_sweep_runner(
         calling_file="example/my_app.py",
         calling_module=None,
         task_function=None,
         config_path=None,
         config_name="config",
-        overrides=["task=1,2,3,4"],
+        overrides=["task=1,2,3,4", f"hydra.sweep.dir={tmpdir}"],
     ) as sweep:
         overrides = {("task=1",), ("task=2",), ("task=3",), ("task=4",)}
 

--- a/tests/standalone_apps/namespace_pkg_config_source_test/some_namespace/namespace_test/dir/config_with_defaults_list.yaml
+++ b/tests/standalone_apps/namespace_pkg_config_source_test/some_namespace/namespace_test/dir/config_with_defaults_list.yaml
@@ -1,0 +1,5 @@
+# @package _global_
+defaults:
+  - dataset: imagenet
+
+key: value

--- a/tests/standalone_apps/namespace_pkg_config_source_test/some_namespace/namespace_test/dir/configs_with_defaults_list/global_package.yaml
+++ b/tests/standalone_apps/namespace_pkg_config_source_test/some_namespace/namespace_test/dir/configs_with_defaults_list/global_package.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+defaults:
+  - foo: bar
+
+configs_with_defaults_list:
+  x: 10

--- a/tests/standalone_apps/namespace_pkg_config_source_test/some_namespace/namespace_test/dir/configs_with_defaults_list/group_package.yaml
+++ b/tests/standalone_apps/namespace_pkg_config_source_test/some_namespace/namespace_test/dir/configs_with_defaults_list/group_package.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - foo: bar
+
+x: 10

--- a/tests/test_apps/app_with_multiple_config_dirs/dir1/cfg1.yaml
+++ b/tests/test_apps/app_with_multiple_config_dirs/dir1/cfg1.yaml
@@ -1,1 +1,2 @@
+# @package _global_
 dir1_cfg1: true

--- a/tests/test_apps/app_with_multiple_config_dirs/dir1/cfg2.yaml
+++ b/tests/test_apps/app_with_multiple_config_dirs/dir1/cfg2.yaml
@@ -1,1 +1,2 @@
+# @package _global_
 dir1_cfg2: true

--- a/tests/test_apps/app_with_multiple_config_dirs/dir2/cfg1.yaml
+++ b/tests/test_apps/app_with_multiple_config_dirs/dir2/cfg1.yaml
@@ -1,1 +1,2 @@
+# @package _global_
 dir2_cfg1: true

--- a/tests/test_apps/app_with_multiple_config_dirs/dir2/cfg2.yaml
+++ b/tests/test_apps/app_with_multiple_config_dirs/dir2/cfg2.yaml
@@ -1,1 +1,2 @@
+# @package _global_
 dir2_cfg2: true

--- a/tests/test_apps/config_source_test/dir/config_with_defaults_list.yaml
+++ b/tests/test_apps/config_source_test/dir/config_with_defaults_list.yaml
@@ -1,0 +1,5 @@
+# @package _global_
+defaults:
+  - dataset: imagenet
+
+key: value

--- a/tests/test_apps/config_source_test/dir/configs_with_defaults_list/global_package.yaml
+++ b/tests/test_apps/config_source_test/dir/configs_with_defaults_list/global_package.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+defaults:
+  - foo: bar
+
+configs_with_defaults_list:
+  x: 10

--- a/tests/test_apps/config_source_test/dir/configs_with_defaults_list/group_package.yaml
+++ b/tests/test_apps/config_source_test/dir/configs_with_defaults_list/group_package.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - foo: bar
+
+x: 10

--- a/tests/test_apps/config_source_test/structured.py
+++ b/tests/test_apps/config_source_test/structured.py
@@ -75,3 +75,32 @@ s.store(name="primary_config", node={"primary": True}, package=None)
 s.store(
     name="primary_config_with_non_global_package", node={"primary": True}, package="foo"
 )
+
+s.store(
+    name="config_with_defaults_list",
+    node={
+        "defaults": [{"dataset": "imagenet"}],
+        "key": "value",
+    },
+    package="_global_",
+)
+
+s.store(
+    group="configs_with_defaults_list",
+    name="global_package",
+    node={
+        "defaults": [{"foo": "bar"}],
+        "configs_with_defaults_list": {"x": 10},
+    },
+    package="_global_",
+)
+
+s.store(
+    group="configs_with_defaults_list",
+    name="group_package",
+    node={
+        "defaults": [{"foo": "bar"}],
+        "x": 10,
+    },
+    package="_group_",
+)

--- a/tests/test_apps/sweep_complex_defaults/conf/config.yaml
+++ b/tests/test_apps/sweep_complex_defaults/conf/config.yaml
@@ -2,5 +2,5 @@
 defaults:
   - optimizer: adam
   - dataset: imagenet
-  - optimizer_dataset: ${defaults.0.optimizer}_${defaults.1.dataset}
+  - optimizer_dataset: ${optimizer}_${dataset}
     optional: true

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -80,7 +80,10 @@ base_completion_list: List[str] = [
 ]
 
 
-@pytest.mark.parametrize("line_prefix", ["", "dict.key1=val1 "])
+@pytest.mark.parametrize(
+    "line_prefix",
+    [pytest.param("", id="no_prefix"), pytest.param("dict.key1=val1 ", id="prefix")],
+)
 @pytest.mark.parametrize(
     "line,num_tabs,expected",
     [
@@ -110,9 +113,9 @@ base_completion_list: List[str] = [
         ("test_hydra/launcher=", 2, ["test_hydra/launcher=fairtask"]),
         ("test_hydra/launcher=fa", 2, ["test_hydra/launcher=fairtask"]),
         # loading groups
-        ("gro", 2, ["group="]),
-        ("group=di", 2, ["group=dict"]),
-        (
+        pytest.param("gro", 2, ["group="], id="group"),
+        pytest.param("group=di", 2, ["group=dict"], id="group"),
+        pytest.param(
             "group=dict ",
             3,
             [
@@ -127,11 +130,12 @@ base_completion_list: List[str] = [
                 "test_hydra/",
                 "toys.",
             ],
+            id="group",
         ),
-        ("group=", 2, ["group=dict", "group=list"]),
-        ("group=dict group.dict=", 2, ["group.dict=true"]),
-        ("group=dict group=", 2, ["group=dict", "group=list"]),
-        ("group=dict group=", 2, ["group=dict", "group=list"]),
+        pytest.param("group=", 2, ["group=dict", "group=list"], id="group"),
+        pytest.param("group=dict group.dict=", 2, ["group.dict=true"], id="group"),
+        pytest.param("group=dict group=", 2, ["group=dict", "group=list"], id="group"),
+        pytest.param("group=dict group=", 2, ["group=dict", "group=list"], id="group"),
     ],
 )
 class TestRunCompletion:

--- a/tests/test_config_repository.py
+++ b/tests/test_config_repository.py
@@ -88,11 +88,13 @@ class TestConfigRepository:
     @pytest.mark.parametrize(  # type: ignore
         "config_path,results_filter,expected",
         [
-            (
+            pytest.param(
                 "",
                 None,
                 [
+                    "config_with_defaults_list",
                     "config_without_group",
+                    "configs_with_defaults_list",
                     "dataset",
                     "level1",
                     "optimizer",
@@ -100,24 +102,53 @@ class TestConfigRepository:
                     "primary_config",
                     "primary_config_with_non_global_package",
                 ],
+                id="root:no_filter",
             ),
-            ("", ObjectType.GROUP, ["dataset", "level1", "optimizer", "package_test"]),
-            (
+            pytest.param(
+                "",
+                ObjectType.GROUP,
+                [
+                    "configs_with_defaults_list",
+                    "dataset",
+                    "level1",
+                    "optimizer",
+                    "package_test",
+                ],
+                id="root:group",
+            ),
+            pytest.param(
                 "",
                 ObjectType.CONFIG,
                 [
+                    "config_with_defaults_list",
                     "config_without_group",
                     "dataset",
                     "primary_config",
                     "primary_config_with_non_global_package",
                 ],
+                id="root:config",
             ),
-            ("dataset", None, ["cifar10", "imagenet"]),
-            ("dataset", ObjectType.GROUP, []),
-            ("dataset", ObjectType.CONFIG, ["cifar10", "imagenet"]),
-            ("level1", ObjectType.GROUP, ["level2"]),
-            ("level1", ObjectType.CONFIG, []),
-            ("level1/level2", ObjectType.CONFIG, ["nested1", "nested2"]),
+            pytest.param(
+                "dataset",
+                None,
+                ["cifar10", "imagenet"],
+                id="dataset:no_filter",
+            ),
+            pytest.param("dataset", ObjectType.GROUP, [], id="dataset:group"),
+            pytest.param(
+                "dataset",
+                ObjectType.CONFIG,
+                ["cifar10", "imagenet"],
+                id="dataset:config",
+            ),
+            pytest.param("level1", ObjectType.GROUP, ["level2"], id="level1:group"),
+            pytest.param("level1", ObjectType.CONFIG, [], id="level1:config"),
+            pytest.param(
+                "level1/level2",
+                ObjectType.CONFIG,
+                ["nested1", "nested2"],
+                id="level1/level2:config",
+            ),
         ],
     )
     def test_config_repository_list(

--- a/tests/test_config_search_path.py
+++ b/tests/test_config_search_path.py
@@ -163,11 +163,11 @@ def test_prepend(
         (None, "package.module", "conf", "pkg://package/conf"),
         # This is an unusual one. this behavior is intentional.
         (None, "package.module", "../conf", "pkg://conf"),
-        (None, "package1.package2.module", "../conf", "pkg://package1/conf"),
+        (None, "package1.rename_package_to.module", "../conf", "pkg://package1/conf"),
         # prefer directory
         (
             "foo",
-            "package1.package2.module",
+            "package1.rename_package_to.module",
             "../conf",
             os.path.realpath(os.path.join(os.getcwd(), "../conf")),
         ),

--- a/tests/test_data/new_defaults_lists/a/a1.yaml
+++ b/tests/test_data/new_defaults_lists/a/a1.yaml
@@ -1,0 +1,1 @@
+# @package _group_

--- a/tests/test_data/new_defaults_lists/a/a2.yaml
+++ b/tests/test_data/new_defaults_lists/a/a2.yaml
@@ -1,0 +1,4 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b1

--- a/tests/test_data/new_defaults_lists/a/a3.yaml
+++ b/tests/test_data/new_defaults_lists/a/a3.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - c: c1
+  - b: b2

--- a/tests/test_data/new_defaults_lists/a/a4.yaml
+++ b/tests/test_data/new_defaults_lists/a/a4.yaml
@@ -1,0 +1,4 @@
+# @package _group_
+defaults:
+  - _self_
+  - b@file_pkg: b1

--- a/tests/test_data/new_defaults_lists/a/a5.yaml
+++ b/tests/test_data/new_defaults_lists/a/a5.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b3
+  - b@file_pkg: b3

--- a/tests/test_data/new_defaults_lists/a/a6.yaml
+++ b/tests/test_data/new_defaults_lists/a/a6.yaml
@@ -1,0 +1,1 @@
+# @package _group_

--- a/tests/test_data/new_defaults_lists/a/global.yaml
+++ b/tests/test_data/new_defaults_lists/a/global.yaml
@@ -1,0 +1,1 @@
+# @package _global_

--- a/tests/test_data/new_defaults_lists/a/invalid_defaults_list.yaml
+++ b/tests/test_data/new_defaults_lists/a/invalid_defaults_list.yaml
@@ -1,0 +1,4 @@
+# @package _group_
+defaults:
+  b: b3
+  b@file_pkg: b3

--- a/tests/test_data/new_defaults_lists/a_b/a1_b1.yaml
+++ b/tests/test_data/new_defaults_lists/a_b/a1_b1.yaml
@@ -1,0 +1,1 @@
+# @package _group_

--- a/tests/test_data/new_defaults_lists/a_b/a6_b1.yaml
+++ b/tests/test_data/new_defaults_lists/a_b/a6_b1.yaml
@@ -1,0 +1,1 @@
+# @package _group_

--- a/tests/test_data/new_defaults_lists/b/b1.yaml
+++ b/tests/test_data/new_defaults_lists/b/b1.yaml
@@ -1,0 +1,1 @@
+# @package _group_

--- a/tests/test_data/new_defaults_lists/b/b2.yaml
+++ b/tests/test_data/new_defaults_lists/b/b2.yaml
@@ -1,0 +1,4 @@
+# @package _group_
+defaults:
+  - _self_
+  - c: c2

--- a/tests/test_data/new_defaults_lists/b/b3.yaml
+++ b/tests/test_data/new_defaults_lists/b/b3.yaml
@@ -1,0 +1,1 @@
+# @package foo

--- a/tests/test_data/new_defaults_lists/b/b4.yaml
+++ b/tests/test_data/new_defaults_lists/b/b4.yaml
@@ -1,0 +1,1 @@
+# @package _group_

--- a/tests/test_data/new_defaults_lists/b/base_from_a.yaml
+++ b/tests/test_data/new_defaults_lists/b/base_from_a.yaml
@@ -1,0 +1,4 @@
+# @package _group_
+defaults:
+  - a/a1
+  - _self_

--- a/tests/test_data/new_defaults_lists/b/base_from_b.yaml
+++ b/tests/test_data/new_defaults_lists/b/base_from_b.yaml
@@ -1,0 +1,4 @@
+# @package _group_
+defaults:
+  - b/b1
+  - _self_

--- a/tests/test_data/new_defaults_lists/c/c1.yaml
+++ b/tests/test_data/new_defaults_lists/c/c1.yaml
@@ -1,0 +1,1 @@
+# @package _group_

--- a/tests/test_data/new_defaults_lists/c/c1_with_schema.yaml
+++ b/tests/test_data/new_defaults_lists/c/c1_with_schema.yaml
@@ -1,0 +1,4 @@
+# @package _group_
+defaults:
+  - schema/c/c1
+  - _self_

--- a/tests/test_data/new_defaults_lists/c/c2.yaml
+++ b/tests/test_data/new_defaults_lists/c/c2.yaml
@@ -1,0 +1,1 @@
+# @package _group_

--- a/tests/test_data/new_defaults_lists/c/c2_with_schema.yaml
+++ b/tests/test_data/new_defaults_lists/c/c2_with_schema.yaml
@@ -1,0 +1,4 @@
+# @package _group_
+defaults:
+  - schema/c/c2
+  - _self_

--- a/tests/test_data/new_defaults_lists/config_with_schema.yaml
+++ b/tests/test_data/new_defaults_lists/config_with_schema.yaml
@@ -1,0 +1,3 @@
+# @package _global_
+defaults:
+  - c: c1_with_schema

--- a/tests/test_data/new_defaults_lists/delete/d1.yaml
+++ b/tests/test_data/new_defaults_lists/delete/d1.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b1
+  - b: null

--- a/tests/test_data/new_defaults_lists/delete/d10.yaml
+++ b/tests/test_data/new_defaults_lists/delete/d10.yaml
@@ -1,0 +1,4 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: null

--- a/tests/test_data/new_defaults_lists/delete/d11.yaml
+++ b/tests/test_data/new_defaults_lists/delete/d11.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - b: b1
+  - b@pkg1: b1
+  - ~b

--- a/tests/test_data/new_defaults_lists/delete/d12.yaml
+++ b/tests/test_data/new_defaults_lists/delete/d12.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - b: b1
+  - b@pkg1: b1
+  - ~b@pkg1

--- a/tests/test_data/new_defaults_lists/delete/d2.yaml
+++ b/tests/test_data/new_defaults_lists/delete/d2.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b1
+  - ~b

--- a/tests/test_data/new_defaults_lists/delete/d3.yaml
+++ b/tests/test_data/new_defaults_lists/delete/d3.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b1
+  - ~b: b1

--- a/tests/test_data/new_defaults_lists/delete/d4.yaml
+++ b/tests/test_data/new_defaults_lists/delete/d4.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b1
+  - ~z

--- a/tests/test_data/new_defaults_lists/delete/d5.yaml
+++ b/tests/test_data/new_defaults_lists/delete/d5.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b1
+  - ~b: b2

--- a/tests/test_data/new_defaults_lists/delete/d6.yaml
+++ b/tests/test_data/new_defaults_lists/delete/d6.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b1
+  - ~b: b1

--- a/tests/test_data/new_defaults_lists/delete/d7.yaml
+++ b/tests/test_data/new_defaults_lists/delete/d7.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b1
+  - ~b@foo: b1

--- a/tests/test_data/new_defaults_lists/delete/d8.yaml
+++ b/tests/test_data/new_defaults_lists/delete/d8.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b2  # will add b:b2, c:c2
+  - ~c: c2

--- a/tests/test_data/new_defaults_lists/delete/d9.yaml
+++ b/tests/test_data/new_defaults_lists/delete/d9.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - ~foo
+  - bar: null

--- a/tests/test_data/new_defaults_lists/delete_rename/dr1.yaml
+++ b/tests/test_data/new_defaults_lists/delete_rename/dr1.yaml
@@ -1,0 +1,6 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b1
+  - 'b@:pkg': _keep_  # no package -> b@pkg
+  - ~b

--- a/tests/test_data/new_defaults_lists/delete_rename/dr2.yaml
+++ b/tests/test_data/new_defaults_lists/delete_rename/dr2.yaml
@@ -1,0 +1,6 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b1
+  - 'b@:pkg': _keep_  # no package -> b@pkg
+  - ~b@pkg

--- a/tests/test_data/new_defaults_lists/delete_rename/rd1.yaml
+++ b/tests/test_data/new_defaults_lists/delete_rename/rd1.yaml
@@ -1,0 +1,6 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b1
+  - ~b
+  - 'b@:pkg': _keep_  # no package -> b@pkg

--- a/tests/test_data/new_defaults_lists/delete_rename/rd2.yaml
+++ b/tests/test_data/new_defaults_lists/delete_rename/rd2.yaml
@@ -1,0 +1,6 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b1
+  - ~b@pkg
+  - 'b@:pkg': _keep_  # no package -> b@pkg

--- a/tests/test_data/new_defaults_lists/duplicate_self.yaml
+++ b/tests/test_data/new_defaults_lists/duplicate_self.yaml
@@ -1,0 +1,5 @@
+# @package _global_
+defaults:
+  - _self_
+  - no_defaults
+  - _self_

--- a/tests/test_data/new_defaults_lists/explicit_leading_self.yaml
+++ b/tests/test_data/new_defaults_lists/explicit_leading_self.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+defaults:
+  - _self_
+  - no_defaults

--- a/tests/test_data/new_defaults_lists/implicit_leading_self.yaml
+++ b/tests/test_data/new_defaults_lists/implicit_leading_self.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+defaults:
+  # implicit _self_
+  - no_defaults

--- a/tests/test_data/new_defaults_lists/interpolation/i1.yaml
+++ b/tests/test_data/new_defaults_lists/interpolation/i1.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+defaults:
+  - _self_
+  - a: a1
+  - b: b1
+  - a_b: ${a}_${b}

--- a/tests/test_data/new_defaults_lists/interpolation/i2_legacy_with_self.yaml
+++ b/tests/test_data/new_defaults_lists/interpolation/i2_legacy_with_self.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+defaults:
+  - _self_
+  - a: a1
+  - b: b1
+  - a_b: ${defaults.1.a}_${defaults.2.b}

--- a/tests/test_data/new_defaults_lists/interpolation/i3_legacy_without_self.yaml
+++ b/tests/test_data/new_defaults_lists/interpolation/i3_legacy_without_self.yaml
@@ -1,0 +1,5 @@
+# @package _global_
+defaults:
+  - a: a1
+  - b: b1
+  - a_b: ${defaults.0.a}_${defaults.1.b}

--- a/tests/test_data/new_defaults_lists/interpolation/i4_forward.yaml
+++ b/tests/test_data/new_defaults_lists/interpolation/i4_forward.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+defaults:
+  - _self_
+  - a_b: ${a}_${b}
+  - a: a1
+  - b: b1

--- a/tests/test_data/new_defaults_lists/no_defaults.yaml
+++ b/tests/test_data/new_defaults_lists/no_defaults.yaml
@@ -1,0 +1,2 @@
+# @package _global_
+# no defaults list

--- a/tests/test_data/new_defaults_lists/one_missing_item.yaml
+++ b/tests/test_data/new_defaults_lists/one_missing_item.yaml
@@ -1,0 +1,3 @@
+# @package _global_
+defaults:
+  - a: ???

--- a/tests/test_data/new_defaults_lists/recursive_item_explicit_self.yaml
+++ b/tests/test_data/new_defaults_lists/recursive_item_explicit_self.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+defaults:
+  - _self_
+  - a: a2

--- a/tests/test_data/new_defaults_lists/recursive_item_implicit_self.yaml
+++ b/tests/test_data/new_defaults_lists/recursive_item_implicit_self.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+defaults:
+  # - _self_
+  - a: a2

--- a/tests/test_data/new_defaults_lists/rename/r1.yaml
+++ b/tests/test_data/new_defaults_lists/rename/r1.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b1
+  - 'b@:pkg': _keep_  # no package -> package

--- a/tests/test_data/new_defaults_lists/rename/r2.yaml
+++ b/tests/test_data/new_defaults_lists/rename/r2.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - b@pkg: b1
+  - 'b@pkg:pkg2': _keep_  # pkg -> pkg2

--- a/tests/test_data/new_defaults_lists/rename/r3.yaml
+++ b/tests/test_data/new_defaults_lists/rename/r3.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - b: b1
+  - 'b@:pkg': b4  # no package -> pkg, option change

--- a/tests/test_data/new_defaults_lists/rename/r4.yaml
+++ b/tests/test_data/new_defaults_lists/rename/r4.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - b@pkg: b1
+  - 'b@pkg:pkg2': b4  # pkg -> pkg2, option change

--- a/tests/test_data/new_defaults_lists/rename/r5.yaml
+++ b/tests/test_data/new_defaults_lists/rename/r5.yaml
@@ -1,0 +1,5 @@
+# @package _group_
+defaults:
+  - _self_
+  - rename/r4
+  - a: a1

--- a/tests/test_data/new_defaults_lists/schema/c/c1.yaml
+++ b/tests/test_data/new_defaults_lists/schema/c/c1.yaml
@@ -1,0 +1,1 @@
+# @package _group_

--- a/tests/test_data/new_defaults_lists/schema/c/c2.yaml
+++ b/tests/test_data/new_defaults_lists/schema/c/c2.yaml
@@ -1,0 +1,1 @@
+# @package _group_

--- a/tests/test_data/new_defaults_lists/test_overrides.yaml
+++ b/tests/test_data/new_defaults_lists/test_overrides.yaml
@@ -1,0 +1,5 @@
+# @package _global_
+defaults:
+  - a: a1
+  - a@pkg: a1
+  - c: c1

--- a/tests/test_data/new_defaults_lists/trailing_self.yaml
+++ b/tests/test_data/new_defaults_lists/trailing_self.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+defaults:
+  - no_defaults
+  - _self_

--- a/tests/test_data/new_defaults_lists/with_missing.yaml
+++ b/tests/test_data/new_defaults_lists/with_missing.yaml
@@ -1,0 +1,3 @@
+# @package _global_
+defaults:
+  - a: ???

--- a/tests/test_data/new_defaults_lists/with_optional.yaml
+++ b/tests/test_data/new_defaults_lists/with_optional.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+defaults:
+  - a: a1  # not missing
+    optional: true
+  - foo: bar  # missing
+    optional: true

--- a/tests/test_defaults_list.py
+++ b/tests/test_defaults_list.py
@@ -1,0 +1,1512 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import re
+from textwrap import dedent
+from typing import Any, List
+
+import pytest
+
+from hydra._internal.config_repository import ConfigRepository
+from hydra._internal.config_search_path_impl import ConfigSearchPathImpl
+from hydra._internal.defaults_list import (
+    compute_element_defaults_list,
+    convert_overrides_to_defaults,
+    expand_defaults_list,
+)
+from hydra.core import DefaultElement
+from hydra.core.override_parser.overrides_parser import OverridesParser
+from hydra.core.plugins import Plugins
+from hydra.errors import ConfigCompositionException, OverrideParseException
+from hydra.test_utils.test_utils import chdir_hydra_root
+
+chdir_hydra_root()
+
+# registers config source plugins
+Plugins.instance()
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "element,expected",
+    [
+        pytest.param(
+            DefaultElement(config_name="no_defaults", parent="this_test"),
+            [
+                DefaultElement(config_name="no_defaults", parent="this_test"),
+            ],
+            id="no_defaults",
+        ),
+        pytest.param(
+            DefaultElement(config_name="duplicate_self", parent="this_test"),
+            pytest.raises(
+                ConfigCompositionException,
+                match="Duplicate _self_ defined in duplicate_self",
+            ),
+            id="duplicate_self",
+        ),
+        pytest.param(
+            DefaultElement(config_name="trailing_self", parent="this_test"),
+            [
+                DefaultElement(config_name="no_defaults", parent="trailing_self"),
+                DefaultElement(config_name="trailing_self", parent="this_test"),
+            ],
+            id="trailing_self",
+        ),
+        pytest.param(
+            DefaultElement(config_name="implicit_leading_self", parent="this_test"),
+            [
+                DefaultElement(config_name="implicit_leading_self", parent="this_test"),
+                DefaultElement(
+                    config_name="no_defaults",
+                    parent="implicit_leading_self",
+                ),
+            ],
+            id="implicit_leading_self",
+        ),
+        pytest.param(
+            DefaultElement(
+                config_name="explicit_leading_self",
+                parent="this_test",
+            ),
+            [
+                DefaultElement(
+                    config_name="explicit_leading_self",
+                    parent="this_test",
+                ),
+                DefaultElement(
+                    config_name="no_defaults",
+                    parent="explicit_leading_self",
+                ),
+            ],
+            id="explicit_leading_self",
+        ),
+        pytest.param(
+            DefaultElement(config_name="a/a1"),
+            [
+                DefaultElement(config_name="a/a1"),
+            ],
+            id="primary_in_config_group_no_defaults",
+        ),
+        pytest.param(
+            DefaultElement(config_group="a", config_name="a1"),
+            [
+                DefaultElement(config_group="a", config_name="a1"),
+            ],
+            id="primary_in_config_group_no_defaults",
+        ),
+        pytest.param(
+            DefaultElement(config_name="a/global"),
+            [
+                DefaultElement(config_name="a/global"),
+            ],
+            id="a/global",
+        ),
+        pytest.param(
+            DefaultElement(config_name="b/b1"),
+            [
+                DefaultElement(config_name="b/b1"),
+            ],
+            id="b/b1",
+        ),
+        pytest.param(
+            DefaultElement(config_group="b", config_name="b1"),
+            [
+                DefaultElement(config_group="b", config_name="b1"),
+            ],
+            id="b/b1",
+        ),
+        pytest.param(
+            DefaultElement(config_group="a", config_name="a2", parent="this_test"),
+            [
+                DefaultElement(config_group="a", config_name="a2", parent="this_test"),
+                DefaultElement(config_group="b", config_name="b1", parent="a/a2"),
+            ],
+            id="a/a2",
+        ),
+        pytest.param(
+            DefaultElement(
+                config_name="recursive_item_explicit_self", parent="this_test"
+            ),
+            [
+                DefaultElement(
+                    config_name="recursive_item_explicit_self", parent="this_test"
+                ),
+                DefaultElement(
+                    config_group="a",
+                    config_name="a2",
+                    parent="recursive_item_explicit_self",
+                ),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="a/a2",
+                ),
+            ],
+            id="recursive_item_explicit_self",
+        ),
+        pytest.param(
+            DefaultElement(
+                config_name="recursive_item_explicit_self", parent="this_test"
+            ),
+            [
+                DefaultElement(
+                    config_name="recursive_item_explicit_self", parent="this_test"
+                ),
+                DefaultElement(
+                    config_group="a",
+                    config_name="a2",
+                    parent="recursive_item_explicit_self",
+                ),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="a/a2",
+                ),
+            ],
+            id="recursive_item_implicit_self",
+        ),
+        pytest.param(
+            DefaultElement(config_group="a", config_name="a3", parent="this_test"),
+            [
+                DefaultElement(config_group="a", config_name="a3", parent="this_test"),
+                DefaultElement(config_group="c", config_name="c2", parent="a/a3"),
+                DefaultElement(config_group="b", config_name="b2", parent="a/a3"),
+            ],
+            id="multiple_item_definitions",
+        ),
+        pytest.param(
+            DefaultElement(config_group="a", config_name="a4", parent="this_test"),
+            [
+                DefaultElement(config_group="a", config_name="a4", parent="this_test"),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    package="file_pkg",
+                    parent="a/a4",
+                ),
+            ],
+            id="a/a4_pkg_override_in_config",
+        ),
+        pytest.param(
+            DefaultElement(config_group="b", config_name="b3", parent="this_test"),
+            [
+                DefaultElement(config_group="b", config_name="b3", parent="this_test"),
+            ],
+            id="b/b3",
+        ),
+        pytest.param(
+            DefaultElement(config_group="a", config_name="a5", parent="this_test"),
+            [
+                DefaultElement(config_group="a", config_name="a5", parent="this_test"),
+                DefaultElement(config_group="b", config_name="b3", parent="a/a5"),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b3",
+                    package="file_pkg",
+                    parent="a/a5",
+                ),
+            ],
+            id="a/a5",
+        ),
+        pytest.param(
+            DefaultElement(
+                config_group="b", config_name="base_from_a", parent="this_test"
+            ),
+            [
+                DefaultElement(config_name="a/a1", parent="b/base_from_a"),
+                DefaultElement(
+                    config_group="b",
+                    config_name="base_from_a",
+                    parent="this_test",
+                ),
+            ],
+            id="b/base_from_a",
+        ),
+        pytest.param(
+            DefaultElement(
+                config_group="b", config_name="base_from_b", parent="this_test"
+            ),
+            [
+                DefaultElement(config_name="b/b1", parent="b/base_from_b"),
+                DefaultElement(
+                    config_group="b", config_name="base_from_b", parent="this_test"
+                ),
+            ],
+            id="b/base_from_b",
+        ),
+        # rename
+        pytest.param(
+            DefaultElement(config_group="rename", config_name="r1", parent="this_test"),
+            [
+                DefaultElement(
+                    config_group="rename", config_name="r1", parent="this_test"
+                ),
+                DefaultElement(
+                    config_group="b",
+                    package="pkg",
+                    config_name="b1",
+                    parent="rename/r1",
+                ),
+            ],
+            id="rename_package_from_none",
+        ),
+        pytest.param(
+            DefaultElement(config_group="rename", config_name="r2", parent="this_test"),
+            [
+                DefaultElement(
+                    config_group="rename", config_name="r2", parent="this_test"
+                ),
+                DefaultElement(
+                    config_group="b",
+                    package="pkg2",
+                    config_name="b1",
+                    parent="rename/r2",
+                ),
+            ],
+            id="rename_package_from_something",
+        ),
+        pytest.param(
+            DefaultElement(config_group="rename", config_name="r3", parent="this_test"),
+            [
+                DefaultElement(
+                    config_group="rename", config_name="r3", parent="this_test"
+                ),
+                DefaultElement(
+                    config_group="b",
+                    package="pkg",
+                    config_name="b4",
+                    parent="rename/r3",
+                ),
+            ],
+            id="rename_package_from_none_and_change_option:r3",
+        ),
+        pytest.param(
+            DefaultElement(config_group="rename", config_name="r4", parent="this_test"),
+            [
+                DefaultElement(
+                    config_group="rename",
+                    config_name="r4",
+                    parent="this_test",
+                ),
+                DefaultElement(
+                    config_group="b",
+                    package="pkg2",
+                    config_name="b4",
+                    parent="rename/r4",
+                ),
+            ],
+            id="rename_package_and_change_option:r4",
+        ),
+        pytest.param(
+            DefaultElement(config_group="rename", config_name="r5", parent="this_test"),
+            [
+                DefaultElement(
+                    config_group="rename",
+                    config_name="r5",
+                    parent="this_test",
+                ),
+                DefaultElement(
+                    config_name="rename/r4",
+                    parent="rename/r5",
+                ),
+                DefaultElement(
+                    config_group="b",
+                    package="pkg2",
+                    config_name="b4",
+                    parent="rename/r4",
+                ),
+                DefaultElement(
+                    config_group="a",
+                    config_name="a1",
+                    parent="rename/r5",
+                ),
+            ],
+            id="rename_package_and_change_option:r5",
+        ),
+        # delete
+        pytest.param(
+            DefaultElement(config_group="delete", config_name="d1", parent="this_test"),
+            [
+                DefaultElement(
+                    config_group="delete", config_name="d1", parent="this_test"
+                ),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                    parent="delete/d1",
+                ),
+            ],
+            id="delete_with_null",
+        ),
+        pytest.param(
+            DefaultElement(config_group="delete", config_name="d2", parent="this_test"),
+            [
+                DefaultElement(
+                    config_group="delete", config_name="d2", parent="this_test"
+                ),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                    parent="delete/d2",
+                ),
+            ],
+            id="delete_with_tilda",
+        ),
+        pytest.param(
+            DefaultElement(config_group="delete", config_name="d3", parent="this_test"),
+            [
+                DefaultElement(
+                    config_group="delete", config_name="d3", parent="this_test"
+                ),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                    parent="delete/d3",
+                ),
+            ],
+            id="delete_with_tilda_k=v",
+        ),
+        pytest.param(
+            DefaultElement(config_group="delete", config_name="d4", parent="this_test"),
+            [
+                DefaultElement(
+                    config_group="delete",
+                    config_name="d4",
+                    parent="this_test",
+                ),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="delete/d4",
+                ),
+            ],
+            id="file_delete_not_mandatory",
+        ),
+        pytest.param(
+            DefaultElement(config_group="delete", config_name="d5", parent="this_test"),
+            [
+                DefaultElement(
+                    config_group="delete", config_name="d5", parent="this_test"
+                ),
+                DefaultElement(config_group="b", config_name="b1", parent="delete/d5"),
+            ],
+            id="file_delete_not_mandatory",
+        ),
+        pytest.param(
+            DefaultElement(config_group="delete", config_name="d7", parent="this_test"),
+            [
+                DefaultElement(
+                    config_group="delete", config_name="d7", parent="this_test"
+                ),
+                DefaultElement(config_group="b", config_name="b1", parent="delete/d7"),
+            ],
+            id="file_delete_not_mandatory",
+        ),
+        pytest.param(
+            DefaultElement(config_group="delete", config_name="d6", parent="this_test"),
+            [
+                DefaultElement(
+                    config_group="delete",
+                    config_name="d6",
+                    parent="this_test",
+                ),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                    parent="delete/d6",
+                ),
+            ],
+            id="specific_delete",
+        ),
+        pytest.param(
+            DefaultElement(config_group="delete", config_name="d8", parent="this_test"),
+            [
+                DefaultElement(
+                    config_group="delete", config_name="d8", parent="this_test"
+                ),
+                DefaultElement(config_group="b", config_name="b2", parent="delete/d8"),
+                DefaultElement(
+                    config_group="c",
+                    config_name="c2",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                    parent="b/b2",
+                ),
+            ],
+            id="delete_from_included",
+        ),
+        pytest.param(
+            DefaultElement(config_group="delete", config_name="d9"),
+            [
+                DefaultElement(config_group="delete", config_name="d9"),
+            ],
+            id="file_delete_not_mandatory",
+        ),
+        pytest.param(
+            DefaultElement(config_group="delete", config_name="d11"),
+            [
+                DefaultElement(config_group="delete", config_name="d11"),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="delete/d11",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                ),
+                DefaultElement(
+                    config_group="b",
+                    package="pkg1",
+                    config_name="b1",
+                    parent="delete/d11",
+                ),
+            ],
+            id="delete_is_specific",
+        ),
+        pytest.param(
+            DefaultElement(config_group="delete", config_name="d12"),
+            [
+                DefaultElement(config_group="delete", config_name="d12"),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="delete/d12",
+                ),
+                DefaultElement(
+                    config_group="b",
+                    package="pkg1",
+                    config_name="b1",
+                    parent="delete/d12",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                ),
+            ],
+            id="delete_is_specific",
+        ),
+        # interpolation
+        pytest.param(
+            DefaultElement(
+                config_group="interpolation",
+                config_name="i1",
+                parent="this_test",
+            ),
+            [
+                DefaultElement(
+                    config_group="interpolation",
+                    config_name="i1",
+                    parent="this_test",
+                ),
+                DefaultElement(
+                    config_group="a",
+                    config_name="a1",
+                    parent="interpolation/i1",
+                ),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="interpolation/i1",
+                ),
+                DefaultElement(
+                    config_group="a_b",
+                    config_name="a1_b1",
+                    parent="interpolation/i1",
+                ),
+            ],
+            id="interpolation",
+        ),
+        pytest.param(
+            DefaultElement(
+                config_group="interpolation",
+                config_name="i2_legacy_with_self",
+                parent="this_test",
+            ),
+            [
+                DefaultElement(
+                    config_group="interpolation",
+                    config_name="i2_legacy_with_self",
+                    parent="this_test",
+                ),
+                DefaultElement(
+                    config_group="a",
+                    config_name="a1",
+                    parent="interpolation/i2_legacy_with_self",
+                ),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="interpolation/i2_legacy_with_self",
+                ),
+                DefaultElement(
+                    config_group="a_b",
+                    config_name="a1_b1",
+                    parent="interpolation/i2_legacy_with_self",
+                ),
+            ],
+            id="interpolation_legacy",
+        ),
+        pytest.param(
+            DefaultElement(
+                config_group="interpolation",
+                config_name="i3_legacy_without_self",
+                parent="this_test",
+            ),
+            [
+                DefaultElement(
+                    config_group="interpolation",
+                    config_name="i3_legacy_without_self",
+                    parent="this_test",
+                ),
+                DefaultElement(
+                    config_group="a",
+                    config_name="a1",
+                    parent="interpolation/i3_legacy_without_self",
+                ),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="interpolation/i3_legacy_without_self",
+                ),
+                DefaultElement(
+                    config_group="a_b",
+                    config_name="a1_b1",
+                    parent="interpolation/i3_legacy_without_self",
+                ),
+            ],
+            id="interpolation_legacy",
+        ),
+        pytest.param(
+            DefaultElement(
+                config_group="interpolation",
+                config_name="i4_forward",
+                parent="this_test",
+            ),
+            [
+                DefaultElement(
+                    config_group="interpolation",
+                    config_name="i4_forward",
+                    parent="this_test",
+                ),
+                DefaultElement(
+                    config_group="a_b",
+                    config_name="a1_b1",
+                    parent="interpolation/i4_forward",
+                ),
+                DefaultElement(
+                    config_group="a",
+                    config_name="a1",
+                    parent="interpolation/i4_forward",
+                ),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="interpolation/i4_forward",
+                ),
+            ],
+            id="forward_interpolation",
+        ),
+        # optional
+        pytest.param(
+            DefaultElement(config_name="with_optional", parent="this_test"),
+            [
+                DefaultElement(config_name="with_optional", parent="this_test"),
+                DefaultElement(
+                    config_group="a",
+                    config_name="a1",
+                    optional=True,
+                    parent="with_optional",
+                ),
+                DefaultElement(
+                    config_group="foo",
+                    config_name="bar",
+                    optional=True,
+                    skip_load=True,
+                    skip_load_reason="missing_optional_config",
+                    parent="with_optional",
+                ),
+            ],
+            id="optional",
+        ),
+        # missing
+        pytest.param(
+            DefaultElement(config_name="with_missing"),
+            pytest.raises(
+                ConfigCompositionException,
+                match=dedent(
+                    """\
+                You must specify 'a', e.g, a=<OPTION>
+                Available options:
+                \ta1
+                \ta2
+                \ta3
+                \ta4
+                \ta5
+                \ta6
+                \tglobal"""
+                ),
+            ),
+            id="missing",
+        ),
+        # delete renamed
+        pytest.param(
+            DefaultElement(config_group="delete_rename", config_name="dr1"),
+            [
+                DefaultElement(config_group="delete_rename", config_name="dr1"),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="delete_rename/dr1",
+                    package="pkg",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                ),
+            ],
+            id="delete_src_after_rename_in_file",
+        ),
+        pytest.param(
+            DefaultElement(config_group="delete_rename", config_name="dr2"),
+            [
+                DefaultElement(config_group="delete_rename", config_name="dr2"),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="delete_rename/dr2",
+                    package="pkg",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                ),
+            ],
+            id="delete_dst_after_rename_in_file",
+        ),
+        # delete renamed
+        pytest.param(
+            DefaultElement(config_group="delete_rename", config_name="rd1"),
+            [
+                DefaultElement(config_group="delete_rename", config_name="rd1"),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="delete_rename/rd1",
+                    package="pkg",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                ),
+            ],
+            id="rename_delete",
+        ),
+        pytest.param(
+            DefaultElement(config_group="delete_rename", config_name="rd2"),
+            [
+                DefaultElement(config_group="delete_rename", config_name="rd2"),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="delete_rename/rd2",
+                    package="pkg",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                ),
+            ],
+            id="rename_delete",
+        ),
+    ],
+)
+def test_compute_element_defaults_list(
+    hydra_restore_singletons: Any,
+    element: DefaultElement,
+    expected: Any,
+    recwarn: Any,
+) -> None:
+
+    csp = ConfigSearchPathImpl()
+    csp.append(provider="test", path="file://tests/test_data/new_defaults_lists")
+    repo = ConfigRepository(config_search_path=csp)
+
+    if isinstance(expected, list):
+        ret = compute_element_defaults_list(
+            element=element, skip_missing=False, repo=repo
+        )
+        assert ret == expected
+    else:
+        with expected:
+            compute_element_defaults_list(
+                element=element, skip_missing=False, repo=repo
+            )
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "input_defaults,expected",
+    [
+        pytest.param(
+            [
+                DefaultElement(config_group="a", config_name="a1", parent="foo"),
+                DefaultElement(config_group="a", config_name="a6", parent="bar"),
+            ],
+            [
+                DefaultElement(config_group="a", config_name="a6", parent="foo"),
+            ],
+            id="simple",
+        ),
+        pytest.param(
+            [
+                DefaultElement(config_group="a", config_name="a2", parent="foo"),
+                DefaultElement(config_group="a", config_name="a6", parent="bar"),
+            ],
+            [
+                DefaultElement(config_group="a", config_name="a6", parent="foo"),
+            ],
+            id="simple",
+        ),
+        pytest.param(
+            [
+                DefaultElement(config_group="a", config_name="a5", parent="foo"),
+                DefaultElement(config_group="b", config_name="b1", parent="bar"),
+                DefaultElement(
+                    config_group="b",
+                    package="file_pkg",
+                    config_name="b1",
+                    parent="zoo",
+                ),
+            ],
+            [
+                DefaultElement(config_group="a", config_name="a5", parent="foo"),
+                DefaultElement(config_group="b", config_name="b1", parent="a/a5"),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    package="file_pkg",
+                    parent="a/a5",
+                ),
+            ],
+            id="a/a5",
+        ),
+    ],
+)
+def test_expand_defaults_list(
+    hydra_restore_singletons: Any,
+    input_defaults: List[DefaultElement],
+    expected: List[DefaultElement],
+) -> None:
+    csp = ConfigSearchPathImpl()
+    csp.append(provider="test", path="file://tests/test_data/new_defaults_lists")
+    repo = ConfigRepository(config_search_path=csp)
+
+    ret = expand_defaults_list(defaults=input_defaults, skip_missing=False, repo=repo)
+    assert ret == expected
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "config_with_defaults,overrides,expected",
+    [
+        # change item
+        pytest.param(
+            "test_overrides",
+            ["a=a6"],
+            [
+                DefaultElement(config_name="test_overrides", parent="this_test"),
+                DefaultElement(
+                    config_group="a",
+                    config_name="a6",
+                    parent="test_overrides",
+                ),
+                DefaultElement(
+                    config_group="a",
+                    package="pkg",
+                    config_name="a1",
+                    parent="test_overrides",
+                ),
+                DefaultElement(
+                    config_group="c", config_name="c1", parent="test_overrides"
+                ),
+            ],
+            id="change_option",
+        ),
+        pytest.param(
+            "test_overrides",
+            ["a@:pkg2=a6"],
+            [
+                DefaultElement(config_name="test_overrides", parent="this_test"),
+                DefaultElement(
+                    config_group="a",
+                    package="pkg2",
+                    config_name="a6",
+                    parent="test_overrides",
+                ),
+                DefaultElement(
+                    config_group="a",
+                    package="pkg",
+                    config_name="a1",
+                    parent="test_overrides",
+                ),
+                DefaultElement(
+                    config_group="c", config_name="c1", parent="test_overrides"
+                ),
+            ],
+            id="change_both",
+        ),
+        pytest.param(
+            "test_overrides",
+            ["a@pkg:pkg2=a6"],
+            [
+                DefaultElement(config_name="test_overrides", parent="this_test"),
+                DefaultElement(
+                    config_group="a", config_name="a1", parent="test_overrides"
+                ),
+                DefaultElement(
+                    config_group="a",
+                    package="pkg2",
+                    config_name="a6",
+                    parent="test_overrides",
+                ),
+                DefaultElement(
+                    config_group="c", config_name="c1", parent="test_overrides"
+                ),
+            ],
+            id="change_both",
+        ),
+        pytest.param(
+            "test_overrides",
+            ["a@XXX:dest=a6"],
+            pytest.raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Could not rename package. No match for 'a@XXX' in the defaults list"
+                ),
+            ),
+            id="change_both_invalid_package",
+        ),
+        # adding item
+        pytest.param(
+            "no_defaults",
+            ["+b=b1"],
+            [
+                DefaultElement(config_name="no_defaults", parent="this_test"),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    is_add=True,
+                    parent="overrides",
+                ),
+            ],
+            id="adding_item",
+        ),
+        pytest.param(
+            "no_defaults",
+            ["+b=b2"],
+            [
+                DefaultElement(config_name="no_defaults", parent="this_test"),
+                DefaultElement(config_group="b", config_name="b2", parent="overrides"),
+                DefaultElement(config_group="c", config_name="c2", parent="b/b2"),
+            ],
+            id="adding_item_recursive",
+        ),
+        pytest.param(
+            "test_overrides",
+            ["+b@pkg=b1"],
+            [
+                DefaultElement(config_name="test_overrides", parent="this_test"),
+                DefaultElement(
+                    config_group="a",
+                    config_name="a1",
+                    parent="test_overrides",
+                ),
+                DefaultElement(
+                    config_group="a",
+                    package="pkg",
+                    config_name="a1",
+                    parent="test_overrides",
+                ),
+                DefaultElement(
+                    config_group="c", config_name="c1", parent="test_overrides"
+                ),
+                DefaultElement(
+                    config_group="b",
+                    package="pkg",
+                    config_name="b1",
+                    is_add=True,
+                    parent="overrides",
+                ),
+            ],
+            id="adding_item_at_package",
+        ),
+        pytest.param(
+            "one_missing_item",
+            ["+a=a1"],
+            pytest.raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Could not add 'a=a1'. 'a' is already in the defaults list."
+                ),
+            ),
+            id="adding_duplicate_item",
+        ),
+        pytest.param(
+            "test_overrides",
+            ["+a=a2"],
+            pytest.raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Could not add 'a=a2'. 'a' is already in the defaults list."
+                ),
+            ),
+            id="adding_duplicate_item",
+        ),
+        pytest.param(
+            "test_overrides",
+            ["+a=a6", "+c=c2"],
+            pytest.raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Could not add 'c=c2'. 'c' is already in the defaults list."
+                ),
+            ),
+            id="adding_duplicate_item_recursive",
+        ),
+        pytest.param(
+            "test_overrides",
+            ["+a@pkg:pkg2=a1"],
+            pytest.raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Add syntax does not support package rename, remove + prefix"
+                ),
+            ),
+            id="add_rename_error",
+        ),
+        pytest.param(
+            "test_overrides",
+            ["+a@pkg=a2"],
+            pytest.raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Could not add 'a@pkg=a2'. 'a@pkg' is already in the defaults list."
+                ),
+            ),
+            id="adding_duplicate_item@pkg",
+        ),
+        pytest.param(
+            "no_defaults",
+            ["c=c1"],
+            pytest.raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Could not override 'c'. No match in the defaults list."
+                    "\nTo append to your default list use +c=c1"
+                ),
+            ),
+            id="adding_without_plus",
+        ),
+        # deleting item
+        pytest.param(
+            "no_defaults",
+            ["~db=mysql"],
+            pytest.raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Could not delete. No match for 'db=mysql' in the defaults list."
+                ),
+            ),
+            id="delete_no_match",
+        ),
+        pytest.param(
+            "no_defaults",
+            ["~db"],
+            pytest.raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Could not delete. No match for 'db' in the defaults list."
+                ),
+            ),
+            id="delete_no_match",
+        ),
+        pytest.param(
+            "no_defaults",
+            ["~db=foo"],
+            pytest.raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Could not delete. No match for 'db=foo' in the defaults list."
+                ),
+            ),
+            id="delete_no_match",
+        ),
+        pytest.param(
+            "test_overrides",
+            ["~a"],
+            [
+                DefaultElement(config_name="test_overrides", parent="this_test"),
+                DefaultElement(
+                    config_group="a",
+                    config_name="a1",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                    parent="test_overrides",
+                ),
+                DefaultElement(
+                    config_group="a",
+                    package="pkg",
+                    config_name="a1",
+                    parent="test_overrides",
+                ),
+                DefaultElement(
+                    config_group="c", config_name="c1", parent="test_overrides"
+                ),
+            ],
+            id="delete ~a",
+        ),
+        pytest.param(
+            "test_overrides",
+            ["~a=a1"],
+            [
+                DefaultElement(config_name="test_overrides", parent="this_test"),
+                DefaultElement(
+                    config_group="a",
+                    config_name="a1",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                    parent="test_overrides",
+                ),
+                DefaultElement(
+                    config_group="a",
+                    package="pkg",
+                    config_name="a1",
+                    parent="test_overrides",
+                ),
+                DefaultElement(
+                    config_group="c", config_name="c1", parent="test_overrides"
+                ),
+            ],
+            id="delete ~a=a1",
+        ),
+        pytest.param(
+            "no_defaults",
+            ["~a=zzz"],
+            pytest.raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Could not delete. No match for 'a=zzz' in the defaults list."
+                ),
+            ),
+            id="delete ~a=zzz",
+        ),
+        pytest.param(
+            "test_overrides",
+            ["~a=zzz"],
+            pytest.raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Could not delete. No match for 'a=zzz' in the defaults list."
+                ),
+            ),
+            id="delete ~a=zzz",
+        ),
+        pytest.param(
+            "test_overrides",
+            ["~a@pkg"],
+            [
+                DefaultElement(config_name="test_overrides", parent="this_test"),
+                DefaultElement(
+                    config_group="a", config_name="a1", parent="test_overrides"
+                ),
+                DefaultElement(
+                    config_group="a",
+                    package="pkg",
+                    config_name="a1",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                    parent="test_overrides",
+                ),
+                DefaultElement(
+                    config_group="c", config_name="c1", parent="test_overrides"
+                ),
+            ],
+            id="delete ~a@pkg",
+        ),
+        pytest.param(
+            "no_defaults",
+            ["a=foo", "~a"],
+            [
+                DefaultElement(config_name="no_defaults", parent="this_test"),
+                DefaultElement(
+                    config_group="a",
+                    config_name="foo",
+                    from_override=True,
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                    parent="overrides",
+                ),
+            ],
+            id="delete_after_set_from_overrides",
+        ),
+        pytest.param(
+            "a/a2",
+            ["b=b2"],
+            [
+                DefaultElement(config_name="a/a2", parent="this_test"),
+                DefaultElement(config_group="b", config_name="b2", parent="a/a2"),
+                DefaultElement(config_group="c", config_name="c2", parent="b/b2"),
+            ],
+            id="delete_after_set_from_overrides:baseline",
+        ),
+        pytest.param(
+            "a/a2",
+            ["b=b2", "~b"],
+            [
+                DefaultElement(config_name="a/a2", parent="this_test"),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="a/a2",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                ),
+            ],
+            id="delete_after_set_from_overrides",
+        ),
+        pytest.param(
+            "a/a2",
+            ["b=b2", "~c"],
+            [
+                DefaultElement(config_name="a/a2", parent="this_test"),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b2",
+                    parent="a/a2",
+                ),
+                DefaultElement(
+                    config_group="c",
+                    config_name="c2",
+                    parent="b/b2",
+                    is_deleted=True,
+                    skip_load=True,
+                    skip_load_reason="deleted_from_list",
+                ),
+            ],
+            id="delete_after_set_from_overrides",
+        ),
+        pytest.param(
+            "delete/d10",
+            ["b=b1"],
+            [
+                DefaultElement(config_name="delete/d10", parent="this_test"),
+                DefaultElement(config_group="b", config_name="b1", parent="delete/d10"),
+            ],
+            id="override_deletion",
+        ),
+        pytest.param(
+            "delete/d10",
+            ["b=b1"],
+            [
+                DefaultElement(config_name="delete/d10", parent="this_test"),
+                DefaultElement(config_group="b", config_name="b1", parent="delete/d10"),
+            ],
+            id="delete_overriden_2",
+        ),
+        # syntax error
+        pytest.param(
+            "test_overrides",
+            ["db"],
+            pytest.raises(
+                OverrideParseException,
+                match=re.escape(
+                    "Error parsing override 'db'\nmissing EQUAL at '<EOF>'"
+                ),
+            ),
+            id="syntax_error",
+        ),
+        pytest.param(
+            "test_overrides",
+            ["db=[a,b,c]"],
+            pytest.raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Defaults list supported delete syntax is in the form "
+                    "~group and ~group=value, where value is a group name (string)"
+                ),
+            ),
+            id="syntax_error",
+        ),
+        pytest.param(
+            "test_overrides",
+            ["db={a:1,b:2}"],
+            pytest.raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Defaults list supported delete syntax is in the form "
+                    "~group and ~group=value, where value is a group name (string)"
+                ),
+            ),
+            id="syntax_error",
+        ),
+        # interpolation
+        pytest.param(
+            "interpolation/i1",
+            [],
+            [
+                DefaultElement(config_name="interpolation/i1", parent="this_test"),
+                DefaultElement(
+                    config_group="a", config_name="a1", parent="interpolation/i1"
+                ),
+                DefaultElement(
+                    config_group="b", config_name="b1", parent="interpolation/i1"
+                ),
+                DefaultElement(
+                    config_group="a_b", config_name="a1_b1", parent="interpolation/i1"
+                ),
+            ],
+            id="interpolation",
+        ),
+        pytest.param(
+            "interpolation/i1",
+            ["a=a6"],
+            [
+                DefaultElement(config_name="interpolation/i1", parent="this_test"),
+                DefaultElement(
+                    config_group="a", config_name="a6", parent="interpolation/i1"
+                ),
+                DefaultElement(
+                    config_group="b", config_name="b1", parent="interpolation/i1"
+                ),
+                DefaultElement(
+                    config_group="a_b", config_name="a6_b1", parent="interpolation/i1"
+                ),
+            ],
+            id="interpolation",
+        ),
+        pytest.param(
+            "interpolation/i2_legacy_with_self",
+            ["a=a6"],
+            [
+                DefaultElement(
+                    config_name="interpolation/i2_legacy_with_self", parent="this_test"
+                ),
+                DefaultElement(
+                    config_group="a",
+                    config_name="a6",
+                    parent="interpolation/i2_legacy_with_self",
+                ),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="interpolation/i2_legacy_with_self",
+                ),
+                DefaultElement(
+                    config_group="a_b",
+                    config_name="a6_b1",
+                    parent="interpolation/i2_legacy_with_self",
+                ),
+            ],
+            id="interpolation_legacy",
+        ),
+        pytest.param(
+            "interpolation/i3_legacy_without_self",
+            ["a=a6"],
+            [
+                DefaultElement(
+                    config_name="interpolation/i3_legacy_without_self",
+                    parent="this_test",
+                ),
+                DefaultElement(
+                    config_group="a",
+                    config_name="a6",
+                    parent="interpolation/i3_legacy_without_self",
+                ),
+                DefaultElement(
+                    config_group="b",
+                    config_name="b1",
+                    parent="interpolation/i3_legacy_without_self",
+                ),
+                DefaultElement(
+                    config_group="a_b",
+                    config_name="a6_b1",
+                    parent="interpolation/i3_legacy_without_self",
+                ),
+            ],
+            id="interpolation_legacy",
+        ),
+        # overriding groups with schema
+        pytest.param(
+            "config_with_schema",
+            [],
+            [
+                DefaultElement(config_name="config_with_schema", parent="this_test"),
+                DefaultElement(config_name="schema/c/c1", parent="c/c1_with_schema"),
+                DefaultElement(
+                    config_group="c",
+                    config_name="c1_with_schema",
+                    parent="config_with_schema",
+                ),
+            ],
+            id="schema::no_override",
+        ),
+        pytest.param(
+            "config_with_schema",
+            # c1_with_schema is already the choice for c, should be no-op:
+            ["c=c1_with_schema"],
+            [
+                DefaultElement(config_name="config_with_schema", parent="this_test"),
+                DefaultElement(config_name="schema/c/c1", parent="c/c1_with_schema"),
+                DefaultElement(
+                    config_group="c",
+                    config_name="c1_with_schema",
+                    parent="config_with_schema",
+                ),
+            ],
+            id="schema:override_to_same",
+        ),
+        pytest.param(
+            "config_with_schema",
+            ["c=c2_with_schema"],
+            [
+                DefaultElement(config_name="config_with_schema", parent="this_test"),
+                DefaultElement(config_name="schema/c/c2", parent="c/c2_with_schema"),
+                DefaultElement(
+                    config_group="c",
+                    config_name="c2_with_schema",
+                    parent="config_with_schema",
+                ),
+            ],
+            id="schema:override_to_c2_with_schema",
+        ),
+    ],
+)
+def test_apply_overrides_to_defaults(
+    config_with_defaults: str,
+    overrides: List[str],
+    expected: Any,
+    recwarn: Any,  # this tests some deprecated functionality
+) -> None:
+    assert isinstance(config_with_defaults, str)
+
+    csp = ConfigSearchPathImpl()
+    csp.append(provider="test", path="file://tests/test_data/new_defaults_lists")
+    repo = ConfigRepository(config_search_path=csp)
+
+    def create_defaults() -> Any:
+        parser = OverridesParser.create()
+        parsed_overrides = parser.parse_overrides(overrides=overrides)
+        overrides_as_defaults = convert_overrides_to_defaults(parsed_overrides)
+        ret = [
+            DefaultElement(config_name=config_with_defaults, parent="this_test"),
+        ]
+        ret.extend(overrides_as_defaults)
+        return ret
+
+    if isinstance(expected, list):
+        defaults = create_defaults()
+        ret = expand_defaults_list(defaults=defaults, skip_missing=False, repo=repo)
+        assert ret == expected
+    else:
+        with expected:
+            defaults = create_defaults()
+            expand_defaults_list(defaults=defaults, skip_missing=False, repo=repo)
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "element,expected",
+    [
+        pytest.param(
+            DefaultElement(config_name="with_missing", parent="this_test"),
+            [
+                DefaultElement(config_name="with_missing", parent="this_test"),
+                DefaultElement(
+                    config_group="a",
+                    config_name="???",
+                    skip_load=True,
+                    skip_load_reason="missing_skipped",
+                    parent="with_missing",
+                ),
+            ],
+            id="with_missing",
+        ),
+    ],
+)
+def test_missing_with_skip_missing(
+    hydra_restore_singletons: Any,
+    element: DefaultElement,
+    expected: Any,
+) -> None:
+
+    csp = ConfigSearchPathImpl()
+    csp.append(provider="test", path="file://tests/test_data/new_defaults_lists")
+    repo = ConfigRepository(config_search_path=csp)
+
+    ret = compute_element_defaults_list(element=element, skip_missing=True, repo=repo)
+    assert ret == expected
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "element",
+    [
+        pytest.param(
+            DefaultElement(
+                config_group="interpolation", config_name="i2_legacy_with_self"
+            ),
+        ),
+    ],
+)
+def test_legacy_interpolation_are_deprecated(
+    hydra_restore_singletons: Any,
+    element: DefaultElement,
+) -> None:
+    csp = ConfigSearchPathImpl()
+    csp.append(provider="test", path="file://tests/test_data/new_defaults_lists")
+    repo = ConfigRepository(config_search_path=csp)
+    msg = dedent(
+        """
+        Defaults list element 'a_b=${defaults.1.a}_${defaults.2.b}' is using a deprecated interpolation form.
+        See http://hydra.cc/docs/next/upgrades/1.0_to_1.1/defaults_list_interpolation for migration information.
+        """
+    )
+    with pytest.warns(UserWarning, match=re.escape(msg)):
+        compute_element_defaults_list(element=element, skip_missing=True, repo=repo)
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "element",
+    [
+        pytest.param(
+            DefaultElement(config_group="a", config_name="invalid_defaults_list"),
+        ),
+    ],
+)
+def test_load_invalid_defaults(
+    hydra_restore_singletons: Any,
+    element: DefaultElement,
+) -> None:
+    csp = ConfigSearchPathImpl()
+    csp.append(provider="test", path="file://tests/test_data/new_defaults_lists")
+    repo = ConfigRepository(config_search_path=csp)
+    msg = dedent(
+        f"""\
+        Invalid defaults list in '{element.config_path()}', defaults must be a list.
+        Example of a valid defaults:
+        defaults:
+          - dataset: imagenet
+          - model: alexnet
+            optional: true
+          - optimizer: nesterov
+        """
+    )
+    with pytest.raises(ValueError, match=re.escape(msg)):
+        compute_element_defaults_list(element=element, skip_missing=True, repo=repo)

--- a/tests/test_examples/test_patterns.py
+++ b/tests/test_examples/test_patterns.py
@@ -1,9 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import re
+from textwrap import dedent
 from typing import Any
 
 from hydra.test_utils.test_utils import (
     TTaskRunner,
+    assert_text_same,
     chdir_hydra_root,
     run_with_error,
     verify_dir_outputs,
@@ -37,5 +38,16 @@ def test_write_protect_config_node(tmpdir: Any) -> None:
         "data_bits=10",
     ]
 
+    expected = dedent(
+        """\
+        Error merging override data_bits=10
+        Cannot change read-only config container
+        \tfull_key: data_bits
+        \treference_type=Optional[SerialPort]
+        \tobject_type=SerialPort
+
+        Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
+        """
+    )
     err = run_with_error(cmd)
-    assert re.search(re.escape("Error merging override data_bits=10"), err) is not None
+    assert_text_same(from_line=expected, to_line=err)

--- a/website/docs/advanced/defaults_list.md
+++ b/website/docs/advanced/defaults_list.md
@@ -1,0 +1,223 @@
+---
+id: defaults_list
+title: The Defaults List
+---
+
+## Introduction
+
+:::important
+Many of the features described in this page are new to Hydra 1.1 and are considered experimental.
+Please report any issues.
+:::
+
+A Defaults List determines how to build a config object from other configs, and in what order. 
+Each config can have a Defaults List as a top level element. The Defaults List itself is not a part of resulting config.
+
+The most common items in the Default List are Config Group Defaults, which determines which config group option
+to use from a particular config group.
+
+```yaml
+defaults:
+ - db: mysql # use mysql as the choice for the db config group
+```
+
+Sometimes a config file should be loaded unconditionally. Such configs can be specified as a string in the 
+Defaults List:
+```yaml
+defaults:
+  - db/mysql  # use db/mysql.yaml unconditionally
+```
+Config files loaded this way are not a part of a config group and will always be loaded.
+They cannot be overridden. In general it is recommended to use the first form (config group default) when possible.
+
+## Defaults list resolution
+When composing the [Output Config Object](/terminology.md#output-config-object), Hydra will first create the final Defaults List and will then compose the
+config with it.
+
+Creating the final defaults list is a complex process: Configs mentioned in the list may have
+their own defaults list, sometimes defining the same config groups!
+
+The behavior that process is implementing can be described by two simple rules:
+1. The last appearance of a config group determines the final value for that group
+2. First appearance of a config group determines the composition order for that group
+
+The first rule allows you to always override a config group selection that was made earlier.
+The second rules ensures that composition order is respected.
+
+## Composition order and `_self_`
+A config can contain both a Defaults List and config nodes.
+
+The special element `_self_` can be added to determine the composition order of this config relative to the items
+in the defaults list.
+
+If `_self_` is not specified, it is implicitly inserted at the top of the defaults list.
+This means that by default, elements in the defaults list are composed **after** the config declaring the Defaults List.
+
+<div className="row">
+<div className="col col--6">
+
+```yaml title="Input without _self_"
+defaults:
+ - foo: bar
+
+```
+</div>
+
+<div className="col  col--6">
+
+```yaml title="Is equivalent to"
+defaults:
+ - _self_
+ - foo: bar
+```
+
+</div>
+</div>
+
+An example with two config files:
+
+<div className="row">
+<div className="col col--6">
+
+```yaml title="config.yaml"
+defaults:
+ - _self_
+ - db: mysql
+```
+
+</div>
+
+<div className="col  col--6">
+
+```yaml title="db/mysql.yaml"
+defaults:
+ - mysql/engine: innodb
+ - _self_
+```
+</div>
+</div>
+
+
+When composing `config.yaml`, the resulting defaults list will be:
+```yaml
+defaults:
+ - config              # per defaults list in config.yaml, it comes first (_self_)
+ - mysql/engine/innodb # first per defaults list in db/mysql  
+ - db/mysql            # second per defaults list in db/mysql (_self_)
+```
+
+The last two items are added as a result of the expansion of `db/mysql.yaml`.
+
+## Interpolation
+The Defaults List supports a limited form of interpolation that differs from the normal interpolation in several aspects.
+- The Defaults List is resolved before the config is computed, so it cannot refer to nodes from the computed config.
+- The defaults list can interpolate with config groups directly
+
+```yaml
+defaults:
+ - dataset: imagenet
+ - model: alexnet
+ - dataset_model: ${dataset}_{model} # will become imagenet_alexnet
+   optional: true                    # do not fail if this config is not found
+```
+
+See [Specializing Configs](/patterns/specializing_config.md) for a more detailed explanation of this example.
+
+## Renaming packages
+Packages of previously defined config groups can be overridden by later items in the Defaults List.
+The syntax is similar to that described in [Basic Override syntax](/advanced/override_grammar/basic.md#modifying-the-defaults-list),
+ 
+<div className="row">
+<div className="col col--6">
+
+```yaml title="Moving to package src"
+defaults:
+  - db: mysql
+  - 'db@:src': _keep_
+```
+
+```yaml title="Renaming package from src to dst"
+defaults:
+  - db@src: mysql
+  - 'db@src:dst': _keep_
+```
+
+```yaml title="Renaming package and changing choice"
+defaults:
+  - db: mysql
+  - 'db@:src': postgresql
+```
+
+</div>
+
+<div className="col  col--6">
+
+```yaml title="Result"
+defaults:
+  - db@src: mysql
+
+```
+
+```yaml title="Result"
+defaults:
+  - db@dst: mysql
+
+```
+
+```yaml title="Result"
+defaults:
+  - db@dst: postgresql
+
+```
+
+
+</div>
+</div>
+
+
+## Deleting from the defaults list
+Previously defined config groups can be deleted by later items in the Defaults List. 
+The syntax is similar to that described in [Basic Override syntax](/advanced/override_grammar/basic.md#modifying-the-defaults-list),
+
+```yaml
+defaults:
+ - db: mysql
+ - ~db # will delete `db` from the list regardless of the choice
+```
+
+```yaml
+defaults:
+ - db: mysql
+ - ~db: mysql # will delete db from the list if the selected value is mysql
+```
+
+
+
+## Config "Inheritance" via composition
+
+TODO: should probably not be here
+
+A common pattern is to "extend" a base config:
+```yaml title="agent.yaml"
+name: ???
+age: ???
+agency: mi6
+```
+
+```yaml title="bond.yaml"
+defaults:
+  - agent
+  - _self_
+
+name: Bond, James Bond
+age: 7
+```
+
+In the above example, `bond.yaml` is overriding the name and age in `base.yaml`
+The resulting config will thus be:
+```yaml
+name: Bond, James Bond
+age: 7
+agency: mi6
+```
+

--- a/website/docs/advanced/hydra-command-line-flags.md
+++ b/website/docs/advanced/hydra-command-line-flags.md
@@ -6,10 +6,10 @@ title: Hydra's command line flags
 Hydra is using the command line for two things:
 
 - Configuring your application (See [Override Grammar](override_grammar/basic.md))
-- Telling Hydra what to do.
+- Controlling Hydra
 
-Any argparse argument that is prefixed by `--`  or `'-` is telling Hydra what to do.
-The rest of the parameters are used to configure your application.
+Any argparse argument that is prefixed by `--`  or `'-` is controlling Hydra.
+The rest of the arguments are used to configure your application.
 
 
 You can view the Hydra specific flags via `--hydra-help`.

--- a/website/docs/patterns/specializing_config.md
+++ b/website/docs/patterns/specializing_config.md
@@ -25,7 +25,7 @@ The idea is that we can add another element to the defaults list that would load
 defaults:
   - dataset: imagenet
   - model: alexnet
-  - dataset_model: ${defaults.0.dataset}_${defaults.1.model}
+  - dataset_model: ${dataset}_${model}
     optional: true
 ```
 
@@ -33,10 +33,14 @@ Let's break this down:
 #### dataset_model
 The key `dataset_model` is an arbitrary directory, it can be anything unique that makes sense, including nested directory like `dataset/model`.
 
-#### ${defaults.0.dataset}_${defaults.1.model}
-the value `${defaults.0.dataset}_${defaults.1.model}` is using OmegaConf's [variable interpolation](https://omegaconf.readthedocs.io/en/latest/usage.html#variable-interpolation).
+#### ${dataset}_${model}
+the value `${dataset}_${model}` is using OmegaConf's [variable interpolation](https://omegaconf.readthedocs.io/en/latest/usage.html#variable-interpolation) syntax.
 At runtime, that value would resolve to *imagenet_alexnet*, or *cifar_resnet* - depending on the values of defaults.dataset and defaults.model.
-This a bit clunky because defaults contains a list (I hope to improve this in the future)
+
+:::info
+This is not standard interpolations and there are some subtle differences and limitations.
+:::
+
 
 #### optional: true
 By default, Hydra would fail with an error if a config specified in the defaults does not exist.

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -16,7 +16,6 @@ Supported input configs are:
 ### Primary Config
 The input config named in [`@hydra.main()`](tutorials/basic/your_first_app/1_simple_cli.md) or in 
 the [`Compose API`](experimental/hydra_compose.md).  
-The Primary Config is the only config that is allowed to have a [Defaults List](#defaults-list)
 
 
 ### Structured Config
@@ -35,8 +34,8 @@ class User:
 
 
 ### Defaults List
-A list in the [Primary Config](#primary-config) that determines how to build the final [Config Object](#output-config-object). 
-The list is typically composed of [Config Group Options](#config-group-option). 
+A list in [input Config](#input-configs) that instructs Hydra how to build the config. 
+The list is typically composed of [Config Group Options](#config-group-option).
 ```yaml title="Example: config.yaml"
 defaults:
   - db: mysql

--- a/website/docs/tutorials/basic/your_first_app/5_defaults.md
+++ b/website/docs/tutorials/basic/your_first_app/5_defaults.md
@@ -10,6 +10,9 @@ You no longer want to type `+db=mysql` every time you run your application.
 
 You can add a `defaults` list into your config file.
 
+This tutorial page briefly describes the Defaults List.  
+Refer to [The Defaults List page](../../../advanced/defaults_list) for more information.
+
 ## Config group defaults
 
 ```yaml title="config.yaml"

--- a/website/docs/upgrades/0.11_to_1.0/adding_a_package_directive.md
+++ b/website/docs/upgrades/0.11_to_1.0/adding_a_package_directive.md
@@ -1,7 +1,9 @@
 ---
 id: adding_a_package_directive
 title: Adding an @package directive
+hide_title: true
 ---
+## Adding an @package directive
 Hydra 1.0 introduces the concept of a config `package`. A `package` is the common parent 
 path of all nodes in the config file.
 

--- a/website/docs/upgrades/0.11_to_1.0/config_path_changes.md
+++ b/website/docs/upgrades/0.11_to_1.0/config_path_changes.md
@@ -1,9 +1,10 @@
 ---
 id: config_path_changes
 title: Config path changes
+hide_title: true
 ---
 
-## Overview
+## Config path changes
 Hydra 1.0 adds a new `config_name` parameter to `@hydra.main()` and changes the meaning of the `config_path`.
 Previously, `config_path` encapsulated two things:
 - Search path relative to the declaring python file.

--- a/website/docs/upgrades/0.11_to_1.0/object_instantiation_changes.md
+++ b/website/docs/upgrades/0.11_to_1.0/object_instantiation_changes.md
@@ -1,10 +1,11 @@
 ---
 id: object_instantiation_changes
 title: Object instantiation changes
+hide_title: true
 ---
 
 
-## Overview
+## Object instantiation changes
 Hydra 1.0.0 is deprecating ObjectConf and the corresponding config structure to a simpler one without the params node.
 This removes a level of nesting from command line and configs overrides.
 

--- a/website/docs/upgrades/0.11_to_1.0/strict_mode_flag_deprecated.md
+++ b/website/docs/upgrades/0.11_to_1.0/strict_mode_flag_deprecated.md
@@ -1,8 +1,9 @@
 ---
 id: strict_mode_flag_deprecated
 title: strict flag mode deprecation
+hide_title: true
 ---
-## Overview
+## strict flag mode deprecation
 The strict mode is a flag added to `@hydra.main()` to enable two features:
 - Command line error detection (overriding a field not in the config)
 - Runtime config access error detection (accessing/setting a field not in the config)

--- a/website/docs/upgrades/1.0_to_1.1/defaults_list_interpolation_changes.md
+++ b/website/docs/upgrades/1.0_to_1.1/defaults_list_interpolation_changes.md
@@ -1,0 +1,40 @@
+---
+id: defaults_list_interpolation
+title: Defaults List interpolation
+hide_title: true
+---
+
+## Defaults List interpolation
+The defaults lists are used to compose the final config object.
+Hydra supports a limited form of interpolation in the defaults list.
+The interpolation style described there is deprecated in favor of a cleaner style more
+appropriate to recursive default lists.
+
+## Migration examples
+
+For example, the following snippet from Hydra 1.0 or older: 
+```yaml
+defaults:
+  - dataset: imagenet
+  - model: alexnet
+  - dataset_model: ${defaults.0.dataset}_${defaults.1.model}
+```
+
+Changes to this in Hydra 1.1 or newer:
+```yaml
+defaults:
+  - dataset: imagenet
+  - model: alexnet
+  - dataset_model: ${dataset}_${model}
+```
+
+The new style is more compact and does not require specifying the exact index of the element in the defaults list.
+This is enables interpolating using config group values that are coming from recursive defaults.
+
+Note that:
+ - This is non-standard interpolation support that is unique to the defaults list
+ - interpolation keys in the defaults list can not access values from the composed config because it does not yet 
+ exist when Hydra is processing the defaults list
+
+:::warning
+Support for the old style will be removed in Hydra 1.2.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -92,7 +92,7 @@ module.exports = {
             'plugins/submitit_launcher',
         ],
 
-        'Advanced': [
+        'Reference manual': [
             'advanced/hydra-command-line-flags',
             {
                 type: 'category',
@@ -102,6 +102,7 @@ module.exports = {
                     'advanced/override_grammar/extended',
                 ]
             },
+            'advanced/defaults_list',
             'advanced/overriding_packages',
             'advanced/search_path',
             'advanced/plugins',
@@ -124,6 +125,13 @@ module.exports = {
         ],
 
         Upgrades: [
+          {
+            type: 'category',
+            label: '1.0 to 1.1',
+            items: [
+                'upgrades/1.0_to_1.1/defaults_list_interpolation',
+            ],
+          },
           {
             type: 'category',
             label: '0.11 to 1.0',


### PR DESCRIPTION
Closes #171
Closes #326
Closes #1080
Closes #1089

- [x] Add `_self_` support (#326)
- [x] Support recursive defaults (with all the existing features, deletion, package rename, overriding)
- [x] Clean new TODOs in the code
- [x] Deprecated `- group: null` deletion form from defaults list in favor of `~group` and `~group=value`.
- [x] Ensure no performance regression (will likely require caching of loaded configs because the new system does two passes.
- [x] Include information about actually used defaults list in the generated Hydra config node.
- [X] Consider changing default for unspecified `_self_` to be last in the list and not first as it is now
  - Decided against. While this is arguably more intuitive for config files it's less intuitive for dataclasses with defaults list.
- [x] Document recursive defaults (probably warrants a dedicated page just for the defaults list).
- [x] Document `_self_`
- [x] Deprecated old way of using interpolation in the defaults list. specifically the pattern in [specializing configs](https://hydra.cc/docs/patterns/specializing_config) will be removed in the future in favor of the simpler but more magical new style. Old style is still supported in 1.1 but will be removed in 1.2.

This:
```yaml
defaults:
  - dataset: imagenet
  - model: alexnet
  - dataset_model: ${defaults.0.dataset}_${defaults.1.model}
    optional: true
```
Will become:
```yaml
defaults:
  - dataset: imagenet
  - model: alexnet
  - dataset_model: ${dataset}_${model}`
    optional: true
```