### PR TITLE
Pin pip to 20.3.1

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -67,7 +67,7 @@ def _upgrade_basic(session):
         "install",
         "--upgrade",
         "setuptools",
-        "pip",
+        "pip==20.3.1",
         silent=SILENT,
     )
 


### PR DESCRIPTION
pip 20.3.2 has a [major issue](https://github.com/pypa/pip/issues/9284) that is breaking the CI. Pip to 20.3.1 until it gets resolved.
