### PR TITLE
pip install with no progress bar in circleCI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,6 @@ commands:
             conda create -n hydra python=<< parameters.py_version >> pywin32 -qy
             conda activate hydra
             pip install nox --progress-bar off
-            pip install dataclasses --progress-bar off
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
           paths:
@@ -119,7 +118,6 @@ jobs:
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
             conda activate hydra
             pip install nox --progress-bar off
-            pip install dataclasses --progress-bar off
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
   test_linux:
     parameters:
@@ -136,7 +134,6 @@ jobs:
             export PATH="$HOME/miniconda3/envs/hydra/bin:$PATH"
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
             pip install nox --progress-bar off
-            pip install dataclasses --progress-bar off
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
   test_win:
     parameters:
@@ -184,7 +181,6 @@ jobs:
               export PLUGINS=<< parameters.test_plugin >>
               conda activate hydra
               pip install nox --progress-bar off
-              pip install dataclasses --progress-bar off
               nox -s lint_plugins test_plugins -ts
   test_plugin_linux:
     parameters:
@@ -204,7 +200,6 @@ jobs:
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
             export PLUGINS=<< parameters.test_plugin >>
             pip install nox --progress-bar off
-            pip install dataclasses --progress-bar off
             nox -s lint_plugins test_plugins -ts
   test_plugin_win:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ commands:
             conda create -n hydra python=<< parameters.py_version >> pywin32 -qy
             conda activate hydra
             pip install nox --progress-bar off
-            pip install dataclasses --progress-bar off
+            pip install dataclasses --progress-bar off  # installation needed for python 3.6
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
           paths:
@@ -119,7 +119,7 @@ jobs:
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
             conda activate hydra
             pip install nox --progress-bar off
-            pip install dataclasses --progress-bar off
+            pip install dataclasses --progress-bar off  # installation needed for python 3.6
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
   test_linux:
     parameters:
@@ -136,7 +136,7 @@ jobs:
             export PATH="$HOME/miniconda3/envs/hydra/bin:$PATH"
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
             pip install nox --progress-bar off
-            pip install dataclasses --progress-bar off
+            pip install dataclasses --progress-bar off  # installation needed for python 3.6
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
   test_win:
     parameters:
@@ -184,7 +184,7 @@ jobs:
               export PLUGINS=<< parameters.test_plugin >>
               conda activate hydra
               pip install nox --progress-bar off
-              pip install dataclasses --progress-bar off
+              pip install dataclasses --progress-bar off  # installation needed for python 3.6
               nox -s lint_plugins test_plugins -ts
   test_plugin_linux:
     parameters:
@@ -204,7 +204,7 @@ jobs:
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
             export PLUGINS=<< parameters.test_plugin >>
             pip install nox --progress-bar off
-            pip install dataclasses --progress-bar off
+            pip install dataclasses --progress-bar off  # installation needed for python 3.6
             nox -s lint_plugins test_plugins -ts
   test_plugin_win:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ commands:
             conda create -n hydra python=<< parameters.py_version >> pywin32 -qy
             conda activate hydra
             pip install nox --progress-bar off
+            pip install dataclasses --progress-bar off
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
           paths:
@@ -118,6 +119,7 @@ jobs:
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
             conda activate hydra
             pip install nox --progress-bar off
+            pip install dataclasses --progress-bar off
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
   test_linux:
     parameters:
@@ -134,6 +136,7 @@ jobs:
             export PATH="$HOME/miniconda3/envs/hydra/bin:$PATH"
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
             pip install nox --progress-bar off
+            pip install dataclasses --progress-bar off
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
   test_win:
     parameters:
@@ -181,6 +184,7 @@ jobs:
               export PLUGINS=<< parameters.test_plugin >>
               conda activate hydra
               pip install nox --progress-bar off
+              pip install dataclasses --progress-bar off
               nox -s lint_plugins test_plugins -ts
   test_plugin_linux:
     parameters:
@@ -200,6 +204,7 @@ jobs:
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
             export PLUGINS=<< parameters.test_plugin >>
             pip install nox --progress-bar off
+            pip install dataclasses --progress-bar off
             nox -s lint_plugins test_plugins -ts
   test_plugin_win:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,7 @@ commands:
           command: |
             conda create -n hydra python=<< parameters.py_version >> pywin32 -qy
             conda activate hydra
-            pip install nox --progress-bar off
-            pip install dataclasses --progress-bar off  # installation needed for python 3.6
+            pip install nox dataclasses --progress-bar off
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
           paths:
@@ -118,8 +117,7 @@ jobs:
           command: |
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
             conda activate hydra
-            pip install nox --progress-bar off
-            pip install dataclasses --progress-bar off  # installation needed for python 3.6
+            pip install nox dataclasses --progress-bar off
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
   test_linux:
     parameters:
@@ -135,8 +133,7 @@ jobs:
           command: |
             export PATH="$HOME/miniconda3/envs/hydra/bin:$PATH"
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
-            pip install nox --progress-bar off
-            pip install dataclasses --progress-bar off  # installation needed for python 3.6
+            pip install nox dataclasses --progress-bar off
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
   test_win:
     parameters:
@@ -183,8 +180,7 @@ jobs:
               export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
               export PLUGINS=<< parameters.test_plugin >>
               conda activate hydra
-              pip install nox --progress-bar off
-              pip install dataclasses --progress-bar off  # installation needed for python 3.6
+              pip install nox dataclasses --progress-bar off
               nox -s lint_plugins test_plugins -ts
   test_plugin_linux:
     parameters:
@@ -203,8 +199,7 @@ jobs:
             export PATH="$HOME/miniconda3/envs/hydra/bin:$PATH"
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
             export PLUGINS=<< parameters.test_plugin >>
-            pip install nox --progress-bar off
-            pip install dataclasses --progress-bar off  # installation needed for python 3.6
+            pip install nox dataclasses --progress-bar off
             nox -s lint_plugins test_plugins -ts
   test_plugin_win:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
           name: Preparing environment - Hydra
           command: |
             conda create -n hydra python=<< parameters.py_version >> -yq
-            conda run -n hydra pip install nox
+            conda run -n hydra pip install nox --progress-bar off
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-macos-sys-{{ .Branch }}-<< parameters.py_version >>
           paths:
@@ -94,8 +94,8 @@ commands:
           command: |
             conda create -n hydra python=<< parameters.py_version >> pywin32 -qy
             conda activate hydra
-            pip install nox
-            pip install dataclasses
+            pip install nox --progress-bar off
+            pip install dataclasses --progress-bar off
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
           paths:
@@ -118,8 +118,8 @@ jobs:
           command: |
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
             conda activate hydra
-            pip install nox
-            pip install dataclasses
+            pip install nox --progress-bar off
+            pip install dataclasses --progress-bar off
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
   test_linux:
     parameters:
@@ -135,8 +135,8 @@ jobs:
           command: |
             export PATH="$HOME/miniconda3/envs/hydra/bin:$PATH"
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
-            pip install nox
-            pip install dataclasses
+            pip install nox --progress-bar off
+            pip install dataclasses --progress-bar off
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
   test_win:
     parameters:
@@ -183,8 +183,8 @@ jobs:
               export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
               export PLUGINS=<< parameters.test_plugin >>
               conda activate hydra
-              pip install nox
-              pip install dataclasses
+              pip install nox --progress-bar off
+              pip install dataclasses --progress-bar off
               nox -s lint_plugins test_plugins -ts
   test_plugin_linux:
     parameters:
@@ -203,8 +203,8 @@ jobs:
             export PATH="$HOME/miniconda3/envs/hydra/bin:$PATH"
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
             export PLUGINS=<< parameters.test_plugin >>
-            pip install nox
-            pip install dataclasses
+            pip install nox --progress-bar off
+            pip install dataclasses --progress-bar off
             nox -s lint_plugins test_plugins -ts
   test_plugin_win:
     parameters:
@@ -232,7 +232,7 @@ jobs:
       - image: circleci/python:3.6
     steps:
       - checkout
-      - run: sudo pip install nox
+      - run: sudo pip install nox --progress-bar off
       - run: nox -s coverage
 
 workflows:


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Clean up the circleCI log a bit by not showing progress bar when `pip install`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

CI

no more progress bar

```
Collecting nox
  Downloading nox-2020.8.22-py3-none-any.whl (44 kB)

Collecting importlib-metadata; python_version < "3.8"
  Downloading importlib_metadata-2.0.0-py2.py3-none-any.whl (31 kB)

```
## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
