### PR TITLE
Increase timeout for windows jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,6 @@ commands:
           name: Preparing environment - system
           command: |
             choco install -y --no-progress miniconda3
-            conda init bash
             choco install -y --no-progress openssl javaruntime
       - run:
           name: Preparing environment - Hydra
@@ -158,6 +157,7 @@ jobs:
           command: |
             export NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
             export PYTHONIOENCODING="utf-8"
+            eval "$(conda shell.bash hook)"
             conda activate hydra
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
             exit $LASTEXITCODE
@@ -229,6 +229,7 @@ jobs:
               export NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
               export PYTHONIOENCODING="utf-8"
               export PLUGINS="<< parameters.test_plugin >>"
+              eval "$(conda shell.bash hook)"
               conda activate hydra
               nox -s lint_plugins test_plugins -ts
               exit $LASTEXITCODE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,6 @@ commands:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
       - run:
           name: Preparing environment - system
-          shell: cmd.exe
           command: |
             choco install -y --no-progress miniconda3
             C:\tools\miniconda3\Scripts\conda.exe init powershell
@@ -142,6 +141,7 @@ jobs:
       py_version:
         type: string
     executor: win/default
+    shell: cmd.exe
     steps:
       - win:
           py_version: << parameters.py_version >>
@@ -210,6 +210,7 @@ jobs:
       test_plugin:
         type: string
     executor: win/default
+    shell: cmd.exe
     steps:
       - win:
           py_version: << parameters.py_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,8 +140,9 @@ jobs:
     parameters:
       py_version:
         type: string
-    executor: win/default
-    shell: cmd.exe
+    executor:
+      name: win/default
+      shell: cmd.exe
     steps:
       - win:
           py_version: << parameters.py_version >>
@@ -209,8 +210,9 @@ jobs:
         type: string
       test_plugin:
         type: string
-    executor: win/default
-    shell: cmd.exe
+    executor:
+      name: win/default
+      shell: cmd.exe
     steps:
       - win:
           py_version: << parameters.py_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,8 +254,7 @@ workflows:
       - test_win:
           matrix:
             parameters:
-#              py_version: ["3.6", "3.7", "3.8"]
-              py_version: ["3.6"]
+              py_version: ["3.6", "3.7", "3.8"]
 
 
   plugin_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,10 +87,9 @@ commands:
       - run:
           name: Preparing environment - system
           command: |
+            choco install -y --no-progress openssl javaruntime
             choco install -y --no-progress miniconda3
             C:\tools\miniconda3\Scripts\conda.exe init powershell
-            $progressPreference = 'silentlyContinue'
-            choco install -y --no-progress openssl javaruntime
       - run:
           name: Preparing environment - Hydra
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
         type: string
     executor:
       name: win/default
-      shell: cmd.exe
+      shell: bash.exe
     steps:
       - win:
           py_version: << parameters.py_version >>
@@ -212,7 +212,7 @@ jobs:
         type: string
     executor:
       name: win/default
-      shell: cmd.exe
+      shell: bash.exe
     steps:
       - win:
           py_version: << parameters.py_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,7 +254,8 @@ workflows:
       - test_win:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8"]
+#              py_version: ["3.6", "3.7", "3.8"]
+              py_version: ["3.6", "3.7"]
 
 
   plugin_tests:
@@ -274,7 +275,7 @@ workflows:
           matrix:
             parameters:
 #              py_version: ["3.6", "3.7", "3.8"]
-              py_version: ["3.6"]
+              py_version: ["3.6", "3.7"]
               test_plugin: [<< pipeline.parameters.test_plugins >>]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,4 +274,4 @@ workflows:
 
 
 orbs:
-  win: circleci/windows@1.0.0
+  win: circleci/windows@2.4.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,11 +150,10 @@ jobs:
           name: Testing Hydra
           no_output_timeout: 10m
           command: |
-            $env:NOX_PYTHON_VERSIONS=<< parameters.py_version >>
-            $env:PYTHONIOENCODING="utf_8"
+            set NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
+            set PYTHONIOENCODING="utf-8"
             conda activate hydra
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
-            exit $LASTEXITCODE
   trigger_plugin_piplines:
     docker:
       - image: circleci/python:3.8
@@ -220,12 +219,11 @@ jobs:
           name: << parameters.test_plugin >>
           no_output_timeout: 10m
           command: |
-              $env:NOX_PYTHON_VERSIONS=<< parameters.py_version >>
-              $env:PYTHONIOENCODING="utf_8"
-              $env:PLUGINS="<< parameters.test_plugin >>"
+              set NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
+              set PYTHONIOENCODING="utf-8"
+              set PLUGINS="<< parameters.test_plugin >>"
               conda activate hydra
               nox -s lint_plugins test_plugins -ts
-              exit $LASTEXITCODE
   # Misc
   coverage:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,15 +85,20 @@ commands:
       - restore_cache:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
       - run:
+          name: Temp fix - add good host for java download
+          command: |
+            echo '23.35.74.212 sdlc-esd.oracle.com' >> C:/Windows/System32/drivers/etc/hosts
+            tracert sdlc-esd.oracle.com
+      - run:
           name: Preparing environment - system
           command: |
-            choco install -y --no-progress openssl javaruntime
             choco install -y --no-progress miniconda3
-            C:\tools\miniconda3\Scripts\conda.exe init powershell
+            choco install -y --no-progress openssl javaruntime
       - run:
           name: Preparing environment - Hydra
           command: |
             conda create -n hydra python=<< parameters.py_version >> pywin32 -qy
+            eval "$(conda shell.bash hook)"
             conda activate hydra
             pip install nox dataclasses --progress-bar off
       - save_cache:
@@ -140,7 +145,9 @@ jobs:
     parameters:
       py_version:
         type: string
-    executor: win/default
+    executor:
+      name: win/default
+      shell: bash.exe
     steps:
       - win:
           py_version: << parameters.py_version >>
@@ -148,8 +155,8 @@ jobs:
           name: Testing Hydra
           no_output_timeout: 10m
           command: |
-            $env:NOX_PYTHON_VERSIONS=<< parameters.py_version >>
-            $env:PYTHONIOENCODING="utf_8"
+            export NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
+            export PYTHONIOENCODING="utf-8"
             conda activate hydra
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
             exit $LASTEXITCODE
@@ -208,7 +215,9 @@ jobs:
         type: string
       test_plugin:
         type: string
-    executor: win/default
+    executor:
+      name: win/default
+      shell: bash.exe
     steps:
       - win:
           py_version: << parameters.py_version >>
@@ -216,9 +225,9 @@ jobs:
           name: << parameters.test_plugin >>
           no_output_timeout: 10m
           command: |
-              $env:NOX_PYTHON_VERSIONS=<< parameters.py_version >>
-              $env:PYTHONIOENCODING="utf_8"
-              $env:PLUGINS="<< parameters.test_plugin >>"
+              export NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
+              export PYTHONIOENCODING="utf-8"
+              export PLUGINS="<< parameters.test_plugin >>"
               conda activate hydra
               nox -s lint_plugins test_plugins -ts
               exit $LASTEXITCODE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ commands:
           name: Preparing environment - system
           command: |
             choco install -y --no-progress miniconda3
+            conda init bash
             C:\tools\miniconda3\Scripts\conda.exe init powershell
             choco install -y --no-progress openssl javaruntime
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,13 +88,13 @@ commands:
           name: Preparing environment - system
           command: |
             choco install -y --no-progress miniconda3
-            conda init bash
             C:\tools\miniconda3\Scripts\conda.exe init powershell
             choco install -y --no-progress openssl javaruntime
       - run:
           name: Preparing environment - Hydra
           command: |
             conda create -n hydra python=<< parameters.py_version >> pywin32 -qy
+            eval "$(conda shell.bash hook)"
             conda activate hydra
             pip install nox dataclasses --progress-bar off
       - save_cache:
@@ -153,9 +153,10 @@ jobs:
           command: |
             set NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
             set PYTHONIOENCODING="utf-8"
+            eval "$(conda shell.bash hook)"
             conda activate hydra
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
-            exit
+            exit $LASTEXITCODE
   trigger_plugin_piplines:
     docker:
       - image: circleci/python:3.8
@@ -224,9 +225,10 @@ jobs:
               set NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
               set PYTHONIOENCODING="utf-8"
               set PLUGINS="<< parameters.test_plugin >>"
+              eval "$(conda shell.bash hook)"
               conda activate hydra
               nox -s lint_plugins test_plugins -ts
-              exit
+              exit $LASTEXITCODE
   # Misc
   coverage:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,9 @@ commands:
             eval "$(conda shell.bash hook)"
             conda activate hydra
             pip install nox dataclasses --progress-bar off
+      - store_artifacts:
+          path: C:\ProgramData\chocolatey\logs
+          destination: chocolatey_logs
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ commands:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
       - run:
           name: Preparing environment - system
+          shell: cmd.exe
           command: |
             choco install -y --no-progress miniconda3
             C:\tools\miniconda3\Scripts\conda.exe init powershell

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,7 @@ jobs:
             set PYTHONIOENCODING="utf-8"
             conda activate hydra
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
+            exit
   trigger_plugin_piplines:
     docker:
       - image: circleci/python:3.8
@@ -224,6 +225,7 @@ jobs:
               set PLUGINS="<< parameters.test_plugin >>"
               conda activate hydra
               nox -s lint_plugins test_plugins -ts
+              exit
   # Misc
   coverage:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,17 +88,15 @@ commands:
           name: Preparing environment - system
           command: |
             choco install -y --no-progress miniconda3
+            C:\tools\miniconda3\Scripts\conda.exe init powershell
+            $progressPreference = 'silentlyContinue'
             choco install -y --no-progress openssl javaruntime
       - run:
           name: Preparing environment - Hydra
           command: |
             conda create -n hydra python=<< parameters.py_version >> pywin32 -qy
-            eval "$(conda shell.bash hook)"
             conda activate hydra
             pip install nox dataclasses --progress-bar off
-      - store_artifacts:
-          path: C:\ProgramData\chocolatey\logs
-          destination: chocolatey_logs
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
           paths:
@@ -143,9 +141,7 @@ jobs:
     parameters:
       py_version:
         type: string
-    executor:
-      name: win/default
-      shell: bash.exe
+    executor: win/default
     steps:
       - win:
           py_version: << parameters.py_version >>
@@ -153,9 +149,8 @@ jobs:
           name: Testing Hydra
           no_output_timeout: 10m
           command: |
-            export NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
-            export PYTHONIOENCODING="utf-8"
-            eval "$(conda shell.bash hook)"
+            $env:NOX_PYTHON_VERSIONS=<< parameters.py_version >>
+            $env:PYTHONIOENCODING="utf_8"
             conda activate hydra
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
             exit $LASTEXITCODE
@@ -214,9 +209,7 @@ jobs:
         type: string
       test_plugin:
         type: string
-    executor:
-      name: win/default
-      shell: bash.exe
+    executor: win/default
     steps:
       - win:
           py_version: << parameters.py_version >>
@@ -224,10 +217,9 @@ jobs:
           name: << parameters.test_plugin >>
           no_output_timeout: 10m
           command: |
-              export NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
-              export PYTHONIOENCODING="utf-8"
-              export PLUGINS="<< parameters.test_plugin >>"
-              eval "$(conda shell.bash hook)"
+              $env:NOX_PYTHON_VERSIONS=<< parameters.py_version >>
+              $env:PYTHONIOENCODING="utf_8"
+              $env:PLUGINS="<< parameters.test_plugin >>"
               conda activate hydra
               nox -s lint_plugins test_plugins -ts
               exit $LASTEXITCODE
@@ -258,7 +250,7 @@ workflows:
           matrix:
             parameters:
 #              py_version: ["3.6", "3.7", "3.8"]
-              py_version: ["3.6", "3.7"]
+              py_version: ["3.6"]
 
 
   plugin_tests:
@@ -278,7 +270,7 @@ workflows:
           matrix:
             parameters:
 #              py_version: ["3.6", "3.7", "3.8"]
-              py_version: ["3.6", "3.7"]
+              py_version: ["3.6"]
               test_plugin: [<< pipeline.parameters.test_plugins >>]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,6 @@ commands:
           name: Preparing environment - system
           command: |
             choco install -y --no-progress miniconda3
-            C:\tools\miniconda3\Scripts\conda.exe init powershell
             choco install -y --no-progress openssl javaruntime
       - run:
           name: Preparing environment - Hydra

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,6 @@ commands:
           name: Preparing environment - system
           command: |
             choco install -y --no-progress miniconda3
-            C:\tools\miniconda3\Scripts\conda.exe init bash
             choco install -y --no-progress openssl javaruntime
       - run:
           name: Preparing environment - Hydra
@@ -153,6 +152,7 @@ jobs:
           command: |
             export NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
             export PYTHONIOENCODING="utf-8"
+            eval "$(conda shell.bash hook)"
             conda activate hydra
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
             exit $LASTEXITCODE
@@ -224,6 +224,7 @@ jobs:
               export NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
               export PYTHONIOENCODING="utf-8"
               export PLUGINS="<< parameters.test_plugin >>"
+              eval "$(conda shell.bash hook)"
               conda activate hydra
               nox -s lint_plugins test_plugins -ts
               exit $LASTEXITCODE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ commands:
           name: Preparing environment - system
           command: |
             choco install -y --no-progress miniconda3
+            conda init bash
             choco install -y --no-progress openssl javaruntime
       - run:
           name: Preparing environment - Hydra

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,8 +151,8 @@ jobs:
           name: Testing Hydra
           no_output_timeout: 10m
           command: |
-            set NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
-            set PYTHONIOENCODING="utf-8"
+            export NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
+            export PYTHONIOENCODING="utf-8"
             eval "$(conda shell.bash hook)"
             conda activate hydra
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
@@ -222,9 +222,9 @@ jobs:
           name: << parameters.test_plugin >>
           no_output_timeout: 10m
           command: |
-              set NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
-              set PYTHONIOENCODING="utf-8"
-              set PLUGINS="<< parameters.test_plugin >>"
+              export NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
+              export PYTHONIOENCODING="utf-8"
+              export PLUGINS="<< parameters.test_plugin >>"
               eval "$(conda shell.bash hook)"
               conda activate hydra
               nox -s lint_plugins test_plugins -ts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ commands:
           name: Preparing environment - system
           command: |
             choco install -y --no-progress miniconda3
+            C:\tools\miniconda3\Scripts\conda.exe init bash
             choco install -y --no-progress openssl javaruntime
       - run:
           name: Preparing environment - Hydra
@@ -152,7 +153,6 @@ jobs:
           command: |
             export NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
             export PYTHONIOENCODING="utf-8"
-            eval "$(conda shell.bash hook)"
             conda activate hydra
             nox -s lint test_tools test_core test_jupyter_notebooks -ts
             exit $LASTEXITCODE
@@ -224,7 +224,6 @@ jobs:
               export NOX_PYTHON_VERSIONS="<< parameters.py_version >>"
               export PYTHONIOENCODING="utf-8"
               export PLUGINS="<< parameters.test_plugin >>"
-              eval "$(conda shell.bash hook)"
               conda activate hydra
               nox -s lint_plugins test_plugins -ts
               exit $LASTEXITCODE


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

We've been seeing some transient failures with preparing for the windows environment (timing out). With no better way to reproduce the failure, I'm increasing the timeout temporarily per circleCI support's suggestions.
some of the failures:
https://app.circleci.com/pipelines/github/facebookresearch/hydra/4729/workflows/598280d6-d2b9-4027-96f6-9e840c2c09bf/jobs/34255
https://app.circleci.com/pipelines/github/facebookresearch/hydra/4710/workflows/b4b392bf-8ee5-4b0b-b359-7e05ee5023a2/jobs/34139
https://app.circleci.com/pipelines/github/facebookresearch/hydra/4695/workflows/a9b93805-67e8-44fc-ae25-8e17fe3d6d64/jobs/34018
https://app.circleci.com/pipelines/github/facebookresearch/hydra/4750/workflows/5846959e-1515-4480-9e1a-5d077e24e3b0/jobs/34400

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

CI
## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
