### PR TITLE
[ray launcher] remove pickling Singleton

### DIFF
--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core_aws.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core_aws.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Sequence
 import cloudpickle  # type: ignore
 import pickle5 as pickle  # type: ignore
 from hydra.core.hydra_config import HydraConfig
-from hydra.core.singleton import Singleton
 from hydra.core.utils import JobReturn, configure_log, filter_overrides, setup_globals
 from omegaconf import OmegaConf, open_dict, read_write
 
@@ -94,7 +93,6 @@ def launch(
             tmp_dir=local_tmp_dir,
             sweep_configs=sweep_configs,  # type: ignore
             task_function=launcher.task_function,
-            singleton_state=Singleton.get_state(),
         )
 
         with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_launcher_util.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_launcher_util.py
@@ -3,11 +3,10 @@ import logging
 import os
 from contextlib import contextmanager
 from subprocess import PIPE, Popen
-from typing import Any, Dict, Generator, List, Tuple
+from typing import Any, Generator, List, Tuple
 
 import ray
 from hydra.core.hydra_config import HydraConfig
-from hydra.core.singleton import Singleton
 from hydra.core.utils import JobReturn, run_job, setup_globals
 from hydra.types import TaskFunction
 from omegaconf import DictConfig, OmegaConf
@@ -32,10 +31,8 @@ def start_ray(init_cfg: DictConfig) -> None:
 def _run_job(
     sweep_config: DictConfig,
     task_function: TaskFunction,
-    singleton_state: Dict[Any, Any],
 ) -> JobReturn:
     setup_globals()
-    Singleton.set_state(singleton_state)
     HydraConfig.instance().set_config(sweep_config)
     return run_job(
         config=sweep_config,
@@ -49,7 +46,6 @@ def launch_job_on_ray(
     ray_remote: DictConfig,
     sweep_config: DictConfig,
     task_function: TaskFunction,
-    singleton_state: Any,
 ) -> Any:
     if ray_remote:
         run_job_ray = ray.remote(**ray_remote)(_run_job)
@@ -59,7 +55,6 @@ def launch_job_on_ray(
     ret = run_job_ray.remote(
         sweep_config=sweep_config,
         task_function=task_function,
-        singleton_state=singleton_state,
     )
     return ret
 

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_remote_invoke.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_remote_invoke.py
@@ -12,7 +12,6 @@ import cloudpickle  # type: ignore
 import pickle5 as pickle  # type: ignore
 import ray
 from hydra.core.hydra_config import HydraConfig
-from hydra.core.singleton import Singleton
 from hydra.core.utils import JobReturn, setup_globals
 from omegaconf import open_dict
 
@@ -30,7 +29,6 @@ def launch_jobs(temp_dir: str) -> None:
     runs = []
     with open(os.path.join(temp_dir, JOB_SPEC_PICKLE), "rb") as f:
         job_spec = pickle.load(f)  # nosec
-        singleton_state = job_spec["singleton_state"]
         sweep_configs = job_spec["sweep_configs"]
         task_function = job_spec["task_function"]
 
@@ -44,7 +42,6 @@ def launch_jobs(temp_dir: str) -> None:
                     f"{instance_id}_{sweep_config.hydra.job.num}"
                 )
             setup_globals()
-            Singleton.set_state(singleton_state)
             HydraConfig.instance().set_config(sweep_config)
             ray_init = sweep_config.hydra.launcher.ray.init
             ray_remote = sweep_config.hydra.launcher.ray.remote
@@ -54,9 +51,7 @@ def launch_jobs(temp_dir: str) -> None:
                 sweep_dir.mkdir(parents=True, exist_ok=True)
 
             start_ray(ray_init)
-            ray_obj = launch_job_on_ray(
-                ray_remote, sweep_config, task_function, singleton_state
-            )
+            ray_obj = launch_job_on_ray(ray_remote, sweep_config, task_function)
             runs.append(ray_obj)
 
     result = [ray.get(run) for run in runs]

--- a/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
@@ -108,22 +108,7 @@ log = logging.getLogger(__name__)
 chdir_plugin_root()
 
 
-def build_ray_launcher_wheel(tmpdir: str) -> str:
-    """
-    This  only works on ray launcher plugin wheels for now, reasons being in our base AMI
-    we do not necessarily have the dependency for other plugins.
-    """
-    command = "python -m pip --disable-pip-version-check list | grep hydra | grep -v hydra-core "
-    output = subprocess.getoutput(command).split("\n")
-    plugins_path = [x.split()[0].replace("-", "_") for x in output]
-    assert (
-        len(plugins_path) == 1 and "hydra_ray_launcher" == plugins_path[0]
-    ), "Ray test AMI doesn't have dependency installed for other plugins."
-
-    return build_plugin_wheel(tmpdir)
-
-
-def build_plugin_wheel(tmp_wheel_dir: str) -> str:
+def build_ray_launcher_wheel(tmp_wheel_dir: str) -> str:
     chdir_hydra_root()
     plugin = "hydra_ray_launcher"
     os.chdir(Path("plugins") / plugin)


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation
After reading through the code, it seems like we do not need to pickle the Singleton state. Having `HydraConfig` available is adequate for calling `run_job` in remote cluster. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
