### PR TITLE
[ray launcher] fix key pair name - add user

### DIFF
--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_config.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_config.py
@@ -65,7 +65,9 @@ class RayProviderConf:
     region: str = "us-west-2"
     availability_zone: str = "us-west-2a,us-west-2b"
     cache_stopped_nodes: bool = False
-    key_pair: Dict[str, str] = field(default_factory=lambda: {"key_name": "hydra"})
+    key_pair: Dict[str, str] = field(
+        default_factory=lambda: {"key_name": "hydra-${env:USER,user}"}
+    )
 
 
 @dataclass


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Right now the default key-pair name is `hydra`. However this won't work well if multiple users share one aws account - they won't be able to share the key pair with same names in the same account (easily.) 


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan

Verified locally the variable was interpreted correctly and example applications run. 
## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
