### PR TITLE
[configen] Adds cwd to PYTHONPATH

### DIFF
--- a/tools/configen/configen/templates/sample_config.yaml
+++ b/tools/configen/configen/templates/sample_config.yaml
@@ -13,7 +13,7 @@ configen:
 
   # list of modules to generate configs for
   modules:
-    - name: configen.samples.user
+    - name: configen.samples.my_module
       # for each module, a list of classes
       classes:
         - User


### PR DESCRIPTION
1. Add cwd to PYTHONPATH, making it easier to generate code for Python files in the current working directory even if they are not installed.
2. Fixed the generated sample config.