### PR TITLE
Instantiate: emulate PyTorch parameters not being copyable

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
-omegaconf>=2.1.0dev10
+omegaconf>=2.1.0dev12
 antlr4-python3-runtime==4.8
 importlib-resources;python_version<'3.9'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -87,6 +87,9 @@ class Parameters:
             return self.params == other.params
         return False
 
+    def __deepcopy__(self, memodict: Any = {}) -> Any:
+        raise NotImplementedError("Pytorch parameters does not support deepcopy")
+
 
 @dataclass
 class Adam:


### PR DESCRIPTION
Emulate PyTorch parameters not being copy-able in instantiation tests.