### PR TITLE
added timezone argument in Omegaconf register_resolver 'now'

### DIFF
--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -5,6 +5,8 @@ import os
 import re
 import sys
 import warnings
+import pytz
+import datetime
 from contextlib import contextmanager
 from dataclasses import dataclass
 from os.path import basename, dirname, splitext
@@ -147,7 +149,14 @@ def setup_globals() -> None:
             pass
 
     # please add documentation when you add a new resolver
-    register("now", lambda pattern: strftime(pattern, localtime()))
+    def resolver_now(pattern: str, tz: str) -> str:
+        if tz is None:
+            return strftime(pattern, localtime())
+
+        else:
+            return datetime.datetime.now(pytz.timezone(tz)).strftime(pattern)
+
+    register("now", lambda pattern, tz=None: resolver_now(pattern, tz))
     register(
         "hydra",
         lambda path: OmegaConf.select(cast(DictConfig, HydraConfig.get()), path),


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

It would be nice if we could set the timezone in the Omegaconf resolver "now".
I described my problem here: https://stackoverflow.com/questions/65109805/how-does-hydra-manages-timezone-when-it-creates-output-directories

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

- How should this PR be tested?
Check that the resolver "now" outputs the right date and time when adding a timezone in the second argument.
As a new contributor, I need to know where to put the tests and the libraries `datetime` and `pytz` in the requirements.
This is not done yet.

- Do you require special setup to run the test or repro the fixed bug?
no

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
no