### PR TITLE
[submitit] Can now specify the maximum number of jobs running in parallel

### DIFF
--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
@@ -31,9 +31,7 @@ class BaseQueueConf:
 class SlurmQueueConf(BaseQueueConf):
     """Slurm configuration overrides and specific parameters"""
 
-    _target_: str = (
-        "hydra_plugins.hydra_submitit_launcher.submitit_launcher.SlurmLauncher"
-    )
+    _target_: str = ("hydra_plugins.hydra_submitit_launcher.submitit_launcher.SlurmLauncher")
 
     # Params are used to configure sbatch, for more info check:
     # https://github.com/facebookincubator/submitit/blob/master/submitit/slurm/slurm.py
@@ -60,27 +58,21 @@ class SlurmQueueConf(BaseQueueConf):
     # Useful to add parameters which are not currently available in the plugin.
     # Eg: {"mail-user": "blublu@fb.com", "mail-type": "BEGIN"}
     additional_parameters: Dict[str, Any] = field(default_factory=dict)
+    # Maximum number of jobs running in parallel
+    array_parallelism: int = 256
 
 
 @dataclass
 class LocalQueueConf(BaseQueueConf):
-    _target_: str = (
-        "hydra_plugins.hydra_submitit_launcher.submitit_launcher.LocalLauncher"
-    )
+    _target_: str = ("hydra_plugins.hydra_submitit_launcher.submitit_launcher.LocalLauncher")
 
 
 # finally, register two different choices:
 ConfigStore.instance().store(
-    group="hydra/launcher",
-    name="submitit_local",
-    node=LocalQueueConf(),
-    provider="submitit_launcher",
+    group="hydra/launcher", name="submitit_local", node=LocalQueueConf(), provider="submitit_launcher",
 )
 
 
 ConfigStore.instance().store(
-    group="hydra/launcher",
-    name="submitit_slurm",
-    node=SlurmQueueConf(),
-    provider="submitit_launcher",
+    group="hydra/launcher", name="submitit_slurm", node=SlurmQueueConf(), provider="submitit_launcher",
 )

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
@@ -31,7 +31,9 @@ class BaseQueueConf:
 class SlurmQueueConf(BaseQueueConf):
     """Slurm configuration overrides and specific parameters"""
 
-    _target_: str = ("hydra_plugins.hydra_submitit_launcher.submitit_launcher.SlurmLauncher")
+    _target_: str = (
+        "hydra_plugins.hydra_submitit_launcher.submitit_launcher.SlurmLauncher"
+    )
 
     # Params are used to configure sbatch, for more info check:
     # https://github.com/facebookincubator/submitit/blob/master/submitit/slurm/slurm.py
@@ -64,15 +66,23 @@ class SlurmQueueConf(BaseQueueConf):
 
 @dataclass
 class LocalQueueConf(BaseQueueConf):
-    _target_: str = ("hydra_plugins.hydra_submitit_launcher.submitit_launcher.LocalLauncher")
+    _target_: str = (
+        "hydra_plugins.hydra_submitit_launcher.submitit_launcher.LocalLauncher"
+    )
 
 
 # finally, register two different choices:
 ConfigStore.instance().store(
-    group="hydra/launcher", name="submitit_local", node=LocalQueueConf(), provider="submitit_launcher",
+    group="hydra/launcher",
+    name="submitit_local",
+    node=LocalQueueConf(),
+    provider="submitit_launcher",
 )
 
 
 ConfigStore.instance().store(
-    group="hydra/launcher", name="submitit_slurm", node=SlurmQueueConf(), provider="submitit_launcher",
+    group="hydra/launcher",
+    name="submitit_slurm",
+    node=SlurmQueueConf(),
+    provider="submitit_launcher",
 )


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

There is currently no way to limit the number of tasks that can be executed in parallel as in `submitit` or directly with a slurm `job array`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes I did

## Test Plan

I did not find any test for `hydra/launcher=submitit_slurm` in the [hydra_submitit_launcher plugging test file](https://github.com/facebookresearch/hydra/blob/master/plugins/hydra_submitit_launcher/tests/test_submitit_launcher.py).
For what it's worth I did try it on a slurm cluster and it did work.

## Related Issues and PRs
https://github.com/facebookresearch/hydra/issues/1135