### PR TITLE
[joblib_launcher] cast params to int when applicable

### DIFF
--- a/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/_core.py
+++ b/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/_core.py
@@ -50,6 +50,18 @@ def execute_job(
     return ret
 
 
+def process_joblib_cfg(joblib_cfg: Dict[str, Any]) -> Dict[str, Any]:
+    for k, v in joblib_cfg.items():
+        if k in ["pre_dispatch", "batch_size", "max_nbytes"] and v:
+            try:
+                joblib_cfg[k] = int(v)
+            except ValueError:
+                joblib_cfg[k] = v
+        else:
+            joblib_cfg[k] = v
+    return joblib_cfg
+
+
 def launch(
     launcher: JoblibLauncher,
     job_overrides: Sequence[Sequence[str]],
@@ -73,6 +85,7 @@ def launch(
     # backend is incompatible with Hydra
     joblib_cfg = launcher.joblib
     joblib_cfg["backend"] = "loky"
+    joblib_cfg = process_joblib_cfg(joblib_cfg)
 
     log.info(
         "Joblib.Parallel({}) is launching {} jobs".format(

--- a/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/_core.py
+++ b/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/_core.py
@@ -52,9 +52,11 @@ def execute_job(
 
 def process_joblib_cfg(joblib_cfg: Dict[str, Any]) -> None:
     for k in ["pre_dispatch", "batch_size", "max_nbytes"]:
-        if k in joblib_cfg.keys() and joblib_cfg.get(k):
+        if k in joblib_cfg.keys():
             try:
-                joblib_cfg[k] = int(joblib_cfg.get(k))
+                val = joblib_cfg.get(k)
+                if val:
+                    joblib_cfg[k] = int(val)
             except ValueError:
                 pass
 

--- a/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/_core.py
+++ b/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/_core.py
@@ -50,16 +50,13 @@ def execute_job(
     return ret
 
 
-def process_joblib_cfg(joblib_cfg: Dict[str, Any]) -> Dict[str, Any]:
-    for k, v in joblib_cfg.items():
-        if k in ["pre_dispatch", "batch_size", "max_nbytes"] and v:
+def process_joblib_cfg(joblib_cfg: Dict[str, Any]) -> None:
+    for k in ["pre_dispatch", "batch_size", "max_nbytes"]:
+        if k in joblib_cfg.keys() and joblib_cfg.get(k):
             try:
-                joblib_cfg[k] = int(v)
+                joblib_cfg[k] = int(joblib_cfg.get(k))
             except ValueError:
-                joblib_cfg[k] = v
-        else:
-            joblib_cfg[k] = v
-    return joblib_cfg
+                pass
 
 
 def launch(
@@ -85,7 +82,7 @@ def launch(
     # backend is incompatible with Hydra
     joblib_cfg = launcher.joblib
     joblib_cfg["backend"] = "loky"
-    joblib_cfg = process_joblib_cfg(joblib_cfg)
+    process_joblib_cfg(joblib_cfg)
 
     log.info(
         "Joblib.Parallel({}) is launching {} jobs".format(

--- a/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/config.py
+++ b/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/config.py
@@ -24,7 +24,7 @@ class JobLibLauncherConf:
     # if greater than zero, prints progress messages
     verbose: int = 0
 
-    # timeout limit for each task
+    # timeout limit for each task. Unit dependent on backend implementation; miliseconds for loky.
     timeout: Optional[float] = None
 
     # number of batches to be pre-dispatched

--- a/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/config.py
+++ b/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/config.py
@@ -25,7 +25,7 @@ class JobLibLauncherConf:
     verbose: int = 0
 
     # timeout limit for each task
-    timeout: Optional[int] = None
+    timeout: Optional[float] = None
 
     # number of batches to be pre-dispatched
     pre_dispatch: str = "2*n_jobs"

--- a/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
+++ b/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
@@ -1,10 +1,13 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 <<<<<<< HEAD
+<<<<<<< HEAD
 from typing import Any
 =======
 from typing import Tuple
 >>>>>>> Cast params to int when applicable
 
+=======
+>>>>>>> lint
 import pytest
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
@@ -13,7 +16,6 @@ from hydra.test_utils.launcher_common_tests import (
     LauncherTestSuite,
 )
 from hydra.test_utils.test_utils import TSweepRunner, chdir_plugin_root
-from omegaconf import OmegaConf
 
 from hydra_plugins.hydra_joblib_launcher.joblib_launcher import JoblibLauncher
 

--- a/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
+++ b/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
@@ -77,21 +77,18 @@ def test_example_app(hydra_sweep_runner: TSweepRunner, tmpdir: Any) -> None:
 
 
 @pytest.mark.parametrize(  # type: ignore
-    "overrides, expected",
+    "overrides",
     [
-        ("hydra.launcher.batch_size=1", ("hydra.launcher.batch_size", "1")),
-        ("hydra.launcher.max_nbytes=10000", ("hydra.launcher.max_nbytes", "10000")),
-        ("hydra.launcher.max_nbytes=1M", ("hydra.launcher.max_nbytes", "1M")),
-        ("hydra.launcher.pre_dispatch=all", ("hydra.launcher.pre_dispatch", "all")),
-        ("hydra.launcher.pre_dispatch=10", ("hydra.launcher.pre_dispatch", "10")),
-        (
-            "hydra.launcher.pre_dispatch=3*n_jobs",
-            ("hydra.launcher.pre_dispatch", "3*n_jobs"),
-        ),
+        "hydra.launcher.batch_size=1",
+        "hydra.launcher.max_nbytes=10000",
+        "hydra.launcher.max_nbytes=1M",
+        "hydra.launcher.pre_dispatch=all",
+        "hydra.launcher.pre_dispatch=10",
+        "hydra.launcher.pre_dispatch=3*n_jobs",
     ],
 )
 def test_example_app_launcher_overrides(
-    hydra_sweep_runner: TSweepRunner, overrides: str, expected: Tuple[str]
+    hydra_sweep_runner: TSweepRunner, overrides: str
 ) -> None:
     with hydra_sweep_runner(
         calling_file="example/my_app.py",
@@ -101,7 +98,4 @@ def test_example_app_launcher_overrides(
         config_name="config",
         overrides=[overrides],
     ) as sweep:
-        assert sweep.returns is not None
-        for ret in sweep.returns[0]:
-            cfg = ret.hydra_cfg
-            assert OmegaConf.select(cfg, expected[0]) == expected[1]
+        assert sweep.returns is not None and len(sweep.returns[0]) == 1

--- a/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
+++ b/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
@@ -1,13 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-<<<<<<< HEAD
-<<<<<<< HEAD
 from typing import Any
-=======
-from typing import Tuple
->>>>>>> Cast params to int when applicable
 
-=======
->>>>>>> lint
 import pytest
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

this is to fix #1094
Some of Joblib.Parallel's params supports int, so add casting for that when applicable. Also fixed the typing for `timeout` from `int` to `float`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

CI, also added integration tests. 

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
