### PR TITLE
Add Optuna sweeper plugin

### DIFF
--- a/news/1132.plugin
+++ b/news/1132.plugin
@@ -1,0 +1,1 @@
+Add [Optuna](https://optuna.org/) Sweeper plugin

--- a/plugins/hydra_optuna_sweeper/MANIFEST.in
+++ b/plugins/hydra_optuna_sweeper/MANIFEST.in
@@ -1,0 +1,3 @@
+global-exclude *.pyc
+global-exclude __pycache__
+recursive-include hydra_plugins/* *.yaml

--- a/plugins/hydra_optuna_sweeper/README.md
+++ b/plugins/hydra_optuna_sweeper/README.md
@@ -1,0 +1,5 @@
+# Hydra Optuna Sweeper
+
+Provides an [Optuna](https://optuna.org) based Hydra Sweeper.
+
+See [website](https://hydra.cc/docs/next/plugins/optuna_sweeper/) for more information.

--- a/plugins/hydra_optuna_sweeper/example/conf/config.yaml
+++ b/plugins/hydra_optuna_sweeper/example/conf/config.yaml
@@ -1,0 +1,25 @@
+defaults:
+  - hydra/sweeper: optuna
+
+hydra:
+  sweeper:
+    optuna_config:
+      direction: "minimize"
+      study_name: null
+      storage: "sqlite:///tmp.db"
+      n_trials: 20
+      n_jobs: 1
+      sampler: "CmaEsSampler"
+      seed: 123
+
+    search_space:
+      x:
+        type: range
+        values: [-5, 5]
+        step: 2
+      y:
+        type: choice
+        values: [0, 1, 2]
+
+x: 1
+y: 1

--- a/plugins/hydra_optuna_sweeper/example/conf/config.yaml
+++ b/plugins/hydra_optuna_sweeper/example/conf/config.yaml
@@ -6,20 +6,21 @@ hydra:
     optuna_config:
       direction: "minimize"
       study_name: null
-      storage: "sqlite:///tmp.db"
+      storage: null
       n_trials: 20
       n_jobs: 1
-      sampler: "CmaEsSampler"
+      sampler: "TPESampler"
       seed: 123
 
     search_space:
       x:
-        type: range
-        values: [-5, 5]
-        step: 2
+        type: float
+        low: -5.5
+        high: 5.5
+        step: 0.5
       y:
-        type: choice
-        values: [0, 1, 2]
+        type: categorical
+        choices: [-5, 0, 5]
 
 x: 1
 y: 1

--- a/plugins/hydra_optuna_sweeper/example/conf/config.yaml
+++ b/plugins/hydra_optuna_sweeper/example/conf/config.yaml
@@ -4,7 +4,7 @@ defaults:
 hydra:
   sweeper:
     optuna_config:
-      direction: "maximize"
+      direction: "minimize"
       study_name: null
       storage: null
       n_trials: 20

--- a/plugins/hydra_optuna_sweeper/example/conf/config.yaml
+++ b/plugins/hydra_optuna_sweeper/example/conf/config.yaml
@@ -9,7 +9,7 @@ hydra:
       storage: null
       n_trials: 20
       n_jobs: 1
-      sampler: TPESampler
+      sampler: tpe
       seed: 123
 
     search_space:

--- a/plugins/hydra_optuna_sweeper/example/conf/config.yaml
+++ b/plugins/hydra_optuna_sweeper/example/conf/config.yaml
@@ -4,7 +4,7 @@ defaults:
 hydra:
   sweeper:
     optuna_config:
-      direction: "minimize"
+      direction: "maximize"
       study_name: null
       storage: null
       n_trials: 20

--- a/plugins/hydra_optuna_sweeper/example/conf/config.yaml
+++ b/plugins/hydra_optuna_sweeper/example/conf/config.yaml
@@ -5,7 +5,7 @@ hydra:
   sweeper:
     optuna_config:
       direction: "minimize"
-      study_name: null
+      study_name: sphere
       storage: null
       n_trials: 20
       n_jobs: 1

--- a/plugins/hydra_optuna_sweeper/example/conf/config.yaml
+++ b/plugins/hydra_optuna_sweeper/example/conf/config.yaml
@@ -4,12 +4,12 @@ defaults:
 hydra:
   sweeper:
     optuna_config:
-      direction: "minimize"
+      direction: minimize
       study_name: sphere
       storage: null
       n_trials: 20
       n_jobs: 1
-      sampler: "TPESampler"
+      sampler: TPESampler
       seed: 123
 
     search_space:

--- a/plugins/hydra_optuna_sweeper/example/sphere.py
+++ b/plugins/hydra_optuna_sweeper/example/sphere.py
@@ -1,0 +1,18 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import logging
+
+import hydra
+from omegaconf import DictConfig
+
+logger = logging.getLogger(__name__)
+
+
+@hydra.main(config_path="conf", config_name="config")
+def sphere(cfg: DictConfig) -> float:
+    x = cfg.x
+    y = cfg.y
+    return x ** 2 + y ** 2
+
+
+if __name__ == "__main__":
+    sphere()

--- a/plugins/hydra_optuna_sweeper/example/sphere.py
+++ b/plugins/hydra_optuna_sweeper/example/sphere.py
@@ -5,8 +5,8 @@ from omegaconf import DictConfig
 
 @hydra.main(config_path="conf", config_name="config")
 def sphere(cfg: DictConfig) -> float:
-    x:float = cfg.x
-    y:float = cfg.y
+    x: float = cfg.x
+    y: float = cfg.y
     return x ** 2 + y ** 2
 
 

--- a/plugins/hydra_optuna_sweeper/example/sphere.py
+++ b/plugins/hydra_optuna_sweeper/example/sphere.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import logging
+from typing import Any
 
 import hydra
 from omegaconf import DictConfig
@@ -8,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 @hydra.main(config_path="conf", config_name="config")
-def sphere(cfg: DictConfig) -> float:
+def sphere(cfg: DictConfig) -> Any:
     x = cfg.x
     y = cfg.y
     return x ** 2 + y ** 2

--- a/plugins/hydra_optuna_sweeper/example/sphere.py
+++ b/plugins/hydra_optuna_sweeper/example/sphere.py
@@ -1,17 +1,12 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import logging
-from typing import Any
-
 import hydra
 from omegaconf import DictConfig
 
-logger = logging.getLogger(__name__)
-
 
 @hydra.main(config_path="conf", config_name="config")
-def sphere(cfg: DictConfig) -> Any:
-    x = cfg.x
-    y = cfg.y
+def sphere(cfg: DictConfig) -> float:
+    x:float = cfg.x
+    y:float = cfg.y
     return x ** 2 + y ** 2
 
 

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/__init__.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -98,12 +98,12 @@ def create_optuna_distribution_from_override(override: Override) -> Any:
         assert value.start is not None
         assert value.end is not None
         if "log" in value.tags:
-            if "int" in value.tags:
+            if isinstance(value.start, int) and isinstance(value.end, int):
                 return IntLogUniformDistribution(int(value.start), int(value.end))
             return LogUniformDistribution(value.start, value.end)
         else:
-            if "int" in value.tags:
-                return IntUniformDistribution(int(value.start), int(value.end))
+            if isinstance(value.start, int) and isinstance(value.end, int):
+                return IntUniformDistribution(value.start, value.end)
             return UniformDistribution(value.start, value.end)
 
     raise NotImplementedError("{} is not supported by Optuna sweeper.".format(override))

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -163,12 +163,11 @@ class OptunaSweeperImpl(Sweeper):
             batch_size = min(n_trials_to_go, batch_size)
 
             trials = [study._ask() for _ in range(batch_size)]
+            overrides = []
             for trial in trials:
                 for param_name, distribution in search_space.items():
                     trial._suggest(param_name, distribution)
-
-            overrides = []
-            for trial in trials:
+                
                 overrides.append(
                     tuple(f"{name}={val}" for name, val in trial.params.items())
                 )

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -71,7 +71,7 @@ def create_optuna_distribution_from_override(override: Override) -> Any:
         for x in override.sweep_iterator(transformer=Transformer.encode):
             assert isinstance(
                 x, (str, int, float, bool)
-            ), f"A choice sweep expects str, int, or float type. Got {type(x)}."
+            ), f"A choice sweep expects str, int, float, or bool type. Got {type(x)}."
             choices.append(x)
         return CategoricalDistribution(choices)
 
@@ -83,7 +83,7 @@ def create_optuna_distribution_from_override(override: Override) -> Any:
             for x in override.sweep_iterator(transformer=Transformer.encode):
                 assert isinstance(
                     x, (str, int, float, bool)
-                ), f"A choice sweep expects str, int, or float type. Got {type(x)}."
+                ), f"A choice sweep expects str, int, float, or bool type. Got {type(x)}."
                 choices.append(x)
             return CategoricalDistribution(choices)
         return IntUniformDistribution(

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -41,15 +41,14 @@ def create_optuna_distribution_from_config(config: MutableMapping[str, Any]) -> 
         assert param.high is not None
         if param.log:
             return IntLogUniformDistribution(int(param.low), int(param.high))
-        return IntUniformDistribution(
-            int(param.low), int(param.high), step=int(param.step)
-        )
+        step = int(param.step) if param.step is not None else 1
+        return IntUniformDistribution(int(param.low), int(param.high), step=step)
     if param.type == "float":
         assert param.low is not None
         assert param.high is not None
         if param.log:
             return LogUniformDistribution(param.low, param.high)
-        if param.step != 1:
+        if param.step is not None:
             return DiscreteUniformDistribution(param.low, param.high, param.step)
         return UniformDistribution(param.low, param.high)
     return config

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -164,6 +164,7 @@ class OptunaSweeperImpl(Sweeper):
             storage=self.optuna_config.storage,
             sampler=sampler,
             direction=self.optuna_config.direction.name,
+            load_if_exists=True,
         )
         log.info(f"Study name: {study.study_name}")
         log.info(f"Storage: {self.optuna_config.storage}")

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -1,0 +1,180 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import logging
+from typing import Any, List, MutableMapping, Optional
+
+import optuna
+from hydra.core.config_loader import ConfigLoader
+from hydra.core.override_parser.overrides_parser import OverridesParser
+from hydra.core.override_parser.types import (
+    ChoiceSweep,
+    IntervalSweep,
+    Override,
+    RangeSweep,
+    Transformer,
+)
+from hydra.core.plugins import Plugins
+from hydra.plugins.sweeper import Sweeper
+from hydra.types import TaskFunction
+from omegaconf import DictConfig, OmegaConf
+from optuna.distributions import (
+    CategoricalDistribution,
+    IntLogUniformDistribution,
+    IntUniformDistribution,
+    LogUniformDistribution,
+    UniformDistribution,
+)
+from optuna.samplers import CmaEsSampler, RandomSampler, TPESampler
+
+from .config import OptunaConfig, ParamConfig
+
+log = logging.getLogger(__name__)
+
+
+def create_optuna_distribution_from_config(config: MutableMapping[str, Any]) -> Any:
+    param = ParamConfig(**config)
+    if param.type == "choice":
+        return CategoricalDistribution(param.values)
+    if param.type == "range":
+        return IntUniformDistribution(
+            int(param.values[0]), int(param.values[1]), step=int(param.step)
+        )
+    if param.type == "interval":
+        if param.log:
+            if param.tags is not None and "int" in param.tags:
+                return IntLogUniformDistribution(
+                    int(param.values[0]), int(param.values[1])
+                )
+            return LogUniformDistribution(param.values[0], param.values[1])
+        if param.tags is not None and "int" in param.tags:
+            return IntUniformDistribution(int(param.values[0]), int(param.values[1]))
+        return UniformDistribution(param.values[0], param.values[1])
+    return config
+
+
+def create_optuna_distribution_from_override(override: Override) -> Any:
+    value = override.value()
+    print(value)
+    if not override.is_sweep_override():
+        return value
+
+    if override.is_choice_sweep():
+        assert isinstance(value, ChoiceSweep)
+        choices = [x for x in override.sweep_iterator(transformer=Transformer.encode)]
+        return CategoricalDistribution(choices)
+
+    if override.is_range_sweep():
+        assert isinstance(value, RangeSweep)
+        if value.shuffle:
+            choices = [
+                x for x in override.sweep_iterator(transformer=Transformer.encode)
+            ]
+            return CategoricalDistribution(choices)
+        return IntUniformDistribution(value.start, value.stop, step=value.step)
+
+    if override.is_interval_sweep():
+        assert isinstance(value, IntervalSweep)
+        if "log" in value.tags:
+            if "int" in value.tags:
+                return IntLogUniformDistribution(value.start, value.end)
+            return LogUniformDistribution(value.start, value.end)
+        else:
+            if "int" in value.tags:
+                return IntUniformDistribution(value.start, value.end)
+            return UniformDistribution(value.start, value.end)
+
+    raise NotImplementedError("{} is not supported by Optuna sweeper.".format(override))
+
+
+class OptunaSweeperImpl(Sweeper):
+    def __init__(
+        self, optuna_config: OptunaConfig, search_space: Optional[DictConfig]
+    ) -> None:
+        self.optuna_config = optuna_config
+        self.search_space = {}
+        if search_space:
+            assert isinstance(search_space, DictConfig)
+            self.search_space = {
+                x: create_optuna_distribution_from_config(y)
+                for x, y in search_space.items()
+            }
+
+    def setup(
+        self,
+        config: DictConfig,
+        config_loader: ConfigLoader,
+        task_function: TaskFunction,
+    ) -> None:
+
+        self.config = config
+        self.config_loader = config_loader
+        self.launcher = Plugins.instance().instantiate_launcher(
+            config=config, config_loader=config_loader, task_function=task_function
+        )
+        self.sweep_dir = config.hydra.sweep.dir
+
+    def sweep(self, arguments: List[str]) -> None:
+        assert self.config is not None
+        assert self.launcher is not None
+
+        parser = OverridesParser.create()
+        parsed = parser.parse_overrides(arguments)
+
+        search_space = dict(self.search_space)
+        for override in parsed:
+            search_space[
+                override.get_key_element()
+            ] = create_optuna_distribution_from_override(override)
+
+        if self.optuna_config.sampler:
+            sampler_class = getattr(optuna.samplers, self.optuna_config.sampler)
+        else:
+            sampler_class = TPESampler
+
+        if sampler_class in {CmaEsSampler, RandomSampler, TPESampler}:
+            sampler = sampler_class(seed=self.optuna_config.seed)
+        else:
+            sampler = sampler_class()
+
+        study = optuna.create_study(
+            study_name=self.optuna_config.study_name,
+            storage=self.optuna_config.storage,
+            sampler=sampler,
+            direction=self.optuna_config.direction,
+        )
+
+        batch_size = self.optuna_config.n_jobs
+        n_trials_to_go = self.optuna_config.n_trials
+
+        while n_trials_to_go > 0:
+            batch_size = min(n_trials_to_go, batch_size)
+
+            trials = [study._ask() for _ in range(batch_size)]
+            for trial in trials:
+                for param_name, distribution in search_space.items():
+                    trial._suggest(param_name, distribution)
+
+            overrides = []
+            for trial in trials:
+                overrides.append(
+                    tuple(f"{name}={val}" for name, val in trial.params.items())
+                )
+
+            returns = self.launcher.launch(overrides, initial_job_idx=trials[0].number)
+            for trial, ret in zip(trials, returns):
+                study._tell(trial, optuna.trial.TrialState.COMPLETE, ret.return_value)
+            n_trials_to_go -= batch_size
+
+        best_trial = study.best_trial
+        results_to_serialize = {
+            "name": "optuna",
+            "best_params": best_trial.params,
+            "best_value": best_trial.value,
+        }
+        OmegaConf.save(
+            OmegaConf.create(results_to_serialize),
+            f"{self.config.hydra.sweep.dir}/optimization_results.yaml",
+        )
+        log.info(f"Best parameters: {best_trial.params}")
+        log.info(f"Best value: {best_trial.value}")
+        log.info(f"Storage: {self.optuna_config.storage}")
+        log.info(f"Study name: {study.study_name}")

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -151,7 +151,8 @@ class OptunaSweeperImpl(Sweeper):
         sampler_class = getattr(optuna.samplers, self.optuna_config.sampler.name)
         sampler = sampler_class(seed=self.optuna_config.seed)
 
-        study = optuna.create_study(
+        # TODO (toshihikoyanase): Remove type-ignore when optuna==2.4.0 is released.
+        study = optuna.create_study(  # type: ignore
             study_name=self.optuna_config.study_name,
             storage=self.optuna_config.storage,
             sampler=sampler,
@@ -181,7 +182,8 @@ class OptunaSweeperImpl(Sweeper):
             returns = self.launcher.launch(overrides, initial_job_idx=self.job_idx)
             self.job_idx += len(returns)
             for trial, ret in zip(trials, returns):
-                study._tell(trial, optuna.trial.TrialState.COMPLETE, ret.return_value)
+                # TODO (toshihikoyanase): Remove type-ignore when optuna==2.4.0 is released.
+                study._tell(trial, optuna.trial.TrialState.COMPLETE, ret.return_value)  # type: ignore
             n_trials_to_go -= batch_size
 
         best_trial = study.best_trial

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -26,7 +26,6 @@ from optuna.distributions import (
     LogUniformDistribution,
     UniformDistribution,
 )
-from optuna.samplers import CmaEsSampler, RandomSampler, TPESampler
 
 from .config import DistributionConfig, DistributionType, OptunaConfig
 

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -149,12 +149,8 @@ class OptunaSweeperImpl(Sweeper):
                 override.get_key_element()
             ] = create_optuna_distribution_from_override(override)
 
-        sampler_class = getattr(optuna.samplers, self.optuna_config.sampler)
-
-        if sampler_class in {CmaEsSampler, RandomSampler, TPESampler}:
-            sampler = sampler_class(seed=self.optuna_config.seed)
-        else:
-            sampler = sampler_class()
+        sampler_class = getattr(optuna.samplers, self.optuna_config.sampler.name)
+        sampler = sampler_class(seed=self.optuna_config.seed)
 
         study = optuna.create_study(
             study_name=self.optuna_config.study_name,
@@ -164,7 +160,7 @@ class OptunaSweeperImpl(Sweeper):
         )
         log.info(f"Study name: {study.study_name}")
         log.info(f"Storage: {self.optuna_config.storage}")
-        log.info(f"Sampler: {self.optuna_config.sampler}")
+        log.info(f"Sampler: {self.optuna_config.sampler.name}")
         log.info(f"Direction: {self.optuna_config.direction.name}")
 
         batch_size = self.optuna_config.n_jobs

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -170,7 +170,7 @@ class OptunaSweeperImpl(Sweeper):
             for trial in trials:
                 for param_name, distribution in search_space.items():
                     trial._suggest(param_name, distribution)
-                
+
                 overrides.append(
                     tuple(f"{name}={val}" for name, val in trial.params.items())
                 )

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -64,7 +64,7 @@ def create_optuna_distribution_from_override(override: Override) -> Any:
     if override.is_choice_sweep():
         assert isinstance(value, ChoiceSweep)
         choices = [x for x in override.sweep_iterator(transformer=Transformer.encode)]
-        _choices = [x for x in choices if isinstance(x, (str, float))]
+        _choices = [x for x in choices if isinstance(x, (str, int, float))]
         assert choices == _choices
         return CategoricalDistribution(_choices)
 
@@ -76,7 +76,7 @@ def create_optuna_distribution_from_override(override: Override) -> Any:
             choices = [
                 x for x in override.sweep_iterator(transformer=Transformer.encode)
             ]
-            _choices = [x for x in choices if isinstance(x, (str, float))]
+            _choices = [x for x in choices if isinstance(x, (str, int, float))]
             assert choices == _choices
             return CategoricalDistribution(_choices)
         return IntUniformDistribution(

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -57,7 +57,6 @@ def create_optuna_distribution_from_config(config: MutableMapping[str, Any]) -> 
 
 def create_optuna_distribution_from_override(override: Override) -> Any:
     value = override.value()
-    print(value)
     if not override.is_sweep_override():
         return value
 
@@ -153,8 +152,12 @@ class OptunaSweeperImpl(Sweeper):
             study_name=self.optuna_config.study_name,
             storage=self.optuna_config.storage,
             sampler=sampler,
-            direction=self.optuna_config.direction,
+            direction=self.optuna_config.direction.name,
         )
+        log.info(f"Study name: {self.optuna_config.study_name}")
+        log.info(f"Storage: {self.optuna_config.storage}")
+        log.info(f"Sampler: {self.optuna_config.sampler}")
+        log.info(f"Direction: {self.optuna_config.direction}")
 
         batch_size = self.optuna_config.n_jobs
         n_trials_to_go = self.optuna_config.n_trials
@@ -189,5 +192,3 @@ class OptunaSweeperImpl(Sweeper):
         )
         log.info(f"Best parameters: {best_trial.params}")
         log.info(f"Best value: {best_trial.value}")
-        log.info(f"Storage: {self.optuna_config.storage}")
-        log.info(f"Study name: {study.study_name}")

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -72,8 +72,9 @@ def create_optuna_distribution_from_override(override: Override) -> Any:
     if override.is_choice_sweep():
         assert isinstance(value, ChoiceSweep)
         for x in override.sweep_iterator(transformer=Transformer.encode):
-            # x can be Union[str, float, List[Any], Dict[str, Any]]
-            assert isinstance(x, (str, int, float))
+            assert isinstance(
+                x, (str, int, float)
+            ), f"A choice sweep expects str, int, or float type. Got {type(x)}."
             choices.append(x)
         return CategoricalDistribution(choices)
 
@@ -83,7 +84,9 @@ def create_optuna_distribution_from_override(override: Override) -> Any:
         assert value.stop is not None
         if value.shuffle:
             for x in override.sweep_iterator(transformer=Transformer.encode):
-                assert isinstance(x, (str, int, float))
+                assert isinstance(
+                    x, (str, int, float)
+                ), f"A choice sweep expects str, int, or float type. Got {type(x)}."
                 choices.append(x)
             return CategoricalDistribution(choices)
         return IntUniformDistribution(

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -155,10 +155,10 @@ class OptunaSweeperImpl(Sweeper):
             sampler=sampler,
             direction=self.optuna_config.direction.name,
         )
-        log.info(f"Study name: {self.optuna_config.study_name}")
+        log.info(f"Study name: {study.study_name}")
         log.info(f"Storage: {self.optuna_config.storage}")
         log.info(f"Sampler: {self.optuna_config.sampler}")
-        log.info(f"Direction: {self.optuna_config.direction}")
+        log.info(f"Direction: {self.optuna_config.direction.name}")
 
         batch_size = self.optuna_config.n_jobs
         n_trials_to_go = self.optuna_config.n_trials

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -72,7 +72,7 @@ def create_optuna_distribution_from_override(override: Override) -> Any:
     if override.is_choice_sweep():
         assert isinstance(value, ChoiceSweep)
         for x in override.sweep_iterator(transformer=Transformer.encode):
-            # `x` can be Union[str, float, List[Any], Dict[str, Any]]
+            # x can be Union[str, float, List[Any], Dict[str, Any]]
             assert isinstance(x, (str, int, float))
             choices.append(x)
         return CategoricalDistribution(choices)

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -15,6 +15,7 @@ from hydra.core.override_parser.types import (
 from hydra.core.plugins import Plugins
 from hydra.plugins.sweeper import Sweeper
 from hydra.types import TaskFunction
+from hydra.utils import get_class
 from omegaconf import DictConfig, OmegaConf
 from optuna.distributions import (
     BaseDistribution,
@@ -156,18 +157,16 @@ class OptunaSweeperImpl(Sweeper):
                 del search_space[param_name]
 
         samplers = {
-            "tpe": "TPESampler",
-            "random": "RandomSampler",
-            "cmaes": "CmaEsSampler",
+            "tpe": "optuna.samplers.TPESampler",
+            "random": "optuna.samplers.RandomSampler",
+            "cmaes": "optuna.samplers.CmaEsSampler",
         }
         if self.optuna_config.sampler.name not in samplers:
             raise NotImplementedError(
                 f"{self.optuna_config.sampler} is not supported by Optuna sweeper."
             )
 
-        sampler_class = getattr(
-            optuna.samplers, samplers[self.optuna_config.sampler.name]
-        )
+        sampler_class = get_class(samplers[self.optuna_config.sampler.name])
         sampler = sampler_class(seed=self.optuna_config.seed)
 
         # TODO (toshihikoyanase): Remove type-ignore when optuna==2.4.0 is released.

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -73,7 +73,7 @@ def create_optuna_distribution_from_override(override: Override) -> Any:
         assert isinstance(value, ChoiceSweep)
         for x in override.sweep_iterator(transformer=Transformer.encode):
             assert isinstance(
-                x, (str, int, float)
+                x, (str, int, float, bool)
             ), f"A choice sweep expects str, int, or float type. Got {type(x)}."
             choices.append(x)
         return CategoricalDistribution(choices)
@@ -85,7 +85,7 @@ def create_optuna_distribution_from_override(override: Override) -> Any:
         if value.shuffle:
             for x in override.sweep_iterator(transformer=Transformer.encode):
                 assert isinstance(
-                    x, (str, int, float)
+                    x, (str, int, float, bool)
                 ), f"A choice sweep expects str, int, or float type. Got {type(x)}."
                 choices.append(x)
             return CategoricalDistribution(choices)

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -110,6 +110,7 @@ class OptunaSweeperImpl(Sweeper):
                 x: create_optuna_distribution_from_config(y)
                 for x, y in search_space.items()
             }
+        self.job_idx: int = 0
 
     def setup(
         self,
@@ -117,7 +118,7 @@ class OptunaSweeperImpl(Sweeper):
         config_loader: ConfigLoader,
         task_function: TaskFunction,
     ) -> None:
-
+        self.job_idx = 0
         self.config = config
         self.config_loader = config_loader
         self.launcher = Plugins.instance().instantiate_launcher(
@@ -175,7 +176,8 @@ class OptunaSweeperImpl(Sweeper):
                     tuple(f"{name}={val}" for name, val in trial.params.items())
                 )
 
-            returns = self.launcher.launch(overrides, initial_job_idx=trials[0].number)
+            returns = self.launcher.launch(overrides, initial_job_idx=self.job_idx)
+            self.job_idx += len(returns)
             for trial, ret in zip(trials, returns):
                 study._tell(trial, optuna.trial.TrialState.COMPLETE, ret.return_value)
             n_trials_to_go -= batch_size

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -136,6 +136,7 @@ class OptunaSweeperImpl(Sweeper):
     def sweep(self, arguments: List[str]) -> None:
         assert self.config is not None
         assert self.launcher is not None
+        assert self.job_idx is not None
 
         parser = OverridesParser.create()
         parsed = parser.parse_overrides(arguments)

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -17,6 +17,7 @@ from hydra.plugins.sweeper import Sweeper
 from hydra.types import TaskFunction
 from omegaconf import DictConfig, OmegaConf
 from optuna.distributions import (
+    BaseDistribution,
     CategoricalDistribution,
     DiscreteUniformDistribution,
     IntLogUniformDistribution,
@@ -31,7 +32,9 @@ from .config import DistributionConfig, OptunaConfig
 log = logging.getLogger(__name__)
 
 
-def create_optuna_distribution_from_config(config: MutableMapping[str, Any]) -> Any:
+def create_optuna_distribution_from_config(
+    config: MutableMapping[str, Any]
+) -> BaseDistribution:
     param = DistributionConfig(**config)
     if param.type == "categorical":
         assert param.choices is not None
@@ -51,7 +54,9 @@ def create_optuna_distribution_from_config(config: MutableMapping[str, Any]) -> 
         if param.step is not None:
             return DiscreteUniformDistribution(param.low, param.high, param.step)
         return UniformDistribution(param.low, param.high)
-    return config
+    raise NotImplementedError(
+        "{} is not supported by Optuna sweeper.".format(param.type)
+    )
 
 
 def create_optuna_distribution_from_override(override: Override) -> Any:

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -175,7 +175,7 @@ class OptunaSweeperImpl(Sweeper):
 
             returns = self.launcher.launch(overrides, initial_job_idx=trials[0].number)
             for trial, ret in zip(trials, returns):
-                study._tell(trial, TrialState.COMPLETE, ret.return_value)
+                study._tell(trial, optuna.trial.TrialState.COMPLETE, ret.return_value)
             n_trials_to_go -= batch_size
 
         best_trial = study.best_trial

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -58,9 +58,7 @@ def create_optuna_distribution_from_config(
         if param.step is not None:
             return DiscreteUniformDistribution(param.low, param.high, param.step)
         return UniformDistribution(param.low, param.high)
-    raise NotImplementedError(
-        "{} is not supported by Optuna sweeper.".format(param.type)
-    )
+    raise NotImplementedError(f"{param.type} is not supported by Optuna sweeper.")
 
 
 def create_optuna_distribution_from_override(override: Override) -> Any:
@@ -106,7 +104,7 @@ def create_optuna_distribution_from_override(override: Override) -> Any:
                 return IntUniformDistribution(value.start, value.end)
             return UniformDistribution(value.start, value.end)
 
-    raise NotImplementedError("{} is not supported by Optuna sweeper.".format(override))
+    raise NotImplementedError(f"{override} is not supported by Optuna sweeper.")
 
 
 class OptunaSweeperImpl(Sweeper):

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -6,12 +6,13 @@ from hydra.core.config_store import ConfigStore
 
 
 @dataclass
-class ParamConfig:
+class DistributionConfig:
     type: str
-    values: List[Union[str, int, float]]
+    choices: Optional[List[Union[str, int, float]]] = None
+    low: Optional[float] = None
+    high: Optional[float] = None
     log: bool = False
     step: float = 1
-    tags: Optional[List[str]] = None
 
 
 @dataclass

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -42,6 +42,9 @@ class OptunaConfig:
     direction: Direction = Direction.minimize
 
     # Storage URL to persist optimization results
+    # For example, you can use SQLite if you set 'sqlite:///example.db'
+    # Please refer to the reference for further details
+    # https://optuna.readthedocs.io/en/stable/reference/storages.html
     storage: Optional[str] = None
 
     # Name of study to persist optimization results

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -27,9 +27,11 @@ class DistributionConfig:
     high: Optional[float] = None
 
     # If True, space is converted to the log domain
+    # Valid for int or float distribution
     log: bool = False
 
     # Discritization step
+    # Valid for int or float distribution
     step: float = 1
 
 

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -1,8 +1,14 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 from hydra.core.config_store import ConfigStore
+
+
+class Direction(Enum):
+    minimize = 1
+    maximize = 2
 
 
 @dataclass
@@ -19,8 +25,7 @@ class DistributionConfig:
 class OptunaConfig:
 
     # Direction of optimization
-    # "minimize" or "maximize"
-    direction: str = "minimize"
+    direction: Direction = Direction.minimize
 
     # Storage URL to persist optimization results
     storage: Optional[str] = None
@@ -35,6 +40,8 @@ class OptunaConfig:
     n_jobs: int = 2
 
     # Sampling algorithm such as RandomSampler, TPESampler and CmaEsSampler
+    # Please refer to the reference for further details
+    # https://optuna.readthedocs.io/en/stable/reference/samplers.html
     sampler: Optional[str] = None
 
     # Random seed of sampler

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -24,7 +24,8 @@ class DistributionConfig:
     type: DistributionType
 
     # Choices of categorical distribution
-    choices: Optional[List[Union[str, int, float]]] = None
+    # List element type should be Union[str, int, float, bool]
+    choices: Optional[List[Any]] = None
 
     # Lower bound of int or float distribution
     low: Optional[float] = None

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -1,0 +1,57 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
+
+from hydra.core.config_store import ConfigStore
+
+
+@dataclass
+class ParamConfig:
+    type: str
+    values: List[Union[str, int, float]]
+    log: bool = False
+    step: float = 1
+    tags: Optional[List[str]] = None
+
+
+@dataclass
+class OptunaConfig:
+
+    # Direction of optimization
+    # "minimize" or "maximize"
+    direction: str = "minimize"
+
+    # Storage URL to persist optimization results
+    storage: Optional[str] = None
+
+    # Name of study to persist optimization results
+    study_name: Optional[str] = None
+
+    # Total number of function evaluations
+    n_trials: int = 20
+
+    # Number of parallel workers
+    n_jobs: int = 2
+
+    # Sampling algorithm such as RandomSampler, TPESampler and CmaEsSampler
+    sampler: Optional[str] = None
+
+    # Random seed of sampler
+    seed: Optional[int] = None
+
+
+@dataclass
+class OptunaSweeperConf:
+    _target_: str = "hydra_plugins.hydra_optuna_sweeper.optuna_sweeper.OptunaSweeper"
+
+    optuna_config: OptunaConfig = OptunaConfig()
+
+    search_space: Dict[str, Any] = field(default_factory=dict)
+
+
+ConfigStore.instance().store(
+    group="hydra/sweeper",
+    name="optuna",
+    node=OptunaSweeperConf,
+    provider="optuna_sweeper",
+)

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -72,7 +72,7 @@ class OptunaConfig:
     # Sampling algorithm
     # Please refer to the reference for further details
     # https://optuna.readthedocs.io/en/stable/reference/samplers.html
-    sampler: Sampler = Sampler.TPESampler
+    sampler: Sampler = Sampler.tpe
 
     # Random seed of sampler
     seed: Optional[int] = None

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -6,6 +6,12 @@ from typing import Any, Dict, List, Optional, Union
 from hydra.core.config_store import ConfigStore
 
 
+class DistributionType(Enum):
+    int = 1
+    float = 2
+    categorical = 3
+
+
 class Direction(Enum):
     minimize = 1
     maximize = 2
@@ -15,7 +21,7 @@ class Direction(Enum):
 class DistributionConfig:
 
     # Type of distribution. "int", "float" or "categorical"
-    type: str
+    type: DistributionType
 
     # Choices of categorical distribution
     choices: Optional[List[Union[str, int, float]]] = None
@@ -59,7 +65,7 @@ class OptunaConfig:
     # Sampling algorithm such as RandomSampler, TPESampler and CmaEsSampler
     # Please refer to the reference for further details
     # https://optuna.readthedocs.io/en/stable/reference/samplers.html
-    sampler: Optional[str] = None
+    sampler: str = "TPESampler"
 
     # Random seed of sampler
     seed: Optional[int] = None

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -13,11 +13,23 @@ class Direction(Enum):
 
 @dataclass
 class DistributionConfig:
+
+    # Type of distribution. "int", "float" or "categorical"
     type: str
+
+    # Choices of categorical distribution
     choices: Optional[List[Union[str, int, float]]] = None
+
+    # Lower bound of int or float distribution
     low: Optional[float] = None
+
+    # Upper bound of int or float distribution
     high: Optional[float] = None
+
+    # If True, space is converted to the log domain
     log: bool = False
+
+    # Discritization step
     step: float = 1
 
 

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from hydra.core.config_store import ConfigStore
 

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -18,9 +18,9 @@ class Direction(Enum):
 
 
 class Sampler(Enum):
-    TPESampler = 1
-    RandomSampler = 2
-    CmaEsSampler = 3
+    tpe = 1
+    random = 2
+    cmaes = 3
 
 
 @dataclass

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -17,6 +17,12 @@ class Direction(Enum):
     maximize = 2
 
 
+class Sampler(Enum):
+    TPESampler = 1
+    RandomSampler = 2
+    CmaEsSampler = 3
+
+
 @dataclass
 class DistributionConfig:
 
@@ -63,10 +69,10 @@ class OptunaConfig:
     # Number of parallel workers
     n_jobs: int = 2
 
-    # Sampling algorithm such as RandomSampler, TPESampler and CmaEsSampler
+    # Sampling algorithm
     # Please refer to the reference for further details
     # https://optuna.readthedocs.io/en/stable/reference/samplers.html
-    sampler: str = "TPESampler"
+    sampler: Sampler = Sampler.TPESampler
 
     # Random seed of sampler
     seed: Optional[int] = None

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -32,7 +32,7 @@ class DistributionConfig:
 
     # Discritization step
     # Valid for int or float distribution
-    step: float = 1
+    step: Optional[float] = None
 
 
 @dataclass

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/optuna_sweeper.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/optuna_sweeper.py
@@ -1,0 +1,31 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from typing import List, Optional
+
+from hydra.core.config_loader import ConfigLoader
+from hydra.plugins.sweeper import Sweeper
+from hydra.types import TaskFunction
+from omegaconf import DictConfig
+
+from .config import OptunaConfig
+
+
+class OptunaSweeper(Sweeper):
+    """Class to interface with Optuna"""
+
+    def __init__(
+        self, optuna_config: OptunaConfig, search_space: Optional[DictConfig]
+    ) -> None:
+        from ._impl import OptunaSweeperImpl
+
+        self.sweeper = OptunaSweeperImpl(optuna_config, search_space)
+
+    def setup(
+        self,
+        config: DictConfig,
+        config_loader: ConfigLoader,
+        task_function: TaskFunction,
+    ) -> None:
+        self.sweeper.setup(config, config_loader, task_function)
+
+    def sweep(self, arguments: List[str]) -> None:
+        return self.sweeper.sweep(arguments)

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -31,9 +31,8 @@ setup(
     ],
     install_requires=[
         "hydra-core",
-        # TODO(toshihikoyanse): Use the release version after merging the following PR.
-        # https://github.com/optuna/optuna/pull/2013
-        "optuna @ git+https://github.com/toshihikoyanase/optuna.git@explicit-reexport",
+        # TODO(toshihikoyanse): Use the release version after releasing optuna==v2.4.0.
+        "optuna @ git+https://github.com/optuna/optuna.git",
     ],
     include_package_data=True,
 )

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -14,8 +14,8 @@ def get_long_description() -> str:
 setup(
     name="hydra-optuna-sweeper",
     version="0.0.1",
-    author="Toshihiko Yanae",
-    author_email="toshihiko.yanase@gmail.com",
+    author="Toshihiko Yanase, Hiroyuki Vincent Yamazaki",
+    author_email="toshihiko.yanase@gmail.com, hiroyuki.vincent.yamazaki@gmail.com",
     description="Hydra Optuna Sweeper plugin",
     long_description=get_long_description(),
     long_description_content_type="text/markdown",

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -1,0 +1,34 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import os
+
+from setuptools import find_namespace_packages, setup
+
+
+def get_long_description() -> str:
+
+    readme_filepath = os.path.join(os.path.dirname(__file__), "README.md")
+    with open(readme_filepath) as f:
+        return f.read()
+
+
+setup(
+    name="hydra-optuna-sweeper",
+    version="0.0.1",
+    author="Toshihiko Yanae",
+    author_email="toshihiko.yanase@gmail.com",
+    description="Hydra Optuna Sweeper plugin",
+    long_description=get_long_description(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/facebookresearch/hydra/",
+    packages=find_namespace_packages(include=["hydra_plugins.*"]),
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Operating System :: OS Independent",
+        "Development Status :: 4 - Beta",
+    ],
+    install_requires=["hydra-core", "optuna"],
+    include_package_data=True,
+)

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -29,6 +29,11 @@ setup(
         "Operating System :: OS Independent",
         "Development Status :: 4 - Beta",
     ],
-    install_requires=["hydra-core", "optuna"],
+    install_requires=[
+        "hydra-core",
+        # TODO(toshihikoyanse): Use the release version after merging the following PR.
+        # https://github.com/optuna/optuna/pull/2013
+        "optuna @ git+https://github.com/toshihikoyanase/optuna.git@explicit-reexport",
+    ],
     include_package_data=True,
 )

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -29,10 +29,6 @@ setup(
         "Operating System :: OS Independent",
         "Development Status :: 4 - Beta",
     ],
-    install_requires=[
-        "hydra-core",
-        # TODO(toshihikoyanse): Use the release version after releasing optuna==v2.4.0.
-        "optuna @ git+https://github.com/optuna/optuna.git",
-    ],
+    install_requires=["hydra-core", "optuna"],
     include_package_data=True,
 )

--- a/plugins/hydra_optuna_sweeper/tests/__init__.py
+++ b/plugins/hydra_optuna_sweeper/tests/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -77,6 +77,7 @@ def test_create_optuna_distribution_from_config(input: Any, expected: Any) -> No
     "input, expected",
     [
         ("key=choice(1,2)", CategoricalDistribution([1, 2])),
+        ("key=choice(true, false)", CategoricalDistribution([True, False])),
         ("key=choice('hello', 'world')", CategoricalDistribution(["hello", "world"])),
         ("key=shuffle(range(1,3))", CategoricalDistribution((1, 2))),
         ("key=range(1,3)", IntUniformDistribution(1, 3)),

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -32,7 +32,13 @@ def test_discovery() -> None:
 def assert_optuna_distribution_equals(expected: Any, actual: Any) -> None:
     assert type(expected) == type(actual)
     if isinstance(actual, CategoricalDistribution):
-        assert sorted(expected.choices) == sorted(actual.choices)
+        assert all(isinstance(x, float) for x in actual.choices) or all(
+            isinstance(x, str) for x in actual.choices
+        )
+        assert all(isinstance(x, float) for x in expected.choices) or all(
+            isinstance(x, str) for x in expected.choices
+        )
+        assert expected.choices == actual.choices
     elif isinstance(actual, (IntLogUniformDistribution, LogUniformDistribution)):
         assert expected.low == actual.low
         assert expected.high == actual.high
@@ -119,7 +125,7 @@ def test_launch_jobs(hydra_sweep_runner: TSweepRunner) -> None:
         assert sweep.returns is None
 
 
-def test_optuna_example(tmpdir: Path):
+def test_optuna_example(tmpdir: Path) -> None:
     cmd = [
         "example/sphere.py",
         "-m",

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -114,7 +114,7 @@ def test_optuna_example(tmpdir: Path) -> None:
         "hydra.sweeper.optuna_config.n_trials=20",
         "hydra.sweeper.optuna_config.n_jobs=8",
         "hydra.sweeper.optuna_config.sampler=RandomSampler",
-        "hydra.sweeper.optuna_config.seed=1",
+        "hydra.sweeper.optuna_config.seed=123",
     ]
     get_run_output(cmd)
     returns = OmegaConf.load(f"{tmpdir}/optimization_results.yaml")
@@ -122,4 +122,4 @@ def test_optuna_example(tmpdir: Path) -> None:
     assert returns.name == "optuna"
     assert returns["best_params"]["x"] == 0
     assert returns["best_params"]["y"] == 0
-    assert returns["best_value"] == 123
+    assert returns["best_value"] == 0

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -29,15 +29,24 @@ def test_discovery() -> None:
     ]
 
 
+def check_categorical_distribution_choices_type(
+    distribution: CategoricalDistribution,
+) -> bool:
+    choices = distribution.choices
+    if all(isinstance(x, float) for x in choices):
+        return True
+    if all(isinstance(x, int) for x in choices):
+        return True
+    if all(isinstance(x, str) for x in choices):
+        return True
+    return False
+
+
 def assert_optuna_distribution_equals(expected: Any, actual: Any) -> None:
     assert type(expected) == type(actual)
     if isinstance(actual, CategoricalDistribution):
-        assert all(isinstance(x, float) for x in actual.choices) or all(
-            isinstance(x, str) for x in actual.choices
-        )
-        assert all(isinstance(x, float) for x in expected.choices) or all(
-            isinstance(x, str) for x in expected.choices
-        )
+        assert check_categorical_distribution_choices_type(expected)
+        assert check_categorical_distribution_choices_type(actual)
         assert expected.choices == actual.choices
     elif isinstance(actual, (IntLogUniformDistribution, LogUniformDistribution)):
         assert expected.low == actual.low

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -82,7 +82,7 @@ def test_create_optuna_distribution_from_config(input: Any, expected: Any) -> No
         ("key=shuffle(range(1,3))", CategoricalDistribution((1, 2))),
         ("key=range(1,3)", IntUniformDistribution(1, 3)),
         ("key=interval(1, 5)", UniformDistribution(1, 5)),
-        ("key=tag(int, interval(1, 5))", IntUniformDistribution(1, 5)),
+        ("key=int(interval(1, 5))", IntUniformDistribution(1, 5)),
         ("key=tag(log, interval(1, 5))", LogUniformDistribution(1, 5)),
     ],
 )

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -1,0 +1,116 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from pathlib import Path
+from typing import Any
+
+from hydra.core.override_parser.overrides_parser import OverridesParser
+from hydra.core.plugins import Plugins
+from hydra.plugins.sweeper import Sweeper
+from hydra.test_utils.test_utils import TSweepRunner, chdir_plugin_root, get_run_output
+import pytest
+from optuna.distributions import (
+    CategoricalDistribution,
+    IntLogUniformDistribution,
+    IntUniformDistribution,
+    LogUniformDistribution,
+    UniformDistribution
+)
+from omegaconf import DictConfig, OmegaConf
+
+
+from hydra_plugins.hydra_optuna_sweeper import _impl
+from hydra_plugins.hydra_optuna_sweeper.optuna_sweeper import OptunaSweeper
+
+chdir_plugin_root()
+
+
+def test_discovery() -> None:
+    assert OptunaSweeper.__name__ in [
+        x.__name__ for x in Plugins.instance().discover(Sweeper)
+    ]
+
+
+def assert_optuna_distribution_equals(expected: Any, actual: Any) -> None:
+    assert type(expected) == type(actual)
+    if isinstance(actual, CategoricalDistribution):
+        assert sorted(expected.choices) == sorted(actual.choices)
+    elif isinstance(actual, (IntLogUniformDistribution, LogUniformDistribution)):
+        assert expected.low == actual.low
+        assert expected.high == actual.high
+    elif isinstance(actual, (IntUniformDistribution, UniformDistribution)):
+        assert expected.low == actual.low
+        assert expected.high == actual.high
+        if isinstance(actual, IntUniformDistribution):
+            assert expected.step == actual.step
+    else:
+        assert False, f"Unexpected type: {type(actual)}"
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "input, expected",
+    [
+        ({"type": "choice", "values": [1, 2, 3]}, CategoricalDistribution([1, 2, 3])),
+        ({"type": "range", "values": [0, 10]}, IntUniformDistribution(0, 10)),
+        ({"type": "range", "values": [0, 10], "step": 2}, IntUniformDistribution(0, 10, step=2)),
+        ({"type": "interval", "values": [0, 1]}, UniformDistribution(0, 1)),
+        ({"type": "interval", "values": [0, 5], "tags": ["int"]}, IntUniformDistribution(0, 5)),
+        ({"type": "interval", "values": [1, 100], "log": True}, LogUniformDistribution(1, 100)),
+        ({"type": "interval", "values": [1, 100], "tags": ["int"], "log": True}, IntLogUniformDistribution(1, 100)),
+    ]
+)
+def test_create_optuna_distribution_from_config(input: Any, expected: Any) -> None:
+    actual = _impl.create_optuna_distribution_from_config(input)
+    assert_optuna_distribution_equals(expected, actual)
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "input, expected",
+    [
+        ("key=choice(1,2)", CategoricalDistribution([1, 2])),
+        ("key=choice('hello', 'world')", CategoricalDistribution(["hello", "world"])),
+        ("key=range(1,3)", IntUniformDistribution(1, 3)),
+        ("key=shuffle(range(1,3))", CategoricalDistribution([1, 2])),
+        ("key=interval(1, 5)", UniformDistribution(1, 5)),
+        ("key=tag(int, interval(1, 5))", IntUniformDistribution(1, 5)),
+        ("key=tag(log, interval(1, 5))", LogUniformDistribution(1, 5)),
+    ]
+)
+def test_create_optuna_distribution_from_override(input: Any, expected: Any) -> None:
+    parser = OverridesParser.create()
+    parsed = parser.parse_overrides([input])[0]
+    dist = _impl.create_optuna_distribution_from_override(parsed)
+    assert_optuna_distribution_equals(expected, dist)
+
+
+def test_launch_jobs(hydra_sweep_runner: TSweepRunner) -> None:
+    sweep = hydra_sweep_runner(
+        calling_file=None,
+        calling_module="hydra.test_utils.a_module",
+        config_path="configs",
+        config_name="compose.yaml",
+        task_function=None,
+        overrides=[
+            "hydra/sweeper=optuna",
+            "hydra/launcher=basic",
+            "hydra.sweeper.optuna_config.n_trials=8",
+            "hydra.sweeper.optuna_config.n_jobs=3",
+        ]
+    )
+    with sweep:
+        assert sweep.returns is None
+
+
+def test_optuna_example(tmpdir: Path):
+    cmd = [
+        "example/sphere.py",
+        "-m",
+        "hydra.sweep.dir=" + str(tmpdir),
+        "hydra.sweeper.optuna_config.n_trials=20",
+        "hydra.sweeper.optuna_config.n_jobs=8",
+    ]
+    get_run_output(cmd)
+    returns = OmegaConf.load(f"{tmpdir}/optimization_results.yaml")
+    assert isinstance(returns, DictConfig)
+    assert returns.name == "optuna"
+    assert "best_params" in returns
+    assert "best_value" in returns
+

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -120,7 +120,7 @@ def test_optuna_example(with_commandline: bool, tmpdir: Path) -> None:
         "hydra.sweep.dir=" + str(tmpdir),
         "hydra.sweeper.optuna_config.n_trials=20",
         "hydra.sweeper.optuna_config.n_jobs=8",
-        "hydra.sweeper.optuna_config.sampler=RandomSampler",
+        "hydra.sweeper.optuna_config.sampler=random",
         "hydra.sweeper.optuna_config.seed=123",
     ]
     if with_commandline:

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -84,6 +84,7 @@ def test_create_optuna_distribution_from_config(input: Any, expected: Any) -> No
         ("key=interval(1, 5)", UniformDistribution(1, 5)),
         ("key=int(interval(1, 5))", IntUniformDistribution(1, 5)),
         ("key=tag(log, interval(1, 5))", LogUniformDistribution(1, 5)),
+        ("key=tag(log, int(interval(1, 5)))", IntLogUniformDistribution(1, 5)),
     ],
 )
 def test_create_optuna_distribution_from_override(input: Any, expected: Any) -> None:

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -85,7 +85,7 @@ def test_create_optuna_distribution_from_override_with_shuffle() -> None:
     parsed = parser.parse_overrides(["key=shuffle(range(1,3))"])[0]
     actual = _impl.create_optuna_distribution_from_override(parsed)
     assert isinstance(actual, CategoricalDistribution)
-    assert list(sorted(actual.choices)) == [1, 2]
+    assert actual.choices == (1, 2) or actual.choices == (2, 1)
 
 
 def test_launch_jobs(hydra_sweep_runner: TSweepRunner) -> None:

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -109,14 +109,17 @@ def test_launch_jobs(hydra_sweep_runner: TSweepRunner) -> None:
 def test_optuna_example(tmpdir: Path) -> None:
     cmd = [
         "example/sphere.py",
-        "-m",
+        "--multirun",
         "hydra.sweep.dir=" + str(tmpdir),
         "hydra.sweeper.optuna_config.n_trials=20",
         "hydra.sweeper.optuna_config.n_jobs=8",
+        "hydra.sweeper.optuna_config.sampler=RandomSampler",
+        "hydra.sweeper.optuna_config.seed=1",
     ]
     get_run_output(cmd)
     returns = OmegaConf.load(f"{tmpdir}/optimization_results.yaml")
     assert isinstance(returns, DictConfig)
     assert returns.name == "optuna"
-    assert "best_params" in returns
-    assert "best_value" in returns
+    assert returns["best_params"]["x"] == 0
+    assert returns["best_params"]["y"] == 0
+    assert returns["best_value"] == 123

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -37,9 +37,7 @@ def check_distribution(expected: BaseDistribution, actual: BaseDistribution) -> 
 
     assert isinstance(actual, CategoricalDistribution)
     # shuffle() will randomize the order of items in choices.
-    assert list(sorted(actual.choices, key=lambda t: str(t))) == list(
-        sorted(actual.choices, key=lambda t: str(t))
-    )
+    assert set(expected.choices) == set(actual.choices)
 
 
 @pytest.mark.parametrize(  # type: ignore

--- a/website/docs/plugins/optuna_sweeper.md
+++ b/website/docs/plugins/optuna_sweeper.md
@@ -10,7 +10,7 @@ sidebar_label: Optuna Sweeper plugin
 
 This plugin enables Hydra applications to utilize [Optuna](https://optuna.org) for the optimization of the parameters of experiments.
 
-### Installation
+## Installation
 
 ```commandline
 git clone https://github.com/facebookresearch/hydra.git
@@ -18,7 +18,7 @@ cd hydra
 pip install plugins/hydra_optuna_sweeper
 ```
 
-### Usage
+## Usage
 
 Please set `hydra/sweeper` to `optuna` in your config file.
 
@@ -31,15 +31,68 @@ Alternatively, add `hydra/sweeper=optuna` option to your command line.
 
 The default configuration is [here](https://github.com/facebookresearch/hydra/blob/master/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py).
 
-### Example
+## Example
 
-You can see an example in this directory. `example/sphere.py` implements a simple benchmark function to be minimized.
+We include an example in this directory. `example/sphere.py` implements a simple benchmark function to be minimized.
 
-```commandline
-python example/sphere.py --multirun 'x=interval(-5.0, 5.0)' 'y=interval(1, 10)'
+You can discover the Optuna sweeper parameters with:
+
+```yaml title="python example/sphere.py hydra/sweeper=optuna --cfg hydra -p hydra.sweeper"
+# @package hydra.sweeper
+_target_: hydra_plugins.hydra_optuna_sweeper.optuna_sweeper.OptunaSweeper
+optuna_config:
+  direction: minimize
+  storage: null
+  study_name: sphere
+  n_trials: 20
+  n_jobs: 1
+  sampler: TPESampler
+  seed: 123
+search_space:
+  x:
+    type: float
+    low: -5.5
+    high: 5.5
+    step: 0.5
+  y:
+    type: categorical
+    choices:
+    - -5
+    - 0
+    - 5
 ```
 
-By default, `interval` is converted to [`UniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.UniformDistribution.html). You can use [`IntUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.IntUniformDistribution.html) or [`LogUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.LogUniformDistribution.html) by specifying the tags:
+The function decorated with `@hydra.main()` returns a float which we want to minimize, the minimum is 0 and reached for:
+```yaml
+x: 0
+y: 0
+```
+
+To run optimization, clone the code and run the following command in the `plugins/hydra_optuna_sweeper` directory:
+
+```commandline
+python example/sphere.py --multirun
+```
+
+You can also override the search space parametrization:
+
+```commandline
+python example/sphere.py --multirun 'x=interval(-5.0, 5.0)' 'y=interval(0, 10)'
+```
+
+## Search space configuration
+
+This plugin supports Optuna's [distributions](https://optuna.readthedocs.io/en/stable/reference/distributions.html) to configure search spaces. They can be defined either through commandline override or config file.
+
+### Configuring through commandline override
+
+Hydra provides a override parser that support rich syntax. Please refer to [OverrideGrammer/Basic](../advanced/override_grammar/basic.md) and [OverrideGrammer/Extended](../advanced/override_grammar/extended.md) for details.
+
+#### Interval override
+
+By default, `interval` is converted to [`UniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.UniformDistribution.html). You can use [`IntUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.IntUniformDistribution.html), [`LogUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.LogUniformDistribution.html) or [`IntLogUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.IntLogUniformDistribution.html) by specifying the `int` and `log` tags.
+
+<details><summary>Example for interval override</summary>
 
 ```commandline
 python example/sphere.py --multirun 'x=tag(int, interval(-5.0, 5.0))' 'y=tag(log, interval(1, 10))'
@@ -61,7 +114,13 @@ The output is as follows:
 [HYDRA] Best value: 1.1944707871885822
 ```
 
+</details>
+
+#### Range override
+
 `range` is converted to [`IntUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.IntUniformDistribution.html). If you apply `shuffle` to `range`, [`CategoricalDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.CategoricalDistribution.html) is used instead.
+
+<details><summary>Example for range override</summary>
 
 ```commandline
 python example/sphere.py --multirun 'x=range(-5.0, 5.0)' 'y=shuffle(range(-5, 5))'
@@ -83,7 +142,13 @@ The output is as follows:
 [HYDRA] Best value: 1
 ```
 
+</details>
+
+#### Choice override
+
 `choice` is converted to [`CategoricalDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.CategoricalDistribution.html).
+
+<details><summary>Example for choice override</summary>
 
 ```commandline
 python example/sphere.py --multirun 'x=choice(-5.0, 0.0, 5.0)' 'y=choice(0, 1, 2, 3, 4, 5)'
@@ -104,3 +169,40 @@ The output is as follows:
 [HYDRA] Best parameters: {'x': 0.0, 'y': 0}
 [HYDRA] Best value: 0.0
 ```
+
+</details>
+
+### Configuring through config file
+
+#### Int parameters
+
+`int` parameters can be defined with the following fields:
+
+- `type`: `int`
+- `low`: lower bound
+- `high`: upper bound
+- `step`: discretization step (optional)
+- `log`: if `true`, space is converted to the log domain
+
+If `log` is `false`, the parameter is mapped to [`IntUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.IntUniformDistribution.html). Otherwise, the parameter is mapped to [`IntLogUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.IntLogUniformDistribution.html). Please note that `step` can not be set if `log=true`.
+
+#### Float parameters
+
+`float` parameters can be defined with the following fields:
+
+- `type`: `float`
+- `low`: lower bound
+- `high`: upper bound
+- `step`: discretization step
+- `log`: if `true`, space is converted to the log domain
+
+If `log` is `false`, the parameter is mapped to [`UniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.UniformDistribution.html) or [`DiscreteUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.DiscreteUniformDistribution.html) depending on the presence or absence of the `step` field, respectively. Otherwise, the parameter is mapped to [`LogUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.LogUniformDistribution.html). Please note that `step` can not be set if `log=true`.
+
+#### Categorical parameters
+
+`categorical` parameters can be defined with the following fields:
+
+  - `type`: `categorical`
+  - `choices`: a list of parameter value candidates
+
+The parameters are mapped to [`CategoricalDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.CategoricalDistribution.html).

--- a/website/docs/plugins/optuna_sweeper.md
+++ b/website/docs/plugins/optuna_sweeper.md
@@ -1,0 +1,46 @@
+---
+id: optuna_sweeper
+title: Optuna Sweeper plugin
+sidebar_label: Optuna Sweeper plugin
+---
+
+[![Example application](https://img.shields.io/badge/-Example%20application-informational)](https://github.com/facebookresearch/hydra/tree/master/plugins/hydra_optuna_sweeper/example)
+[![Plugin source](https://img.shields.io/badge/-Plugin%20source-informational)](https://github.com/facebookresearch/hydra/tree/master/plugins/hydra_optuna_sweeper)
+
+
+This plugin enables Hydra applications to utilize [Optuna](https://optuna.org) for the optimization of the parameters of experiments.
+
+### Installation
+
+```commandline
+git clone https://github.com/facebookresearch/hydra.git
+cd hydra
+pip install plugins/hydra_optuna_sweeper
+```
+
+### Usage
+
+Please set `hydra/sweeper` to `optuna` in your config file.
+
+```yaml
+defaults:
+  - hydra/sweeper: optuna
+```
+
+Alternatively, add `hydra/sweeper=optuna` option to your command line.
+
+The default configuration is [here](https://github.com/facebookresearch/hydra/blob/master/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py).
+
+### Example
+
+You can see an example in this directory. `example/sphere.py` implements a simple benchmark function to be minimized.
+
+```console
+python example/sphere.py -m 'x=interval(-5.0, 5.0)' 'y=interval(1, 10)'
+```
+
+By default, interval is converted to [`UniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.UniformDistribution.html). You can use [`IntUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.IntUniformDistribution.html) or [`LogUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.LogUniformDistribution.html) by specifying the tags:
+
+```console
+python example/sphere.py -m 'x=tag(int, interval(-5.0, 5.0))' 'y=tag(log, interval(1, 10))'
+```

--- a/website/docs/plugins/optuna_sweeper.md
+++ b/website/docs/plugins/optuna_sweeper.md
@@ -61,7 +61,7 @@ The output is as follows:
 [HYDRA] Best value: 1.1944707871885822
 ```
 
-`range` is converted to [`IntUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.IntUniformDistribution.html). If you apply `shuffle` to `range`, [`CategoricalDistribution`]((https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.CategoricalDistribution.html)) is used instead.
+`range` is converted to [`IntUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.IntUniformDistribution.html). If you apply `shuffle` to `range`, [`CategoricalDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.CategoricalDistribution.html) is used instead.
 
 ```commandline
 python example/sphere.py --multirun 'x=range(-5.0, 5.0)' 'y=shuffle(range(-5, 5))'
@@ -83,7 +83,7 @@ The output is as follows:
 [HYDRA] Best value: 1
 ```
 
-`choice` is converted to [`CategoricalDistribution`]((https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.CategoricalDistribution.html)).
+`choice` is converted to [`CategoricalDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.CategoricalDistribution.html).
 
 ```commandline
 python example/sphere.py --multirun 'x=choice(-5.0, 0.0, 5.0)' 'y=choice(0, 1, 2, 3, 4, 5)'

--- a/website/docs/plugins/optuna_sweeper.md
+++ b/website/docs/plugins/optuna_sweeper.md
@@ -35,12 +35,72 @@ The default configuration is [here](https://github.com/facebookresearch/hydra/bl
 
 You can see an example in this directory. `example/sphere.py` implements a simple benchmark function to be minimized.
 
-```console
+```commandline
 python example/sphere.py --multirun 'x=interval(-5.0, 5.0)' 'y=interval(1, 10)'
 ```
 
-By default, interval is converted to [`UniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.UniformDistribution.html). You can use [`IntUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.IntUniformDistribution.html) or [`LogUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.LogUniformDistribution.html) by specifying the tags:
+By default, `interval` is converted to [`UniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.UniformDistribution.html). You can use [`IntUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.IntUniformDistribution.html) or [`LogUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.LogUniformDistribution.html) by specifying the tags:
 
-```console
+```commandline
 python example/sphere.py --multirun 'x=tag(int, interval(-5.0, 5.0))' 'y=tag(log, interval(1, 10))'
+```
+
+The output is as follows:
+
+```commandline
+[HYDRA] Study name: sphere
+[HYDRA] Storage: None
+[HYDRA] Sampler: TPESampler
+[HYDRA] Direction: minimize
+[HYDRA] Launching 1 jobs locally
+[HYDRA]        #0 : x=-3 y=1.6859762540733367
+[HYDRA] Launching 1 jobs locally
+[HYDRA]        #1 : x=1 y=5.237816870668193
+...
+[HYDRA] Best parameters: {'x': 0, 'y': 1.0929184723430116}
+[HYDRA] Best value: 1.1944707871885822
+```
+
+`range` is converted to [`IntUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.IntUniformDistribution.html). If you apply `shuffle` to `range`, [`CategoricalDistribution`]((https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.CategoricalDistribution.html)) is used instead.
+
+```commandline
+python example/sphere.py --multirun 'x=range(-5.0, 5.0)' 'y=shuffle(range(-5, 5))'
+```
+
+The output is as follows:
+
+```commandline
+[HYDRA] Study name: sphere
+[HYDRA] Storage: None
+[HYDRA] Sampler: TPESampler
+[HYDRA] Direction: minimize
+[HYDRA] Launching 1 jobs locally
+[HYDRA]        #0 : x=-3 y=-1
+[HYDRA] Launching 1 jobs locally
+[HYDRA]        #1 : x=1 y=0
+...
+[HYDRA] Best parameters: {'x': 1, 'y': 0}
+[HYDRA] Best value: 1
+```
+
+`choice` is converted to [`CategoricalDistribution`]((https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.CategoricalDistribution.html)).
+
+```commandline
+python example/sphere.py --multirun 'x=choice(-5.0, 0.0, 5.0)' 'y=choice(0, 1, 2, 3, 4, 5)'
+```
+
+The output is as follows:
+
+```commandline
+[HYDRA] Study name: sphere
+[HYDRA] Storage: None
+[HYDRA] Sampler: TPESampler
+[HYDRA] Direction: minimize
+[HYDRA] Launching 1 jobs locally
+[HYDRA]        #0 : x=5.0 y=5
+[HYDRA] Launching 1 jobs locally
+[HYDRA]        #1 : x=5.0 y=2
+...
+[HYDRA] Best parameters: {'x': 0.0, 'y': 0}
+[HYDRA] Best value: 0.0
 ```

--- a/website/docs/plugins/optuna_sweeper.md
+++ b/website/docs/plugins/optuna_sweeper.md
@@ -36,11 +36,11 @@ The default configuration is [here](https://github.com/facebookresearch/hydra/bl
 You can see an example in this directory. `example/sphere.py` implements a simple benchmark function to be minimized.
 
 ```console
-python example/sphere.py -m 'x=interval(-5.0, 5.0)' 'y=interval(1, 10)'
+python example/sphere.py --multirun 'x=interval(-5.0, 5.0)' 'y=interval(1, 10)'
 ```
 
 By default, interval is converted to [`UniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.UniformDistribution.html). You can use [`IntUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.IntUniformDistribution.html) or [`LogUniformDistribution`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.distributions.LogUniformDistribution.html) by specifying the tags:
 
 ```console
-python example/sphere.py -m 'x=tag(int, interval(-5.0, 5.0))' 'y=tag(log, interval(1, 10))'
+python example/sphere.py --multirun 'x=tag(int, interval(-5.0, 5.0))' 'y=tag(log, interval(1, 10))'
 ```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -87,6 +87,7 @@ module.exports = {
             'plugins/colorlog',
             'plugins/joblib_launcher',
             'plugins/nevergrad_sweeper',
+            'plugins/optuna_sweeper',
             'plugins/ray_launcher',
             'plugins/rq_launcher',
             'plugins/submitit_launcher',


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

This PR provides an [Optuna](https://github.com/optuna/optuna) sweeper plugin. Optuna is a hyperparameter optimization library, which includes efficient optimization algorithms such as TPE and CMA-ES as well as various visualization features. Using this sweeper, users can easily configure experiments and visualize the results, for example, as follows:

```console
python example/sphere.py -m \
  'hydra.sweeper.optuna_config.storage="sqlite:///optuna.db"' \
  'hydra.sweeper.optuna_config.study_name="example"'
```

```python
import optuna
study = optuna.load_study(study_name='example', storage='sqlite:///optuna.db')
optuna.visualization.plot_optimization_history(study).show()
```

![image](https://user-images.githubusercontent.com/3255979/98786300-4429db00-2441-11eb-8441-2883210bdcf5.png)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

I added unit tests and a runnable example.

## Related Issues and PRs

N/A