### PR TITLE
add __init__.py tutorial examples conf/

### DIFF
--- a/examples/tutorials/basic/your_first_hydra_app/4_config_groups/conf/__init__.py
+++ b/examples/tutorials/basic/your_first_hydra_app/4_config_groups/conf/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/examples/tutorials/basic/your_first_hydra_app/5_defaults/conf/__init__.py
+++ b/examples/tutorials/basic/your_first_hydra_app/5_defaults/conf/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/examples/tutorials/basic/your_first_hydra_app/6_composition/conf/__init__.py
+++ b/examples/tutorials/basic/your_first_hydra_app/6_composition/conf/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/examples/tutorials/structured_configs/5_structured_config_schema/conf/__init__.py
+++ b/examples/tutorials/structured_configs/5_structured_config_schema/conf/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/examples/tutorials/structured_configs/6_static_schema_many_configs/conf/__init__.py
+++ b/examples/tutorials/structured_configs/6_static_schema_many_configs/conf/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/examples/tutorials/structured_configs/7_dynamic_schema_many_configs/conf/__init__.py
+++ b/examples/tutorials/structured_configs/7_dynamic_schema_many_configs/conf/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation
Need `__init__.py` under `conf` for the example to run in fbcode


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

CI

Also applied the patch in fbcode and verified the example apps run with no issue.

structure config example 6&7 has no TARGET file, will add them.


## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
