### PR TITLE
fix lints on hydra 1.0_branch

### DIFF
--- a/hydra/_internal/grammar/grammar_functions.py
+++ b/hydra/_internal/grammar/grammar_functions.py
@@ -309,7 +309,7 @@ def _sort_sweep(
     sweep = copy(sweep)
 
     if isinstance(sweep, ChoiceSweep):
-        sweep.list = sorted(sweep.list, reverse=reverse)
+        sweep.list = sorted(sweep.list, reverse=reverse)  # type: ignore
         return sweep
     elif isinstance(sweep, RangeSweep):
         assert sweep.start is not None

--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -175,7 +175,7 @@ class Plugins(metaclass=Singleton):
                         )
                         for w in recorded_warnings:
                             warnings.showwarning(
-                                message=w.message,  # type: ignore
+                                message=w.message,
                                 category=w.category,
                                 filename=w.filename,
                                 lineno=w.lineno,


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

lints have started to [fai](https://app.circleci.com/pipelines/github/facebookresearch/hydra/3963/workflows/df530697-d765-45ec-b120-e466d4c7f32a/jobs/28990) on 1.0_branch.

```
nox > [2020-10-09 17:21:29,828] Command mypy . --strict failed with exit code 1:
hydra/_internal/grammar/grammar_functions.py:312: error: Value of type variable "_LT" of "sorted" cannot be "Union[str, float, List[Any], Dict[str, Any], QuotedString, None]"
hydra/core/plugins.py:178: error: unused 'type: ignore' comment
Found 2 errors in 2 files (checked 86 source files)
```


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

run lints locally.
## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
