### PR TITLE
Skip AWS integration tests if credentials not configured.

### DIFF
--- a/plugins/hydra_ray_launcher/integration_test_tools/create_integration_test_ami.py
+++ b/plugins/hydra_ray_launcher/integration_test_tools/create_integration_test_ami.py
@@ -16,7 +16,6 @@ import subprocess
 import tempfile
 import time
 from datetime import datetime
-from pathlib import Path
 
 import boto3
 import hydra
@@ -83,36 +82,21 @@ def set_up_machine(cfg: DictConfig) -> None:
             ret = ec2_client.create_image(InstanceId=instance_id, Name=ami_name)
             image_id = ret.get("ImageId")
 
-            # wait till image is ready, this could take a while, 60 mins for now.
+            # wait till image is ready, 30 mins for now, this could take a while
             for i in range(60):
-                time.sleep(60)
+                time.sleep(30)
                 image = ec2_resource.Image(image_id)
                 if image.state == "available":
-                    print(f"{image} ready for use now.")
+                    print(
+                        f"{image} ready for use now. Please update your env variable: AWS_RAY_AMI={image}. "
+                        f"Please also update the test user's IAM policy to allow access to the new AMI."
+                    )
                     break
                 else:
                     print(f"{image} current state {image.state}")
         finally:
             # Terminate instance now we have the AMI.
             ec2_resource.instances.filter(InstanceIds=[instance_id]).terminate()
-
-        # now we update test config in s3 for integration test to consume.
-        test_config_path = str(Path(tempfile.mkdtemp()) / "config.yaml")
-        s3 = boto3.client("s3")
-        s3.download_file(
-            "hydra-integration-test-us-west-2",
-            "hydra_ray_launcher_test_config.yaml",
-            test_config_path,
-        )
-        test_config = OmegaConf.load(test_config_path)
-        test_config.ami = image_id
-        with tempfile.NamedTemporaryFile(suffix=".yaml") as f:
-            OmegaConf.save(config=test_config, f=f.name)
-            s3.upload_file(
-                f.name,
-                "hydra-integration-test-us-west-2",
-                "hydra_ray_launcher_test_config.yaml",
-            )
 
 
 if __name__ == "__main__":

--- a/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
@@ -9,7 +9,6 @@ import tempfile
 from pathlib import Path
 from typing import Generator, List, Optional
 
-import boto3  # type: ignore
 import pkg_resources
 import pytest
 from hydra.core.plugins import Plugins
@@ -44,28 +43,10 @@ win_msg = "Ray doesn't support Windows."
 cur_py_version = (
     f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 )
-
-try:
-    test_config_path = str(Path(tempfile.mkdtemp()) / "config.yaml")
-    s3 = boto3.client("s3")
-    s3.download_file(
-        "hydra-integration-test-us-west-2",
-        "hydra_ray_launcher_test_config.yaml",
-        test_config_path,
-    )
-    test_config = OmegaConf.load(test_config_path)
-    ami = test_config.ami
-    security_group_id = test_config.security_group_id
-    subnet_id = test_config.subnet_id
-    instance_role = test_config.instance_role
-except Exception as e:
-    logging.warning(
-        f"Error reading test config from S3, {e}. Try env variable instead."
-    )
-    ami = os.environ.get("AWS_RAY_AMI", "")
-    security_group_id = os.environ.get("AWS_RAY_SECURITY_GROUP", "")
-    subnet_id = os.environ.get("AWS_RAY_SUBNET", "")
-    instance_role = os.environ.get("INSTANCE_ROLE_ARN", "")
+ami = os.environ.get("AWS_RAY_AMI", "")
+security_group_id = os.environ.get("AWS_RAY_SECURITY_GROUP", "")
+subnet_id = os.environ.get("AWS_RAY_SUBNET", "")
+instance_role = os.environ.get("INSTANCE_ROLE_ARN", "")
 
 assert (
     ami != "" and security_group_id != "" and subnet_id != "" and instance_role != ""
@@ -73,6 +54,7 @@ assert (
     f"Missing variable for test, ami={ami}, security_group_id={security_group_id}, subnet_id={subnet_id}, "
     f"instance_role={instance_role}"
 )
+
 
 ray_nodes_conf = {
     "InstanceType": "m5.large",

--- a/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
@@ -9,8 +9,10 @@ import tempfile
 from pathlib import Path
 from typing import Generator, List, Optional
 
+import boto3  # type: ignore
 import pkg_resources
 import pytest
+from botocore.exceptions import NoCredentialsError, NoRegionError  # type: ignore
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
 from hydra.test_utils.launcher_common_tests import (
@@ -43,10 +45,23 @@ win_msg = "Ray doesn't support Windows."
 cur_py_version = (
     f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 )
-ami = os.environ.get("AWS_RAY_AMI", "")
-security_group_id = os.environ.get("AWS_RAY_SECURITY_GROUP", "")
-subnet_id = os.environ.get("AWS_RAY_SUBNET", "")
-instance_role = os.environ.get("INSTANCE_ROLE_ARN", "")
+
+aws_not_configured = True
+aws_not_configured_msg = "AWS credentials not configured correctly. Skipping AWS tests."
+try:
+    ec2 = boto3.client("ec2")
+    ec2.describe_regions()
+    aws_not_configured = False
+except (NoCredentialsError, NoRegionError):
+    pass
+
+
+ami = os.environ.get("AWS_RAY_AMI", "ami-0bb5a2431d0b0dcea")
+security_group_id = os.environ.get("AWS_RAY_SECURITY_GROUP", "sg-0a12b09a5ff961aee")
+subnet_id = os.environ.get("AWS_RAY_SUBNET", "subnet-acd2cfe7")
+instance_role = os.environ.get(
+    "INSTANCE_ROLE_ARN", "arn:aws:iam::135937774131:instance-profile/ray-autoscaler-v1"
+)
 
 assert (
     ami != "" and security_group_id != "" and subnet_id != "" and instance_role != ""
@@ -237,6 +252,7 @@ def manage_cluster() -> Generator[None, None, None]:
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason=win_msg)
+@pytest.mark.skipif(aws_not_configured, reason=aws_not_configured_msg)
 @pytest.mark.usefixtures("manage_cluster")
 @pytest.mark.parametrize(
     "launcher_name, overrides, tmpdir",
@@ -263,6 +279,7 @@ class TestRayAWSLauncher(LauncherTestSuite):
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason=win_msg)
+@pytest.mark.skipif(aws_not_configured, reason=aws_not_configured_msg)
 @pytest.mark.usefixtures("manage_cluster")
 @pytest.mark.parametrize(
     "tmpdir,  task_launcher_cfg, extra_flags",

--- a/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
@@ -46,14 +46,13 @@ cur_py_version = (
     f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 )
 
-aws_not_configured = True
-aws_not_configured_msg = "AWS credentials not configured correctly. Skipping AWS tests."
 try:
     ec2 = boto3.client("ec2")
     ec2.describe_regions()
     aws_not_configured = False
 except (NoCredentialsError, NoRegionError):
-    pass
+    aws_not_configured = True
+    aws_not_configured_msg = "AWS credentials not configured correctly. Skipping AWS tests."
 
 
 ami = os.environ.get("AWS_RAY_AMI", "ami-0bb5a2431d0b0dcea")

--- a/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
@@ -9,6 +9,7 @@ import tempfile
 from pathlib import Path
 from typing import Generator, List, Optional
 
+import boto3  # type: ignore
 import pkg_resources
 import pytest
 from hydra.core.plugins import Plugins
@@ -43,10 +44,28 @@ win_msg = "Ray doesn't support Windows."
 cur_py_version = (
     f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 )
-ami = os.environ.get("AWS_RAY_AMI", "")
-security_group_id = os.environ.get("AWS_RAY_SECURITY_GROUP", "")
-subnet_id = os.environ.get("AWS_RAY_SUBNET", "")
-instance_role = os.environ.get("INSTANCE_ROLE_ARN", "")
+
+try:
+    test_config_path = str(Path(tempfile.mkdtemp()) / "config.yaml")
+    s3 = boto3.client("s3")
+    s3.download_file(
+        "hydra-integration-test-us-west-2",
+        "hydra_ray_launcher_test_config.yaml",
+        test_config_path,
+    )
+    test_config = OmegaConf.load(test_config_path)
+    ami = test_config.ami
+    security_group_id = test_config.security_group_id
+    subnet_id = test_config.subnet_id
+    instance_role = test_config.instance_role
+except Exception as e:
+    logging.warning(
+        f"Error reading test config from S3, {e}. Try env variable instead."
+    )
+    ami = os.environ.get("AWS_RAY_AMI", "")
+    security_group_id = os.environ.get("AWS_RAY_SECURITY_GROUP", "")
+    subnet_id = os.environ.get("AWS_RAY_SUBNET", "")
+    instance_role = os.environ.get("INSTANCE_ROLE_ARN", "")
 
 assert (
     ami != "" and security_group_id != "" and subnet_id != "" and instance_role != ""
@@ -54,7 +73,6 @@ assert (
     f"Missing variable for test, ami={ami}, security_group_id={security_group_id}, subnet_id={subnet_id}, "
     f"instance_role={instance_role}"
 )
-
 
 ray_nodes_conf = {
     "InstanceType": "m5.large",

--- a/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
@@ -46,13 +46,13 @@ cur_py_version = (
     f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 )
 
+aws_not_configured_msg = "AWS credentials not configured correctly. Skipping AWS tests."
 try:
     ec2 = boto3.client("ec2")
     ec2.describe_regions()
     aws_not_configured = False
 except (NoCredentialsError, NoRegionError):
     aws_not_configured = True
-    aws_not_configured_msg = "AWS credentials not configured correctly. Skipping AWS tests."
 
 
 ami = os.environ.get("AWS_RAY_AMI", "ami-0bb5a2431d0b0dcea")


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

This is to address #1100 


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan
1. CI
2. remove AWS CLI configurations on my local machine and run the tests
```
$ pytest -s tests/test_ray_aws_launcher.py 
================================================================================================================================ test session starts ================================================================================================================================
platform darwin -- Python 3.8.2, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /Users/jieru/workspace/hydra-fork/hydra/plugins/hydra_ray_launcher, inifile: pytest.ini
plugins: snail-0.1.0, hydra-core-1.0.3
collected 21 items                                                                                                                                                                                                                                                                  

tests/test_ray_aws_launcher.py::test_discovery PASSED
tests/test_ray_aws_launcher.py::TestRayAWSLauncher::test_sweep_1_job[ray_aws-overrides0-tmpdir0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncher::test_sweep_2_jobs[ray_aws-overrides0-tmpdir0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncher::test_not_sweeping_hydra_overrides[ray_aws-overrides0-tmpdir0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncher::test_sweep_1_job_strict[ray_aws-overrides0-tmpdir0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncher::test_sweep_1_job_strict_and_bad_key[ray_aws-overrides0-tmpdir0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncher::test_sweep_2_optimizers[ray_aws-overrides0-tmpdir0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncher::test_sweep_over_unspecified_mandatory_default[ray_aws-overrides0-tmpdir0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncher::test_sweep_and_override[ray_aws-overrides0-tmpdir0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncher::test_sweep_with_custom_resolver[ray_aws-overrides0-tmpdir0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncherIntegration::test_custom_task_name[no_config-tmpdir0-task_launcher_cfg0-extra_flags0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncherIntegration::test_custom_task_name[different_filename-tmpdir0-task_launcher_cfg0-extra_flags0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncherIntegration::test_custom_task_name[different_filename_and_config_file_name_override-tmpdir0-task_launcher_cfg0-extra_flags0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncherIntegration::test_custom_task_name[different_filename_and_config_file_name_override_and_command_line_override-tmpdir0-task_launcher_cfg0-extra_flags0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncherIntegration::test_custom_sweeper_run_workdir[sweep_dir_config_override-tmpdir0-task_launcher_cfg0-extra_flags0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncherIntegration::test_custom_sweeper_run_workdir[sweep_dir_cli_override-tmpdir0-task_launcher_cfg0-extra_flags0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncherIntegration::test_custom_sweeper_run_workdir[sweep_dir_cli_overridding_config-tmpdir0-task_launcher_cfg0-extra_flags0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncherIntegration::test_custom_sweeper_run_workdir[subdir:override_dirname-tmpdir0-task_launcher_cfg0-extra_flags0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncherIntegration::test_custom_sweeper_run_workdir[subdir:custom_override_dirname-tmpdir0-task_launcher_cfg0-extra_flags0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncherIntegration::test_get_orig_dir_multirun[tmpdir0-task_launcher_cfg0-extra_flags0] SKIPPED
tests/test_ray_aws_launcher.py::TestRayAWSLauncherIntegration::test_to_absolute_path_multirun[tmpdir0-task_launcher_cfg0-extra_flags0] SKIPPED

=========================================================================================================================== 1 passed, 20 skipped in 2.62s ===========================================================================================================================
(pytest38) jieru-mbp:hydra_ray_launcher jieru$ 

```
## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
