### PR TITLE
ignore UserWarning introduced by torch 1.7.0

### DIFF
--- a/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
+++ b/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
@@ -40,6 +40,7 @@ def quadratic(cfg: DictConfig) -> Any:
         (6, [[1, 2, 3, 4, 5]]),
     ],
 )
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_chunk_method_for_valid_inputs(n: int, expected: List[List[int]]) -> None:
     from hydra_plugins.hydra_ax_sweeper._core import CoreAxSweeper  # type: ignore
 
@@ -210,7 +211,7 @@ def test_ax_logging(tmpdir: Path, cmd_arg: str, expected_str: str) -> None:
         "polynomial.z=10",
         "hydra.sweeper.ax_config.max_trials=2",
     ] + [cmd_arg]
-    result, _ = get_run_output(cmd)
+    result, _ = get_run_output(cmd=cmd, allow_warnings=True)
     assert "polynomial.x: range=[-5.0, -2.0]" in result
     assert expected_str in result
     assert "polynomial.z: fixed=10" in result
@@ -246,7 +247,7 @@ def test_jobs_using_choice_between_lists(
         "hydra.run.dir=" + str(tmpdir),
         "hydra.sweeper.ax_config.max_trials=3",
     ] + [cmd_arg]
-    result, _ = get_run_output(cmd)
+    result, _ = get_run_output(cmd=cmd, allow_warnings=True)
     assert f"polynomial.coefficients: {serialized_encoding}" in result
     assert f"'polynomial.coefficients': {best_coefficients}" in result
     assert f"New best value: {best_value}" in result
@@ -282,7 +283,7 @@ def test_jobs_using_choice_between_dicts(
         "hydra.run.dir=" + str(tmpdir),
         "hydra.sweeper.ax_config.max_trials=3",
     ] + [cmd_arg]
-    result, _ = get_run_output(cmd)
+    result, _ = get_run_output(cmd=cmd, allow_warnings=True)
     assert f"polynomial.coefficients: {serialized_encoding}" in result
     assert f"'+polynomial.coefficients': {best_coefficients}" in result
     assert f"New best value: {best_value}" in result
@@ -297,6 +298,6 @@ def test_example_app(tmpdir: Path) -> None:
         "banana.y=interval(-5, 10.1)",
         "hydra.sweeper.ax_config.max_trials=2",
     ]
-    result, _ = get_run_output(cmd)
+    result, _ = get_run_output(cmd=cmd, allow_warnings=True)
     assert "banana.x: range=[-5, 5]" in result
     assert "banana.y: range=[-5.0, 10.1]" in result

--- a/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
+++ b/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
@@ -40,7 +40,7 @@ def quadratic(cfg: DictConfig) -> Any:
         (6, [[1, 2, 3, 4, 5]]),
     ],
 )
-@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.filterwarnings("ignore::UserWarning")  # type: ignore
 def test_chunk_method_for_valid_inputs(n: int, expected: List[List[int]]) -> None:
     from hydra_plugins.hydra_ax_sweeper._core import CoreAxSweeper  # type: ignore
 


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->


## Motivation

This is to address https://github.com/facebookresearch/hydra/issues/1093
Once this PR is approved I will also cherry pick the change to 1.0 branch.

@shagunsodhani pointed that it might be related to a new torch release this mornign and indeed it is the case. To verify this assumption I pined ```torch==1.6.0``` and all the tests pass.

The warning was thrown here: https://github.com/pytorch/pytorch/blob/master/c10/cuda/CUDAFunctions.cpp#L100
introduced by this commit recently 
https://github.com/pytorch/pytorch/commit/06d978a9ad329380912fdc50547363e5f822a460

example failure & stacktrace:
https://app.circleci.com/pipelines/github/facebookresearch/hydra/4259/workflows/52186ca6-be5c-41d5-a544-e350786ab999/jobs/30831



### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan

run on my linux box and verified the tests pass, CI should pass now. 
## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
