### PR TITLE
Config loading optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.benchmarks
 /.idea
 /temp
 outputs

--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -421,15 +421,11 @@ class ConfigLoaderImpl(ConfigLoader):
         for default in defaults:
             loaded = self._load_single_config(default=default, repo=repo)
             try:
-                merged = OmegaConf.merge(cfg, loaded.config)
+                cfg.merge_with(loaded.config)
             except ValidationError as e:
                 raise ConfigCompositionException(
                     f"In '{default.config_path}': Validation error while composing config:\n{e}"
                 ).with_traceback(sys.exc_info()[2])
-
-            assert isinstance(merged, DictConfig)
-            cfg = merged
-            assert cfg is not None
 
         # This is primarily cosmetic
         cfg._metadata.ref_type = cfg._metadata.object_type

--- a/hydra/_internal/config_repository.py
+++ b/hydra/_internal/config_repository.py
@@ -299,8 +299,8 @@ class ConfigRepository(IConfigRepository):
 
 
 class CachingConfigRepository(IConfigRepository):
-    def __init__(self, delegeate: IConfigRepository):
-        self.delegate = delegeate
+    def __init__(self, delegate: IConfigRepository):
+        self.delegate = delegate
         self.cache: Dict[str, Optional[ConfigResult]] = {}
 
     def get_schema_source(self) -> ConfigSource:

--- a/hydra/plugins/completion_plugin.py
+++ b/hydra/plugins/completion_plugin.py
@@ -16,7 +16,7 @@ from omegaconf import (
     OmegaConf,
     ListConfig,
 )
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple
 
 from hydra.core.config_loader import ConfigLoader
 from hydra.core.object_type import ObjectType
@@ -96,7 +96,7 @@ class CompletionPlugin(Plugin):
 
     @staticmethod
     def _get_matches(config: Container, word: str) -> List[str]:
-        def str_rep(in_key: Union[str, int], in_value: Any) -> str:
+        def str_rep(in_key: Any, in_value: Any) -> str:
             if OmegaConf.is_config(in_value):
                 return f"{in_key}."
             else:
@@ -137,7 +137,8 @@ class CompletionPlugin(Plugin):
                 else:
                     if isinstance(config, DictConfig):
                         for key, value in config.items_ex(resolve=False):
-                            if key.startswith(word):
+                            str_key = str(key)
+                            if str_key.startswith(word):
                                 matches.append(str_rep(key, value))
                     elif OmegaConf.is_list(config):
                         assert isinstance(config, ListConfig)

--- a/hydra/test_utils/launcher_common_tests.py
+++ b/hydra/test_utils/launcher_common_tests.py
@@ -497,8 +497,8 @@ class IntegrationTestSuite:
         extra_flags: List[str],
     ) -> None:
         overrides = extra_flags + overrides
-        task_launcher_cfg = OmegaConf.create(task_launcher_cfg or {})  # type: ignore
-        task_config = OmegaConf.create(task_config or {})  # type: ignore
+        task_launcher_cfg = OmegaConf.create(task_launcher_cfg or {})
+        task_config = OmegaConf.create(task_config or {})
         cfg = OmegaConf.merge(task_launcher_cfg, task_config)
         assert isinstance(cfg, DictConfig)
 
@@ -606,7 +606,7 @@ class IntegrationTestSuite:
         extra_flags: List[str],
     ) -> None:
         overrides = extra_flags + overrides
-        task_launcher_cfg = OmegaConf.create(task_launcher_cfg or {})  # type: ignore
+        task_launcher_cfg = OmegaConf.create(task_launcher_cfg or {})
         task_config = OmegaConf.create(task_config or {})  # type: ignore
         cfg = OmegaConf.merge(task_launcher_cfg, task_config)
         assert isinstance(cfg, DictConfig)
@@ -630,7 +630,7 @@ class IntegrationTestSuite:
         self, tmpdir: Path, task_launcher_cfg: DictConfig, extra_flags: List[str]
     ) -> None:
         overrides = extra_flags
-        task_launcher_cfg = OmegaConf.create(task_launcher_cfg or {})  # type: ignore
+        task_launcher_cfg = OmegaConf.create(task_launcher_cfg or {})
         task_config = OmegaConf.create()
         cfg = OmegaConf.merge(task_launcher_cfg, task_config)
         assert isinstance(cfg, DictConfig)
@@ -652,7 +652,7 @@ class IntegrationTestSuite:
             "hydra.sweep.dir=cli_dir",
             "hydra.sweep.subdir=cli_dir_${hydra.job.num}",
         ]
-        task_launcher_cfg = OmegaConf.create(task_launcher_cfg or {})  # type: ignore
+        task_launcher_cfg = OmegaConf.create(task_launcher_cfg or {})
         task_config = OmegaConf.create()
         cfg = OmegaConf.merge(task_launcher_cfg, task_config)
         assert isinstance(cfg, DictConfig)

--- a/news/1328.feature
+++ b/news/1328.feature
@@ -1,0 +1,1 @@
+Improve performance of config composition in a benchmark by 64%

--- a/noxfile.py
+++ b/noxfile.py
@@ -484,3 +484,12 @@ def test_jupyter_notebooks(session):
         args = pytest_args("--nbval", str(notebook))
         args = [x for x in args if x != "-Werror"]
         session.run(*args, silent=SILENT)
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def benchmark(session):
+    _upgrade_basic(session)
+    install_dev_deps(session)
+    install_hydra(session, INSTALL_COMMAND)
+    session.install("pytest")
+    run_pytest(session, "build_helpers", "tests/benchmark.py", *session.posargs)

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
@@ -198,7 +198,7 @@ class CoreAxSweeper(Sweeper):
 
     def setup_ax_client(self, arguments: List[str]) -> AxClient:
         """Method to setup the Ax Client"""
-        parameters: List[Dict[str, Any]] = []
+        parameters: List[Dict[Any, Any]] = []
         for key, value in self.ax_params.items():
             param = OmegaConf.to_container(value, resolve=True)
             assert isinstance(param, Dict)

--- a/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/_impl.py
+++ b/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/_impl.py
@@ -95,7 +95,7 @@ class NevergradSweeperImpl(Sweeper):
         if parametrization is not None:
             assert isinstance(parametrization, DictConfig)
             self.parametrization = {
-                x: create_nevergrad_param_from_config(y)
+                str(x): create_nevergrad_param_from_config(y)
                 for x, y in parametrization.items()
             }
         self.job_idx: Optional[int] = None

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -116,7 +116,7 @@ class OptunaSweeperImpl(Sweeper):
         if search_space:
             assert isinstance(search_space, DictConfig)
             self.search_space = {
-                x: create_optuna_distribution_from_config(y)
+                str(x): create_optuna_distribution_from_config(y)
                 for x, y in search_space.items()
             }
         self.job_idx: int = 0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,6 +10,7 @@ nox
 packaging
 pre-commit
 pytest
+pytest-benchmark
 pytest-snail
 setuptools
 towncrier

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
-omegaconf==2.1.0dev14
+omegaconf>=2.1.0dev16
 antlr4-python3-runtime==4.8
 importlib-resources;python_version<'3.9'

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -1,0 +1,25 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Any
+
+from pytest import fixture
+
+from hydra._internal.config_loader_impl import ConfigLoaderImpl
+from hydra._internal.utils import create_config_search_path
+from hydra.types import RunMode
+
+
+@fixture(scope="module")
+def config_loader() -> Any:
+    return ConfigLoaderImpl(
+        config_search_path=create_config_search_path("pkg://hydra.test_utils.configs")
+    )
+
+
+def test_config_loading(config_loader: ConfigLoaderImpl, benchmark: Any) -> None:
+    benchmark(
+        config_loader.load_configuration,
+        "config",
+        overrides=[],
+        run_mode=RunMode.RUN,
+    )


### PR DESCRIPTION
Closes #1328
Closes #1323 (because it's including the fix in omegaconf==2.1.0dev16).

This includes significant optimizations in OmegaConf as well (https://github.com/omry/omegaconf/pull/481, https://github.com/omry/omegaconf/pull/485).

1. Adding a benchmark for config initialization.
2. Config load time reduced by 64% (81ms to 29ms).
3. Example app start time reduced by 28% (308ms to 221ms)
4. Tests time reduced by 28% (122s to 87s).