### PR TITLE
Minimal DDP implementation with multirun

### DIFF
--- a/examples/advanced/pytorch_ddp_example/conf/config.yaml
+++ b/examples/advanced/pytorch_ddp_example/conf/config.yaml
@@ -1,0 +1,8 @@
+master_addr: "localhost"
+master_port: "12345"
+backend: "gloo"
+rank: 0
+world_size: 4
+
+defaults:
+    - hydra/launcher: joblib

--- a/examples/advanced/pytorch_ddp_example/main.py
+++ b/examples/advanced/pytorch_ddp_example/main.py
@@ -1,14 +1,12 @@
-import multiprocessing as mp
 import os
-import time
 
 import hydra
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig
 import torch
 import torch.distributed as dist
 
 
-def setup(master_addr, master_port, rank, world_size, backend):
+def setup(master_addr: str, master_port: str, rank: int, world_size: int, backend: str):
     """Initializes distributed process group.
 
     Arguments:
@@ -22,6 +20,7 @@ def setup(master_addr, master_port, rank, world_size, backend):
 
 
 def cleanup():
+    """Cleans up distributed backend resources."""
     dist.destroy_process_group()
 
 

--- a/examples/advanced/pytorch_ddp_example/main.py
+++ b/examples/advanced/pytorch_ddp_example/main.py
@@ -1,9 +1,10 @@
 import os
 
-import hydra
-from omegaconf import DictConfig
 import torch
 import torch.distributed as dist
+from omegaconf import DictConfig
+
+import hydra
 
 
 def setup(master_addr: str, master_port: str, rank: int, world_size: int, backend: str):

--- a/examples/advanced/pytorch_ddp_example/main.py
+++ b/examples/advanced/pytorch_ddp_example/main.py
@@ -1,0 +1,42 @@
+import multiprocessing as mp
+import os
+import time
+
+import hydra
+from omegaconf import DictConfig, OmegaConf
+import torch
+import torch.distributed as dist
+
+
+def setup(master_addr, master_port, rank, world_size, backend):
+    """Initializes distributed process group.
+
+    Arguments:
+        rank: the rank of the current process.
+        world_size: the total number of processes.
+        backend: the backend used for distributed processing.
+    """
+    os.environ["MASTER_ADDR"] = master_addr
+    os.environ["MASTER_PORT"] = master_port
+    dist.init_process_group(backend=backend, rank=rank, world_size=world_size)
+
+
+def cleanup():
+    dist.destroy_process_group()
+
+
+@hydra.main(config_path="conf", config_name="config")
+def main(cfg: DictConfig):
+    setup(cfg.master_addr, cfg.master_port, cfg.rank, cfg.world_size, cfg.backend)
+    group = dist.new_group(list(range(cfg.world_size)))
+    tensor = torch.rand(1)
+    print("Rank {} - {}".format(cfg.rank, tensor[0]))
+    dist.reduce(tensor, dst=0, op=dist.ReduceOp.SUM, group=group)
+    if cfg.rank == 0:
+        tensor /= 4
+        print("Rank {} has average: {}".format(cfg.rank, tensor[0]))
+    cleanup()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Created a minimal implementation of using distributed computation with multirun for a single DDP group, as mentioned in #951. 

```bash
>>> python main.py -m rank=0,1,2,3

[2020-11-16 19:19:22,512][HYDRA] Joblib.Parallel(n_jobs=-1,backend=loky,prefer=processes,require=None,verbose=0,timeout=None,pre_dispatch=2*n_jobs,batch_size=auto,temp_folder=None,max_nbytes=None,mmap_mode=r) is launching 4 jobs
[2020-11-16 19:19:22,513][HYDRA] Launching jobs, sweep output dir : multirun/2020-11-16/19-19-21
[2020-11-16 19:19:22,513][HYDRA]        #0 : rank=0
[2020-11-16 19:19:22,513][HYDRA]        #1 : rank=1
[2020-11-16 19:19:22,513][HYDRA]        #2 : rank=2
[2020-11-16 19:19:22,513][HYDRA]        #3 : rank=3
Rank 1 - 0.035238564014434814
Rank 0 - 0.7433204650878906
Rank 2 - 0.836401641368866
Rank 3 - 0.3215029239654541
Rank 0 has average: 0.4841158986091614
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

(Yes)/No

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)
