### PR TITLE
Update hydra_compose.md

### DIFF
--- a/website/versioned_docs/version-0.11/advanced/hydra_compose.md
+++ b/website/versioned_docs/version-0.11/advanced/hydra_compose.md
@@ -16,7 +16,7 @@ from hydra.experimental import compose, initialize
 
 if __name__ == "__main__":
     initialize(
-        config_path="conf", strict=True,
+        config_dir="conf", strict=True,
     )
 
     cfg = compose("config.yaml", overrides=["db=mysql", "db.user=me"])


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Just correcting a small error. Hydra 0.11 uses config_dir rather than config_path as a parameter to hydra.experimental.initialize.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Likely unnecessary since this is just a small documentation change.

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)

None.