### PR TITLE
fix test failure on platform009

### DIFF
--- a/hydra/_internal/core_plugins/importlib_resources_config_source.py
+++ b/hydra/_internal/core_plugins/importlib_resources_config_source.py
@@ -40,8 +40,10 @@ class ImportlibResourcesConfigSource(ConfigSource):
         if not res.exists():
             raise ConfigLoadError(f"Config not found : {normalized_config_path}")
 
-        with res.open(encoding="utf-8") as f:
+        with res.open() as f:
             header_text = f.read(512)
+            if isinstance(header_text, bytes):
+                header_text = header_text.decode("utf-8")
             header = ConfigSource._get_header_dict(header_text)
             self._update_package_in_header(
                 header=header,


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

This is to fix the test failure on platform009.
For some reasons, the importresources we get returned is in `zipfile.Path` format and it does not support decoding. 

Tested by
```
buck test @mode/opt -c fbcode.platform=platform009 $targ
```
### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
