### PR TITLE
Enable %f pattern in now resolver

### DIFF
--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -7,9 +7,9 @@ import sys
 import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime
 from os.path import basename, dirname, splitext
 from pathlib import Path
-from time import localtime, strftime
 from typing import Any, Dict, Optional, Sequence, Tuple, Union, cast
 
 from omegaconf import DictConfig, OmegaConf, open_dict, read_write
@@ -151,7 +151,7 @@ def setup_globals() -> None:
             pass
 
     # please add documentation when you add a new resolver
-    register("now", lambda pattern: strftime(pattern, localtime()))
+    register("now", lambda pattern: datetime.now().strftime(pattern))
     register(
         "hydra",
         lambda path: OmegaConf.select(cast(DictConfig, HydraConfig.get()), path),

--- a/news/1287.bugfix
+++ b/news/1287.bugfix
@@ -1,1 +1,1 @@
-Bug fix to make %f strftime directive to work for ${now:} resolver
+Add support for %f directive (microseconds) to the ${now:} resolver

--- a/news/1287.bugfix
+++ b/news/1287.bugfix
@@ -1,0 +1,1 @@
+Bug fix to make %f strftime directive to work for ${now:} resolver

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -730,6 +730,24 @@ def test_local_run_workdir(
     )
 
 
+@pytest.mark.parametrize(
+    "task_config",
+    [
+        ({"hydra": {"run": {"dir": "${now:%Y%m%d_%H%M%S_%f}"}}}),
+    ],
+)
+def test_run_dir_microseconds(tmpdir: Path, task_config: DictConfig) -> None:
+    cfg = OmegaConf.create(task_config)
+    assert isinstance(cfg, DictConfig)
+    integration_test(
+        tmpdir=tmpdir,
+        task_config=cfg,
+        overrides=[],
+        prints="str('%f' not in os.getcwd())",
+        expected_outputs="True",
+    )
+
+
 def test_hydra_env_set_with_config(tmpdir: Path) -> None:
     cfg = OmegaConf.create({"hydra": {"job": {"env_set": {"foo": "bar"}}}})
     integration_test(

--- a/website/docs/configure_hydra/Intro.md
+++ b/website/docs/configure_hydra/Intro.md
@@ -92,7 +92,7 @@ Hydra supports several [OmegaConf resolvers](https://github.com/facebookresearch
 **hydra**: Interpolates into the `hydra` config node. e.g. Use `${hydra:job.name}` to get the Hydra job name.
 
 **now**: Creates a string representing the current time using 
-[strftime](https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior). 
+[strftime](https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior).
 e.g. for formatting the time you can use something like`${now:%H-%M-%S}`.
 
 **python_version**: Return a string representing the runtime python version by calling `sys.version_info`.

--- a/website/docs/configure_hydra/Intro.md
+++ b/website/docs/configure_hydra/Intro.md
@@ -92,7 +92,7 @@ Hydra supports several [OmegaConf resolvers](https://github.com/facebookresearch
 **hydra**: Interpolates into the `hydra` config node. e.g. Use `${hydra:job.name}` to get the Hydra job name.
 
 **now**: Creates a string representing the current time using 
-[strftime](https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior).
+[strftime](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior).
 e.g. for formatting the time you can use something like`${now:%H-%M-%S}`.
 
 **python_version**: Return a string representing the runtime python version by calling `sys.version_info`.


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

I sometimes manually run multiple instances of Hydra configured programs within a fraction of a second. In that case, their output directory's timestamp collide.

The user manual points to python2 strftime document which supports %f pattern (micro seconds), which would be one way of solving this issue.
https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior
However, in Python 3,
https://docs.python.org/3/library/time.html?highlight=strftime#time.strftime
time.strftime does not implement %f format and datetime.stftime does.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

Simple tutorial codes in the user manual would do the job

main.py:
```
#!/usr/bin/env python

import logging
import hydra
from omegaconf import OmegaConf

log = logging.getLogger(__name__)


@hydra.main(config_name='config')
def main(cfg):
    log.info(OmegaConf.to_yaml(cfg))
    log.debug("hello world!")


if __name__ == "__main__":
    main()
```

config.yaml:
```
db:
  driver: mysql
  user: omry
  password: secret

hydra:
  run:
    dir: ./outputs/${now:%Y%m%d_%H%M%S_%f}
```

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)

None related