### PR TITLE
[master] Remove cache_stopped_nodes=True from example app.

### DIFF
--- a/plugins/hydra_ray_launcher/examples/upload_download/conf/config.yaml
+++ b/plugins/hydra_ray_launcher/examples/upload_download/conf/config.yaml
@@ -24,6 +24,3 @@ hydra:
       include: ["*.pt", "*/"]
       # No need to sync down config files.
       exclude: ["*"]
-    ray_cluster_cfg:
-      provider:
-        cache_stopped_nodes: true


### PR DESCRIPTION
This was included by mistake. Leaving this config in would leave instance behind
after example app finishes

<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
