### PR TITLE
Set `USER` env variable only if it is not already set.

### DIFF
--- a/hydra/test_utils/test_utils.py
+++ b/hydra/test_utils/test_utils.py
@@ -26,8 +26,8 @@ from hydra.core.utils import JobReturn, split_config_path
 from hydra.types import TaskFunction
 
 # CircleCI does not have the environment variable USER, breaking the tests.
-if "USER" not in os.environ:
-    os.environ["USER"] = "test_user"
+# if "USER" not in os.environ:
+#     os.environ["USER"] = "test_user"
 
 
 @contextmanager

--- a/hydra/test_utils/test_utils.py
+++ b/hydra/test_utils/test_utils.py
@@ -26,8 +26,8 @@ from hydra.core.utils import JobReturn, split_config_path
 from hydra.types import TaskFunction
 
 # CircleCI does not have the environment variable USER, breaking the tests.
-
-os.environ["USER"] = "test_user"
+if "USER" not in os.environ:
+    os.environ["USER"] = "test_user"
 
 
 @contextmanager

--- a/hydra/test_utils/test_utils.py
+++ b/hydra/test_utils/test_utils.py
@@ -25,10 +25,6 @@ from hydra.core.global_hydra import GlobalHydra
 from hydra.core.utils import JobReturn, split_config_path
 from hydra.types import TaskFunction
 
-# CircleCI does not have the environment variable USER, breaking the tests.
-# if "USER" not in os.environ:
-#     os.environ["USER"] = "test_user"
-
 
 @contextmanager
 def does_not_raise(enter_result: Any = None) -> Iterator[Any]:

--- a/news/1059.bugfix
+++ b/news/1059.bugfix
@@ -1,1 +1,1 @@
-Installing Hydra was setting `USER` env variable in pytest tests via a pytest plugin.
+Hydra no longer errorenously changes the USER environment variable in pytest unit tests once installed

--- a/news/1059.bugfix
+++ b/news/1059.bugfix
@@ -1,0 +1,1 @@
+Installing Hydra was setting `USER` env variable in pytest tests via a pytest plugin.

--- a/tests/test_examples/test_tutorials_basic.py
+++ b/tests/test_examples/test_tutorials_basic.py
@@ -295,9 +295,9 @@ def test_advanced_ad_hoc_composition(
         "hydra.run.dir=" + str(tmpdir),
     ]
     result, _err = get_run_output(cmd)
+    assert OmegaConf.create(result) == OmegaConf.create(expected)
     if should_remove_variable:
         del os.environ["USER"]
-    assert OmegaConf.create(result) == OmegaConf.create(expected)
 
 
 def test_examples_using_the_config_object(tmpdir: Path) -> None:

--- a/tests/test_examples/test_tutorials_basic.py
+++ b/tests/test_examples/test_tutorials_basic.py
@@ -286,13 +286,17 @@ def test_advanced_ad_hoc_composition(
 ) -> None:
 
     # CircleCI does not have the environment variable USER.
+    should_remove_variable = False
     if "USER" not in os.environ:
         os.environ["USER"] = "test_user"
+        should_remove_variable = True
     cmd = [
         "examples/advanced/ad_hoc_composition/hydra_compose_example.py",
         "hydra.run.dir=" + str(tmpdir),
     ]
     result, _err = get_run_output(cmd)
+    if should_remove_variable:
+        del os.environ["USER"]
     assert OmegaConf.create(result) == OmegaConf.create(expected)
 
 

--- a/tests/test_examples/test_tutorials_basic.py
+++ b/tests/test_examples/test_tutorials_basic.py
@@ -1,5 +1,4 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import os
 import re
 import subprocess
 from pathlib import Path
@@ -282,22 +281,16 @@ def test_sweeping_example(
     ],
 )
 def test_advanced_ad_hoc_composition(
-    tmpdir: Path, args: List[str], expected: Any
+    monkeypatch: Any, tmpdir: Path, args: List[str], expected: Any
 ) -> None:
 
-    # CircleCI does not have the environment variable USER.
-    should_remove_variable = False
-    if "USER" not in os.environ:
-        os.environ["USER"] = "test_user"
-        should_remove_variable = True
+    monkeypatch.setenv("USER", "test_user")
     cmd = [
         "examples/advanced/ad_hoc_composition/hydra_compose_example.py",
         "hydra.run.dir=" + str(tmpdir),
     ]
     result, _err = get_run_output(cmd)
     assert OmegaConf.create(result) == OmegaConf.create(expected)
-    if should_remove_variable:
-        del os.environ["USER"]
 
 
 def test_examples_using_the_config_object(tmpdir: Path) -> None:

--- a/tests/test_examples/test_tutorials_basic.py
+++ b/tests/test_examples/test_tutorials_basic.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -283,6 +284,10 @@ def test_sweeping_example(
 def test_advanced_ad_hoc_composition(
     tmpdir: Path, args: List[str], expected: Any
 ) -> None:
+
+    # CircleCI does not have the environment variable USER.
+    if "USER" not in os.environ:
+        os.environ["USER"] = "test_user"
     cmd = [
         "examples/advanced/ad_hoc_composition/hydra_compose_example.py",
         "hydra.run.dir=" + str(tmpdir),


### PR DESCRIPTION
Fixes #1059.

<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Set `USER` env variable only if it is not already set.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

CI

## Related Issues and PRs

#1059 
