### PR TITLE
Change default log level from INFO to WARNING

### DIFF
--- a/examples/configure_hydra/logging/my_app.py
+++ b/examples/configure_hydra/logging/my_app.py
@@ -10,7 +10,11 @@ log = logging.getLogger(__name__)
 
 @hydra.main(config_path="conf", config_name="config")
 def my_app(_cfg: DictConfig) -> None:
-    log.info("Info level message")
+    # By default, only logs of warning or higher level will be printed
+    log.debug("DEBUG level message")
+    log.info("INFO level message")
+    log.warning("WARN level message")
+    log.error("ERROR level message")
 
 
 if __name__ == "__main__":

--- a/examples/tutorials/basic/running_your_hydra_app/4_logging/my_app.py
+++ b/examples/tutorials/basic/running_your_hydra_app/4_logging/my_app.py
@@ -11,6 +11,8 @@ log = logging.getLogger(__name__)
 
 @hydra.main()
 def my_app(_cfg: DictConfig) -> None:
+    log.error("Error level message")
+    log.warning("Warning level message")
     log.info("Info level message")
     log.debug("Debug level message")
 

--- a/hydra/conf/hydra/hydra_logging/default.yaml
+++ b/hydra/conf/hydra/hydra_logging/default.yaml
@@ -10,11 +10,12 @@ handlers:
     formatter: simple
     stream: ext://sys.stdout
 root:
-  level: INFO
   handlers: [console]
 
 loggers:
-  logging_example:
-    level: DEBUG
+  hydra:
+    level: INFO
+  hydra_plugins:
+    level: INFO
 
 disable_existing_loggers: false

--- a/hydra/conf/hydra/job_logging/default.yaml
+++ b/hydra/conf/hydra/job_logging/default.yaml
@@ -16,7 +16,6 @@ handlers:
     # relative to the job log directory
     filename: ${hydra.job.name}.log
 root:
-  level: INFO
   handlers: [console, file]
 
 disable_existing_loggers: false

--- a/news/1262.api_change
+++ b/news/1262.api_change
@@ -1,0 +1,1 @@
+Default log level for Hydra apps is now WARNING (consistent with the default log level for all Python apps)

--- a/tests/test_examples/test_configure_hydra.py
+++ b/tests/test_examples/test_configure_hydra.py
@@ -75,7 +75,15 @@ def test_logging(tmpdir: Path) -> None:
         "hydra.run.dir=" + str(tmpdir),
     ]
     result, _err = get_run_output(cmd)
-    assert result == "[INFO] - Info level message"
+    assert_text_same(
+        result,
+        dedent(
+            """\
+            [WARNING] - WARN level message
+            [ERROR] - ERROR level message
+            """
+        ),
+    )
 
 
 def test_disabling_logging(tmpdir: Path) -> None:

--- a/website/docs/tutorials/basic/running_your_app/4_logging.md
+++ b/website/docs/tutorials/basic/running_your_app/4_logging.md
@@ -24,6 +24,8 @@ log = logging.getLogger(__name__)
 
 @hydra.main()
 def my_app(_cfg: DictConfig) -> None:
+    log.error("Error level message")
+    log.warning("Warning level message")
     log.info("Info level message")
     log.debug("Debug level message")
 
@@ -31,9 +33,10 @@ if __name__ == "__main__":
     my_app()
 
 $ python my_app.py
-[2019-06-27 00:52:46,653][__main__][INFO] - Info level message
-
+[2021-01-04 11:17:20,261][__main__][ERROR] - Error level message
+[2021-01-04 11:17:20,261][__main__][WARNING] - Warning level message
 ```
+By default, Python log level is WARNING.
 You can enable DEBUG level logging from the command line  by overriding `hydra.verbose`.
 
 `hydra.verbose` can be a Boolean, a String or a List:
@@ -46,11 +49,15 @@ Examples:
 Example output:
 ``` text
 $ python my_app.py hydra.verbose=[__main__,hydra]
-[2019-09-29 13:06:00,880] - Installed Hydra Plugins
-[2019-09-29 13:06:00,880] - ***********************
+[2021-01-04 11:18:32,776][HYDRA] Hydra 1.1.0                 
+[2021-01-04 11:18:32,776][HYDRA] ===============               
+[2021-01-04 11:18:32,776][HYDRA] Installed Hydra Plugins
+[2021-01-04 11:18:32,776][HYDRA] ***********************
 ...
-[2019-09-29 13:06:00,896][__main__][INFO] - Info level message
-[2019-09-29 13:06:00,896][__main__][DEBUG] - Debug level message
+[2021-01-04 11:18:32,994][__main__][ERROR] - Error level message
+[2021-01-04 11:18:32,994][__main__][WARNING] - Warning level message
+[2021-01-04 11:18:32,994][__main__][INFO] - Info level message
+[2021-01-04 11:18:32,994][__main__][DEBUG] - Debug level message
 ```
 
 You can disable the logging output by setting `hydra/job_logging` to `disabled`   
@@ -59,6 +66,6 @@ $ python my_app.py hydra/job_logging=disabled
 <NO OUTPUT>
 ```
 
-You can also set `hydra/job_logging=none` and `hydra/hydra_logging=none` if you do not want Hydra to configure the logging.
+To completely prevent Hydra from configuring the logging, set `hydra/job_logging=none` and `hydra/hydra_logging=none`.
 
 Logging can be [customized](/configure_hydra/logging.md).


### PR DESCRIPTION
Closes #1262.

The default log level for Python apps is WARNING ([per Python docs](https://docs.python.org/3/howto/logging.html)). Hydra no longer sets the log level of the root logger to ensure it does not change this behavior.
This is a breaking change, people relying on the previous behavior can configure the log level on their own side by adding something like this to their config:

```yaml
hydra:
  job_logging:
    root:
      level: INFO
```