### PR TITLE
temporarily pin ray to 1.0.1 to fix CI

### DIFF
--- a/plugins/hydra_ray_launcher/setup.py
+++ b/plugins/hydra_ray_launcher/setup.py
@@ -24,7 +24,7 @@ with open("README.md", "r") as fh:
         install_requires=[
             "boto3==1.15.6",
             "hydra-core>=1.0.0",
-            "ray>=1.0.0",
+            "ray==1.0.1.post1",
             "cloudpickle>=1.6.0",
             "pickle5",
         ],


### PR DESCRIPTION
Temp solution for #1238
cc @jieru-hu 
we need to talk about it.

1. A proper fix is to update the AMI.
2. We should consider making this a warning.