### PR TITLE
Add depreciation warning for renaming package via cmd.

### DIFF
--- a/hydra/core/override_parser/overrides_parser.py
+++ b/hydra/core/override_parser/overrides_parser.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import sys
+import warnings
 from typing import Any, List, Optional
 
 from antlr4.error.Errors import LexerNoViableAltException, RecognitionException
@@ -11,7 +12,7 @@ from hydra.core.override_parser.overrides_visitor import (
     HydraErrorListener,
     HydraOverrideVisitor,
 )
-from hydra.core.override_parser.types import Override
+from hydra.core.override_parser.types import Override, OverrideType
 from hydra.errors import HydraException, OverrideParseException
 
 try:
@@ -79,6 +80,12 @@ class OverridesParser:
         for override in overrides:
             try:
                 parsed = self.parse_rule(override, "override")
+                if parsed.type == OverrideType.CHANGE:
+                    # DEPRECATED: remove in 1.1
+                    msg = """\nSupport for overriding the package via the command line
+                    is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1.
+                    For more details, refer https://github.com/facebookresearch/hydra/issues/1140."""
+                    warnings.warn(message=msg, category=UserWarning)
             except HydraException as e:
                 cause = e.__cause__
                 if isinstance(cause, LexerNoViableAltException):

--- a/hydra/core/override_parser/overrides_parser.py
+++ b/hydra/core/override_parser/overrides_parser.py
@@ -1,6 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import sys
-import warnings
 from typing import Any, List, Optional
 
 from antlr4.error.Errors import LexerNoViableAltException, RecognitionException
@@ -12,7 +11,7 @@ from hydra.core.override_parser.overrides_visitor import (
     HydraErrorListener,
     HydraOverrideVisitor,
 )
-from hydra.core.override_parser.types import Override, OverrideType
+from hydra.core.override_parser.types import Override
 from hydra.errors import HydraException, OverrideParseException
 
 try:
@@ -80,12 +79,6 @@ class OverridesParser:
         for override in overrides:
             try:
                 parsed = self.parse_rule(override, "override")
-                if parsed.type == OverrideType.CHANGE:
-                    # DEPRECATED: remove in 1.1
-                    msg = """\nSupport for overriding the package via the command line
-                    is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1.
-                    For more details, refer https://github.com/facebookresearch/hydra/issues/1140."""
-                    warnings.warn(message=msg, category=UserWarning)
             except HydraException as e:
                 cause = e.__cause__
                 if isinstance(cause, LexerNoViableAltException):

--- a/hydra/core/override_parser/types.py
+++ b/hydra/core/override_parser/types.py
@@ -240,9 +240,9 @@ class Override:
         if self.pkg2 is not None:
             # DEPRECATED: remove in 1.1
             msg = (
-                "\nSupport for overriding the package via the command line "
+                "\nSupport for renaming packages via the command line "
                 "is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1. "
-                "For more details, refer https://github.com/facebookresearch/hydra/issues/1140."
+                "For more details, see https://github.com/facebookresearch/hydra/issues/1140."
             )
             warnings.warn(message=msg, category=UserWarning)
 

--- a/hydra/core/override_parser/types.py
+++ b/hydra/core/override_parser/types.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import decimal
 import fnmatch
+import warnings
 from copy import copy
 from dataclasses import dataclass, field
 from enum import Enum
@@ -234,6 +235,14 @@ class Override:
 
     # Configs repo
     config_loader: Optional[ConfigLoader] = None
+
+    def __post_init__(self) -> None:
+        if self.pkg2 is not None:
+            # DEPRECATED: remove in 1.1
+            msg = """\nSupport for overriding the package via the command line
+                is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1.
+                For more details, refer https://github.com/facebookresearch/hydra/issues/1140."""
+            warnings.warn(message=msg, category=UserWarning)
 
     def is_delete(self) -> bool:
         """

--- a/hydra/core/override_parser/types.py
+++ b/hydra/core/override_parser/types.py
@@ -239,9 +239,11 @@ class Override:
     def __post_init__(self) -> None:
         if self.pkg2 is not None:
             # DEPRECATED: remove in 1.1
-            msg = """\nSupport for overriding the package via the command line
-                is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1.
-                For more details, refer https://github.com/facebookresearch/hydra/issues/1140."""
+            msg = (
+                "\nSupport for overriding the package via the command line "
+                "is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1. "
+                "For more details, refer https://github.com/facebookresearch/hydra/issues/1140."
+            )
             warnings.warn(message=msg, category=UserWarning)
 
     def is_delete(self) -> bool:

--- a/hydra/core/override_parser/types.py
+++ b/hydra/core/override_parser/types.py
@@ -243,7 +243,8 @@ class Override:
 
             msg = dedent(
                 """\n
-                    Support for renaming packages via the command line is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1.
+                    Support for renaming packages via the command line is deprecated since Hydra 1.0.5.
+                    The support will be removed in Hydra 1.1.
                     For more details, see https://github.com/facebookresearch/hydra/issues/1140.
                     """
             )

--- a/hydra/core/override_parser/types.py
+++ b/hydra/core/override_parser/types.py
@@ -6,6 +6,7 @@ from copy import copy
 from dataclasses import dataclass, field
 from enum import Enum
 from random import shuffle
+from textwrap import dedent
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Union, cast
 
 from omegaconf import OmegaConf
@@ -239,10 +240,12 @@ class Override:
     def __post_init__(self) -> None:
         if self.pkg2 is not None:
             # DEPRECATED: remove in 1.1
-            msg = (
-                "\nSupport for renaming packages via the command line "
-                "is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1. "
-                "For more details, see https://github.com/facebookresearch/hydra/issues/1140."
+
+            msg = dedent(
+                """\n
+                    Support for renaming packages via the command line is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1.
+                    For more details, see https://github.com/facebookresearch/hydra/issues/1140.
+                    """
             )
             warnings.warn(message=msg, category=UserWarning)
 

--- a/news/1140.api_change
+++ b/news/1140.api_change
@@ -1,0 +1,1 @@
+Deprecate support for renaming packages via the command line.

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -127,13 +127,12 @@ class TestConfigLoader:
         config_loader = ConfigLoaderImpl(
             config_search_path=create_config_search_path(path)
         )
-        with pytest.warns(UserWarning):
-            cfg = config_loader.load_configuration(
-                config_name="optional-default",
-                overrides=[override],
-                strict=False,
-                run_mode=RunMode.RUN,
-            )
+        cfg = config_loader.load_configuration(
+            config_name="optional-default",
+            overrides=[override],
+            strict=False,
+            run_mode=RunMode.RUN,
+        )
         with open_dict(cfg):
             del cfg["hydra"]
         assert cfg == expected
@@ -145,6 +144,16 @@ class TestConfigLoader:
                 [],
                 {"group1_option1": True, "pkg1": {"group2_option1": True}},
                 id="no_overrides",
+            ),
+            pytest.param(
+                ["group1@:pkg2=option1"],
+                {"pkg2": {"group1_option1": True}, "pkg1": {"group2_option1": True}},
+                id="override_unspecified_pkg_of_default",
+            ),
+            pytest.param(
+                ["group1@:pkg1=option1"],
+                {"pkg1": {"group1_option1": True, "group2_option1": True}},
+                id="override_two_groups_to_same_package",
             ),
         ],
     )
@@ -165,38 +174,33 @@ class TestConfigLoader:
         "overrides,expected",
         [
             pytest.param(
-                ["group1@:pkg2=option1"],
-                {"pkg2": {"group1_option1": True}, "pkg1": {"group2_option1": True}},
-                id="override_unspecified_pkg_of_default",
-            ),
-            pytest.param(
-                ["group1@:pkg1=option1"],
-                {"pkg1": {"group1_option1": True, "group2_option1": True}},
-                id="override_two_groups_to_same_package",
-            ),
-        ],
-    )
-    def test_load_changing_group_and_package_in_default_deprecated(
-        self, path: str, overrides: List[str], expected: Any
-    ) -> None:
-        config_loader = ConfigLoaderImpl(
-            config_search_path=create_config_search_path(f"{path}/package_tests")
-        )
-        with pytest.warns(UserWarning):
-            cfg = config_loader.load_configuration(
-                config_name="pkg_override", overrides=overrides, run_mode=RunMode.RUN
-            )
-        with open_dict(cfg):
-            del cfg["hydra"]
-        assert cfg == expected
-
-    @pytest.mark.parametrize(  # type: ignore
-        "overrides,expected",
-        [
-            pytest.param(
                 [],
                 {"pkg1": {"group1_option1": True}, "pkg2": {"group1_option1": True}},
                 id="baseline",
+            ),
+            pytest.param(
+                ["+group1@pkg3=option1"],
+                {
+                    "pkg1": {"group1_option1": True},
+                    "pkg2": {"group1_option1": True},
+                    "pkg3": {"group1_option1": True},
+                },
+                id="append",
+            ),
+            pytest.param(
+                ["~group1@pkg1"],
+                {"pkg2": {"group1_option1": True}},
+                id="delete_package",
+            ),
+            pytest.param(
+                ["group1@pkg1:new_pkg=option1"],
+                {"new_pkg": {"group1_option1": True}, "pkg2": {"group1_option1": True}},
+                id="change_pkg1",
+            ),
+            pytest.param(
+                ["group1@pkg2:new_pkg=option1"],
+                {"pkg1": {"group1_option1": True}, "new_pkg": {"group1_option1": True}},
+                id="change_pkg2",
             ),
         ],
     )
@@ -211,37 +215,6 @@ class TestConfigLoader:
             overrides=overrides,
             run_mode=RunMode.RUN,
         )
-        with open_dict(cfg):
-            del cfg["hydra"]
-        assert cfg == expected
-
-    @pytest.mark.parametrize(  # type: ignore
-        "overrides,expected",
-        [
-            pytest.param(
-                ["group1@pkg1:new_pkg=option1"],
-                {"new_pkg": {"group1_option1": True}, "pkg2": {"group1_option1": True}},
-                id="change_pkg1",
-            ),
-            pytest.param(
-                ["group1@pkg2:new_pkg=option1"],
-                {"pkg1": {"group1_option1": True}, "new_pkg": {"group1_option1": True}},
-                id="change_pkg2",
-            ),
-        ],
-    )
-    def test_override_compose_two_package_one_group_deprecated(
-        self, path: str, overrides: List[str], expected: Any
-    ) -> None:
-        config_loader = ConfigLoaderImpl(
-            config_search_path=create_config_search_path(f"{path}/package_tests")
-        )
-        with pytest.warns(UserWarning):
-            cfg = config_loader.load_configuration(
-                config_name="two_packages_one_group",
-                overrides=overrides,
-                run_mode=RunMode.RUN,
-            )
         with open_dict(cfg):
             del cfg["hydra"]
         assert cfg == expected
@@ -910,6 +883,33 @@ defaults_list = [{"db": "mysql"}, {"db@src": "mysql"}, {"hydra/launcher": "basic
             [{"db": "mysql"}, {"db@src": "postgresql"}, {"hydra/launcher": "basic"}],
             id="change_option",
         ),
+        pytest.param(
+            defaults_list,
+            ["db@:dest=postgresql"],
+            [
+                {"db@dest": "postgresql"},
+                {"db@src": "mysql"},
+                {"hydra/launcher": "basic"},
+            ],
+            id="change_both",
+        ),
+        pytest.param(
+            defaults_list,
+            ["db@src:dest=postgresql"],
+            [{"db": "mysql"}, {"db@dest": "postgresql"}, {"hydra/launcher": "basic"}],
+            id="change_both",
+        ),
+        pytest.param(
+            defaults_list,
+            ["db@XXX:dest=postgresql"],
+            pytest.raises(
+                HydraException,
+                match=re.escape(
+                    "Could not rename package. No match for 'db@XXX' in the defaults list."
+                ),
+            ),
+            id="change_both_invalid_package",
+        ),
         # adding item
         pytest.param([], ["+db=mysql"], [{"db": "mysql"}], id="adding_item"),
         pytest.param(
@@ -933,6 +933,17 @@ defaults_list = [{"db": "mysql"}, {"db@src": "mysql"}, {"hydra/launcher": "basic
                 ),
             ),
             id="adding_duplicate_item",
+        ),
+        pytest.param(
+            defaults_list,
+            ["+db@src:foo=mysql"],
+            pytest.raises(
+                HydraException,
+                match=re.escape(
+                    "Add syntax does not support package rename, remove + prefix"
+                ),
+            ),
+            id="add_rename_error",
         ),
         pytest.param(
             defaults_list,
@@ -1050,78 +1061,6 @@ def test_apply_overrides_to_defaults(
     else:
         with expected:
             parsed_overrides = parser.parse_overrides(overrides=overrides)
-            ConfigLoaderImpl._apply_overrides_to_defaults(
-                overrides=parsed_overrides, defaults=defaults
-            )
-
-
-@pytest.mark.parametrize(  # type: ignore
-    "input_defaults,overrides,expected",
-    [
-        # change item
-        pytest.param(
-            defaults_list,
-            ["db@:dest=postgresql"],
-            [
-                {"db@dest": "postgresql"},
-                {"db@src": "mysql"},
-                {"hydra/launcher": "basic"},
-            ],
-            id="change_both",
-        ),
-        pytest.param(
-            defaults_list,
-            ["db@src:dest=postgresql"],
-            [{"db": "mysql"}, {"db@dest": "postgresql"}, {"hydra/launcher": "basic"}],
-            id="change_both",
-        ),
-        pytest.param(
-            defaults_list,
-            ["db@XXX:dest=postgresql"],
-            pytest.raises(
-                HydraException,
-                match=re.escape(
-                    "Could not rename package. No match for 'db@XXX' in the defaults list."
-                ),
-            ),
-            id="change_both_invalid_package",
-        ),
-        # adding item
-        pytest.param(
-            defaults_list,
-            ["+db@src:foo=mysql"],
-            pytest.raises(
-                HydraException,
-                match=re.escape(
-                    "Add syntax does not support package rename, remove + prefix"
-                ),
-            ),
-            id="add_rename_error",
-        ),
-    ],
-)
-def test_apply_overrides_to_defaults_deprecated(
-    input_defaults: List[str], overrides: List[str], expected: Any
-) -> None:
-    defaults = ConfigLoaderImpl._parse_defaults(
-        OmegaConf.create({"defaults": input_defaults})
-    )
-
-    parser = OverridesParser.create()
-    if isinstance(expected, list):
-        with pytest.warns(UserWarning):
-            parsed_overrides = parser.parse_overrides(overrides=overrides)
-        expected_defaults = ConfigLoaderImpl._parse_defaults(
-            OmegaConf.create({"defaults": expected})
-        )
-        ConfigLoaderImpl._apply_overrides_to_defaults(
-            overrides=parsed_overrides, defaults=defaults
-        )
-        assert defaults == expected_defaults
-    else:
-        with expected:
-            with pytest.warns(UserWarning):
-                parsed_overrides = parser.parse_overrides(overrides=overrides)
             ConfigLoaderImpl._apply_overrides_to_defaults(
                 overrides=parsed_overrides, defaults=defaults
             )

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -122,7 +122,7 @@ class TestConfigLoader:
         ],
     )
     def test_load_changing_group_in_default(
-        self, path: str, override: str, expected: Dict[Any, Any]
+        self, path: str, override: str, expected: Dict[Any, Any], recwarn: Any
     ) -> None:
         config_loader = ConfigLoaderImpl(
             config_search_path=create_config_search_path(path)
@@ -149,7 +149,7 @@ class TestConfigLoader:
         ],
     )
     def test_load_changing_group_and_package_in_default(
-        self, path: str, overrides: List[str], expected: Any
+        self, path: str, overrides: List[str], expected: Any, recwarn: Any
     ) -> None:
         config_loader = ConfigLoaderImpl(
             config_search_path=create_config_search_path(f"{path}/package_tests")
@@ -201,7 +201,7 @@ class TestConfigLoader:
         ],
     )
     def test_override_compose_two_package_one_group(
-        self, path: str, overrides: List[str], expected: Any
+        self, path: str, overrides: List[str], expected: Any, recwarn: Any
     ) -> None:
         config_loader = ConfigLoaderImpl(
             config_search_path=create_config_search_path(f"{path}/package_tests")
@@ -1031,7 +1031,7 @@ defaults_list = [{"db": "mysql"}, {"db@src": "mysql"}, {"hydra/launcher": "basic
     ],
 )
 def test_apply_overrides_to_defaults(
-    input_defaults: List[str], overrides: List[str], expected: Any
+    input_defaults: List[str], overrides: List[str], expected: Any, recwarn: Any
 ) -> None:
     defaults = ConfigLoaderImpl._parse_defaults(
         OmegaConf.create({"defaults": input_defaults})

--- a/tests/test_examples/test_advanced_package_overrides.py
+++ b/tests/test_examples/test_advanced_package_overrides.py
@@ -36,9 +36,9 @@ def test_advanced_package_override_simple_with_cli_pakcage_override(
         "source": {"driver": "mysql", "user": "omry", "pass": "secret"}
     }
     from_line = (
-        "Support for overriding the package via the command line "
+        "Support for renaming packages via the command line "
         "is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1. "
-        "For more details, refer https://github.com/facebookresearch/hydra/issues/1140."
+        "For more details, see https://github.com/facebookresearch/hydra/issues/1140."
         "\n  warnings.warn(message=msg, category=UserWarning)"
     )
     assert_text_same(from_line, err.split("\n", 1)[1])
@@ -68,9 +68,9 @@ def test_advanced_package_override_two_packages_with_cli_override(tmpdir: Path) 
         "backup": {"driver": "mysql", "user": "omry", "pass": "secret"},
     }
     from_line = (
-        "Support for overriding the package via the command line "
+        "Support for renaming packages via the command line "
         "is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1. "
-        "For more details, refer https://github.com/facebookresearch/hydra/issues/1140."
+        "For more details, see https://github.com/facebookresearch/hydra/issues/1140."
         "\n  warnings.warn(message=msg, category=UserWarning)"
     )
     assert_text_same(from_line, err.split("\n", 1)[1])

--- a/tests/test_examples/test_advanced_package_overrides.py
+++ b/tests/test_examples/test_advanced_package_overrides.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 from omegaconf import OmegaConf
 
-from hydra.test_utils.test_utils import chdir_hydra_root, get_run_output
+from hydra.test_utils.test_utils import (
+    assert_text_same,
+    chdir_hydra_root,
+    get_run_output,
+)
 
 chdir_hydra_root()
 
@@ -27,10 +31,17 @@ def test_advanced_package_override_simple_with_cli_pakcage_override(
         "hydra.run.dir=" + str(tmpdir),
         "db@:source=mysql",
     ]
-    result, _err = get_run_output(cmd)
+    result, err = get_run_output(cmd, allow_warnings=True)
     assert OmegaConf.create(result) == {
         "source": {"driver": "mysql", "user": "omry", "pass": "secret"}
     }
+    from_line = (
+        "Support for overriding the package via the command line "
+        "is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1. "
+        "For more details, refer https://github.com/facebookresearch/hydra/issues/1140."
+        "\n  warnings.warn(message=msg, category=UserWarning)"
+    )
+    assert_text_same(from_line, err.split("\n", 1)[1])
 
 
 def test_advanced_package_override_two_packages(tmpdir: Path) -> None:
@@ -51,8 +62,15 @@ def test_advanced_package_override_two_packages_with_cli_override(tmpdir: Path) 
         "hydra.run.dir=" + str(tmpdir),
         "db@destination:backup=mysql",
     ]
-    result, _err = get_run_output(cmd)
+    result, err = get_run_output(cmd, allow_warnings=True)
     assert OmegaConf.create(result) == {
         "source": {"driver": "mysql", "user": "omry", "pass": "secret"},
         "backup": {"driver": "mysql", "user": "omry", "pass": "secret"},
     }
+    from_line = (
+        "Support for overriding the package via the command line "
+        "is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1. "
+        "For more details, refer https://github.com/facebookresearch/hydra/issues/1140."
+        "\n  warnings.warn(message=msg, category=UserWarning)"
+    )
+    assert_text_same(from_line, err.split("\n", 1)[1])

--- a/tests/test_examples/test_advanced_package_overrides.py
+++ b/tests/test_examples/test_advanced_package_overrides.py
@@ -3,11 +3,7 @@ from pathlib import Path
 
 from omegaconf import OmegaConf
 
-from hydra.test_utils.test_utils import (
-    assert_text_same,
-    chdir_hydra_root,
-    get_run_output,
-)
+from hydra.test_utils.test_utils import chdir_hydra_root, get_run_output
 
 chdir_hydra_root()
 
@@ -23,27 +19,6 @@ def test_advanced_package_override_simple(tmpdir: Path) -> None:
     }
 
 
-def test_advanced_package_override_simple_with_cli_pakcage_override(
-    tmpdir: Path,
-) -> None:
-    cmd = [
-        "examples/advanced/package_overrides/simple.py",
-        "hydra.run.dir=" + str(tmpdir),
-        "db@:source=mysql",
-    ]
-    result, err = get_run_output(cmd, allow_warnings=True)
-    assert OmegaConf.create(result) == {
-        "source": {"driver": "mysql", "user": "omry", "pass": "secret"}
-    }
-    from_line = (
-        "Support for renaming packages via the command line "
-        "is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1. "
-        "For more details, see https://github.com/facebookresearch/hydra/issues/1140."
-        "\n  warnings.warn(message=msg, category=UserWarning)"
-    )
-    assert_text_same(from_line, err.split("\n", 1)[1])
-
-
 def test_advanced_package_override_two_packages(tmpdir: Path) -> None:
     cmd = [
         "examples/advanced/package_overrides/two_packages.py",
@@ -54,23 +29,3 @@ def test_advanced_package_override_two_packages(tmpdir: Path) -> None:
         "source": {"driver": "mysql", "user": "omry", "pass": "secret"},
         "destination": {"driver": "mysql", "user": "omry", "pass": "secret"},
     }
-
-
-def test_advanced_package_override_two_packages_with_cli_override(tmpdir: Path) -> None:
-    cmd = [
-        "examples/advanced/package_overrides/two_packages.py",
-        "hydra.run.dir=" + str(tmpdir),
-        "db@destination:backup=mysql",
-    ]
-    result, err = get_run_output(cmd, allow_warnings=True)
-    assert OmegaConf.create(result) == {
-        "source": {"driver": "mysql", "user": "omry", "pass": "secret"},
-        "backup": {"driver": "mysql", "user": "omry", "pass": "secret"},
-    }
-    from_line = (
-        "Support for renaming packages via the command line "
-        "is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1. "
-        "For more details, see https://github.com/facebookresearch/hydra/issues/1140."
-        "\n  warnings.warn(message=msg, category=UserWarning)"
-    )
-    assert_text_same(from_line, err.split("\n", 1)[1])

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -654,12 +654,23 @@ def test_primitive(value: str, expected: Any) -> None:
     [
         pytest.param("abc=xyz", False, id="no_rename"),
         pytest.param("abc@pkg=xyz", False, id="no_rename"),
-        pytest.param("abc@pkg1:pkg2=xyz", True, id="rename"),
-        pytest.param("abc@:pkg2=xyz", True, id="rename_from_current"),
     ],
 )
 def test_key_rename(value: str, expected: bool) -> None:
     ret = parse_rule(value, "override")
+    assert ret.is_package_rename() == expected
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "value,expected",
+    [
+        pytest.param("abc@pkg1:pkg2=xyz", True, id="rename"),
+        pytest.param("abc@:pkg2=xyz", True, id="rename_from_current"),
+    ],
+)
+def test_key_rename_deprecated(value: str, expected: bool) -> None:
+    with pytest.warns(UserWarning):
+        ret = parse_rule(value, "override")
     assert ret.is_package_rename() == expected
 
 
@@ -903,22 +914,36 @@ def test_parse_overrides() -> None:
         # change
         pytest.param("key=value", "key", id="key"),
         pytest.param("key@pkg1=value", "key@pkg1", id="key@pkg1"),
-        pytest.param("key@pkg1:pkg2=value", "key@pkg1:pkg2", id="key@pkg1:pkg2"),
-        pytest.param("key@:pkg2=value", "key@:pkg2", id="key@:pkg2"),
         # add
         pytest.param("+key=value", "+key", id="+key"),
         pytest.param("+key@pkg1=value", "+key@pkg1", id="+key@pkg1"),
-        pytest.param("+key@pkg1:pkg2=value", "+key@pkg1:pkg2", id="+key@pkg1:pkg2"),
-        pytest.param("+key@:pkg2=value", "+key@:pkg2", id="+key@:pkg2"),
         # del
         pytest.param("~key=value", "~key", id="~key"),
         pytest.param("~key@pkg1=value", "~key@pkg1", id="~key@pkg1"),
-        pytest.param("~key@pkg1:pkg2=value", "~key@pkg1:pkg2", id="~key@pkg1:pkg2"),
-        pytest.param("~key@:pkg2=value", "~key@:pkg2", id="~key@:pkg2"),
     ],
 )
 def test_get_key_element(override: str, expected: str) -> None:
     ret = parse_rule(override, "override")
+    assert ret.get_key_element() == expected
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "override,expected",
+    [
+        # change
+        pytest.param("key@pkg1:pkg2=value", "key@pkg1:pkg2", id="key@pkg1:pkg2"),
+        pytest.param("key@:pkg2=value", "key@:pkg2", id="key@:pkg2"),
+        # add
+        pytest.param("+key@pkg1:pkg2=value", "+key@pkg1:pkg2", id="+key@pkg1:pkg2"),
+        pytest.param("+key@:pkg2=value", "+key@:pkg2", id="+key@:pkg2"),
+        # del
+        pytest.param("~key@pkg1:pkg2=value", "~key@pkg1:pkg2", id="~key@pkg1:pkg2"),
+        pytest.param("~key@:pkg2=value", "~key@:pkg2", id="~key@:pkg2"),
+    ],
+)
+def test_get_key_element_deprecated(override: str, expected: str) -> None:
+    with pytest.warns(UserWarning):
+        ret = parse_rule(override, "override")
     assert ret.get_key_element() == expected
 
 

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -654,23 +654,12 @@ def test_primitive(value: str, expected: Any) -> None:
     [
         pytest.param("abc=xyz", False, id="no_rename"),
         pytest.param("abc@pkg=xyz", False, id="no_rename"),
-    ],
-)
-def test_key_rename(value: str, expected: bool) -> None:
-    ret = parse_rule(value, "override")
-    assert ret.is_package_rename() == expected
-
-
-@pytest.mark.parametrize(  # type: ignore
-    "value,expected",
-    [
         pytest.param("abc@pkg1:pkg2=xyz", True, id="rename"),
         pytest.param("abc@:pkg2=xyz", True, id="rename_from_current"),
     ],
 )
-def test_key_rename_deprecated(value: str, expected: bool) -> None:
-    with pytest.warns(UserWarning):
-        ret = parse_rule(value, "override")
+def test_key_rename(value: str, expected: bool, recwarn: Any) -> None:
+    ret = parse_rule(value, "override")
     assert ret.is_package_rename() == expected
 
 
@@ -914,36 +903,22 @@ def test_parse_overrides() -> None:
         # change
         pytest.param("key=value", "key", id="key"),
         pytest.param("key@pkg1=value", "key@pkg1", id="key@pkg1"),
-        # add
-        pytest.param("+key=value", "+key", id="+key"),
-        pytest.param("+key@pkg1=value", "+key@pkg1", id="+key@pkg1"),
-        # del
-        pytest.param("~key=value", "~key", id="~key"),
-        pytest.param("~key@pkg1=value", "~key@pkg1", id="~key@pkg1"),
-    ],
-)
-def test_get_key_element(override: str, expected: str) -> None:
-    ret = parse_rule(override, "override")
-    assert ret.get_key_element() == expected
-
-
-@pytest.mark.parametrize(  # type: ignore
-    "override,expected",
-    [
-        # change
         pytest.param("key@pkg1:pkg2=value", "key@pkg1:pkg2", id="key@pkg1:pkg2"),
         pytest.param("key@:pkg2=value", "key@:pkg2", id="key@:pkg2"),
         # add
+        pytest.param("+key=value", "+key", id="+key"),
+        pytest.param("+key@pkg1=value", "+key@pkg1", id="+key@pkg1"),
         pytest.param("+key@pkg1:pkg2=value", "+key@pkg1:pkg2", id="+key@pkg1:pkg2"),
         pytest.param("+key@:pkg2=value", "+key@:pkg2", id="+key@:pkg2"),
         # del
+        pytest.param("~key=value", "~key", id="~key"),
+        pytest.param("~key@pkg1=value", "~key@pkg1", id="~key@pkg1"),
         pytest.param("~key@pkg1:pkg2=value", "~key@pkg1:pkg2", id="~key@pkg1:pkg2"),
         pytest.param("~key@:pkg2=value", "~key@:pkg2", id="~key@:pkg2"),
     ],
 )
-def test_get_key_element_deprecated(override: str, expected: str) -> None:
-    with pytest.warns(UserWarning):
-        ret = parse_rule(override, "override")
+def test_get_key_element(override: str, expected: str, recwarn: Any) -> None:
+    ret = parse_rule(override, "override")
     assert ret.get_key_element() == expected
 
 


### PR DESCRIPTION
Support for overriding the package via the command line is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1. For more details, refer https://github.com/facebookresearch/hydra/issues/1140.

## Motivation

Support for overriding the package via the command line is deprecated since Hydra 1.0.5 and will be removed in Hydra 1.1

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

To add a test.

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)

#1140
