### PR TITLE
[master] Revert "ignore UserWarning introduced by torch 1.7.0 (#1095)"

### DIFF
--- a/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
+++ b/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
@@ -40,7 +40,6 @@ def quadratic(cfg: DictConfig) -> Any:
         (6, [[1, 2, 3, 4, 5]]),
     ],
 )
-@pytest.mark.filterwarnings("ignore::UserWarning")  # type: ignore
 def test_chunk_method_for_valid_inputs(n: int, expected: List[List[int]]) -> None:
     from hydra_plugins.hydra_ax_sweeper._core import CoreAxSweeper  # type: ignore
 
@@ -211,7 +210,7 @@ def test_ax_logging(tmpdir: Path, cmd_arg: str, expected_str: str) -> None:
         "polynomial.z=10",
         "hydra.sweeper.ax_config.max_trials=2",
     ] + [cmd_arg]
-    result, _ = get_run_output(cmd=cmd, allow_warnings=True)
+    result, _ = get_run_output(cmd)
     assert "polynomial.x: range=[-5.0, -2.0]" in result
     assert expected_str in result
     assert "polynomial.z: fixed=10" in result
@@ -247,7 +246,7 @@ def test_jobs_using_choice_between_lists(
         "hydra.run.dir=" + str(tmpdir),
         "hydra.sweeper.ax_config.max_trials=3",
     ] + [cmd_arg]
-    result, _ = get_run_output(cmd=cmd, allow_warnings=True)
+    result, _ = get_run_output(cmd)
     assert f"polynomial.coefficients: {serialized_encoding}" in result
     assert f"'polynomial.coefficients': {best_coefficients}" in result
     assert f"New best value: {best_value}" in result
@@ -283,7 +282,7 @@ def test_jobs_using_choice_between_dicts(
         "hydra.run.dir=" + str(tmpdir),
         "hydra.sweeper.ax_config.max_trials=3",
     ] + [cmd_arg]
-    result, _ = get_run_output(cmd=cmd, allow_warnings=True)
+    result, _ = get_run_output(cmd)
     assert f"polynomial.coefficients: {serialized_encoding}" in result
     assert f"'+polynomial.coefficients': {best_coefficients}" in result
     assert f"New best value: {best_value}" in result
@@ -298,6 +297,6 @@ def test_example_app(tmpdir: Path) -> None:
         "banana.y=interval(-5, 10.1)",
         "hydra.sweeper.ax_config.max_trials=2",
     ]
-    result, _ = get_run_output(cmd=cmd, allow_warnings=True)
+    result, _ = get_run_output(cmd)
     assert "banana.x: range=[-5, 5]" in result
     assert "banana.y: range=[-5.0, 10.1]" in result


### PR DESCRIPTION
This reverts commit b8564d94127a822e3a11478b4f81123f1f84a44e.

<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

with https://github.com/facebook/Ax/issues/417 fixed, we can remove the warning filter now.

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
