### PR TITLE
Document fix: Add note to use .yaml for file extension

### DIFF
--- a/website/versioned_docs/version-1.0/intro.md
+++ b/website/versioned_docs/version-1.0/intro.md
@@ -46,6 +46,8 @@ db:
   user: omry
   pass: secret
 ```
+Note: File extension needs to be `.yaml`. `.yml` will be ignored.
+
 Application:
 ```python {4-6} title="my_app.py"
 import hydra


### PR DESCRIPTION
## Motivation

I ran into `MissingConfigException` error when trying to use `.yml` for config, and took some time to discover that file extension is required to be `.yaml`. 
This seems to be not written anywhere in the documentation explicitly. 
So I want to add note to the document (for other beginners like me).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

- To pass the default ci

## Related Issues and PRs

Previous discussions to support `.yml` or not (concluded not to support for now).
#398 #1050
