### PR TITLE
separate tests that expects support on overlap config name and path

### DIFF
--- a/hydra/test_utils/config_source_common_tests.py
+++ b/hydra/test_utils/config_source_common_tests.py
@@ -16,7 +16,7 @@ class ConfigSourceTestSuite:
         Some config source plugins do not support config name and path overlap, for example:
         /dateset.yaml
         /dataset/cifar.yaml
-        is not allowed in configerator.
+        may not be allowed.
         """
         return False
 
@@ -48,13 +48,6 @@ class ConfigSourceTestSuite:
         ret = src.is_group(config_path=config_path)
         assert ret == expected
 
-    def is_config_helper(
-        self, type_: Type[ConfigSource], path: str, config_path: str, expected: bool
-    ) -> None:
-        src = type_(provider="foo", path=path)
-        ret = src.is_config(config_path=config_path)
-        assert ret == expected
-
     @mark.parametrize(  # type: ignore
         "config_path, expected",
         [
@@ -73,7 +66,9 @@ class ConfigSourceTestSuite:
     def test_is_config(
         self, type_: Type[ConfigSource], path: str, config_path: str, expected: bool
     ) -> None:
-        self.is_config_helper(type_, path, config_path, expected)
+        src = type_(provider="foo", path=path)
+        ret = src.is_config(config_path=config_path)
+        assert ret == expected
 
     @mark.parametrize(  # type: ignore
         "config_path, expected",
@@ -86,21 +81,9 @@ class ConfigSourceTestSuite:
     ) -> None:
         if self.skip_overlap_config_path_name():
             pytest.skip("Plugin does not support overlap config name with config path.")
-        self.is_config_helper(type_, path, config_path, expected)
-
-    def list_helper(
-        self,
-        type_: Type[ConfigSource],
-        path: str,
-        config_path: str,
-        results_filter: Optional[ObjectType],
-        expected: List[str],
-    ) -> None:
         src = type_(provider="foo", path=path)
-        ret = src.list(config_path=config_path, results_filter=results_filter)
-        for x in expected:
-            assert x in ret
-        assert ret == sorted(ret)
+        ret = src.is_config(config_path=config_path)
+        assert ret == expected
 
     @mark.parametrize(  # type: ignore
         "config_path,results_filter,expected",
@@ -134,7 +117,11 @@ class ConfigSourceTestSuite:
         results_filter: Optional[ObjectType],
         expected: List[str],
     ) -> None:
-        self.list_helper(type_, path, config_path, results_filter, expected)
+        src = type_(provider="foo", path=path)
+        ret = src.list(config_path=config_path, results_filter=results_filter)
+        for x in expected:
+            assert x in ret
+        assert ret == sorted(ret)
 
     @mark.parametrize(  # type: ignore
         "config_path,results_filter,expected",
@@ -153,7 +140,11 @@ class ConfigSourceTestSuite:
     ) -> None:
         if self.skip_overlap_config_path_name():
             pytest.skip("Plugin does not support overlap config name with config path.")
-        self.list_helper(type_, path, config_path, results_filter, expected)
+        src = type_(provider="foo", path=path)
+        ret = src.list(config_path=config_path, results_filter=results_filter)
+        for x in expected:
+            assert x in ret
+        assert ret == sorted(ret)
 
     @mark.parametrize(  # type: ignore
         "config_path,expected,expectation",

--- a/hydra/test_utils/config_source_common_tests.py
+++ b/hydra/test_utils/config_source_common_tests.py
@@ -18,9 +18,9 @@ class ConfigSourceTestSuite:
         (dataset exists both as a config object and a config group)
         /dateset.yaml
         /dataset/cifar.yaml
-
-        Override this function to return True so the test assumes /dataset/cifar.yaml
-        exists instead of /dataset.yaml
+        
+        Overriding and returning True here will disable testing of this scenario
+        by assuming the dataset config (dataset.yaml) is not present.
         """
         return False
 

--- a/hydra/test_utils/config_source_common_tests.py
+++ b/hydra/test_utils/config_source_common_tests.py
@@ -52,7 +52,6 @@ class ConfigSourceTestSuite:
         "config_path, expected",
         [
             ("", False),
-            ("dataset", True),
             ("optimizer", False),
             ("dataset/imagenet", True),
             ("dataset/imagenet.yaml", True),
@@ -95,7 +94,6 @@ class ConfigSourceTestSuite:
             ("level1", ObjectType.GROUP, ["level2"]),
             ("level1/level2", ObjectType.GROUP, []),
             # Configs
-            ("", ObjectType.CONFIG, ["config_without_group", "dataset"]),
             ("dataset", ObjectType.CONFIG, ["cifar10", "imagenet"]),
             ("optimizer", ObjectType.CONFIG, ["adam", "nesterov"]),
             ("level1", ObjectType.CONFIG, []),


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation
The config source test suite expects the config source plugins to support the following patterns: config name and config path overlap.
```
/dataset.yaml
/dataset/imagenet.yaml
```
However this pattern is not supported in `configerator`, this PR aims to provide a way for the subclasses of this test suite to skip the tests when needed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

created my own test_suite
**SKIP the tests**
```
@pytest.mark.parametrize(
    "type_, path",
    [
        pytest.param(
            FileConfigSource,
            "file://tests/test_apps/config_source_test/dir",
            id="FileConfigSource",
        ),
    ],
)
class TestCoreConfigSources(ConfigSourceTestSuite):

    def skip_overlap_config_path_name(self) -> bool:
        return True
```
output

```
$ pytest -s /Users/jieru/workspace/hydra-fork/hydra/tests/test_jieru.py
====================================================================================================== test session starts =======================================================================================================
platform darwin -- Python 3.8.2, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /Users/jieru/workspace/hydra-fork/hydra, inifile: pytest.ini
plugins: snail-0.1.0, hydra-core-1.1.0.dev1
collected 51 items                                                                                                                                                                                                               

tests/test_jieru.py ...................s................s..............

================================================================================================= 49 passed, 2 skipped in 0.11s ==================================================================================================
(pytest38) jieru-mbp:hydra jieru$ 

```

**Do not skip**


```
@pytest.mark.parametrize(
    "type_, path",
    [
        pytest.param(
            FileConfigSource,
            "file://tests/test_apps/config_source_test/dir",
            id="FileConfigSource",
        ),
    ],
)
class TestCoreConfigSources(ConfigSourceTestSuite):
    pass

```
output
```
$ pytest -s /Users/jieru/workspace/hydra-fork/hydra/tests/test_jieru.py
================================================================================================================================ test session starts ================================================================================================================================
platform darwin -- Python 3.8.2, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /Users/jieru/workspace/hydra-fork/hydra, inifile: pytest.ini
plugins: snail-0.1.0, hydra-core-1.1.0.dev1
collected 51 items                                                                                                                                                                                                                                                                  

tests/test_jieru.py ...................................................

================================================================================================================================ 51 passed in 0.14s =================================================================================================================================
(pytest38) jieru-mbp:hydra jieru$ 

```
## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
