### PR TITLE
[1.0_branch] remove type-ignore for optuna 2.4.0

### DIFF
--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -169,8 +169,7 @@ class OptunaSweeperImpl(Sweeper):
         sampler_class = get_class(samplers[self.optuna_config.sampler.name])
         sampler = sampler_class(seed=self.optuna_config.seed)
 
-        # TODO (toshihikoyanase): Remove type-ignore when optuna==2.4.0 is released.
-        study = optuna.create_study(  # type: ignore
+        study = optuna.create_study(
             study_name=self.optuna_config.study_name,
             storage=self.optuna_config.storage,
             sampler=sampler,
@@ -201,8 +200,7 @@ class OptunaSweeperImpl(Sweeper):
             returns = self.launcher.launch(overrides, initial_job_idx=self.job_idx)
             self.job_idx += len(returns)
             for trial, ret in zip(trials, returns):
-                # TODO (toshihikoyanase): Remove type-ignore when optuna==2.4.0 is released.
-                study._tell(trial, optuna.trial.TrialState.COMPLETE, ret.return_value)  # type: ignore
+                study._tell(trial, optuna.trial.TrialState.COMPLETE, [ret.return_value])
             n_trials_to_go -= batch_size
 
         best_trial = study.best_trial

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -13,7 +13,7 @@ def get_long_description() -> str:
 
 setup(
     name="hydra-optuna-sweeper",
-    version="0.9.0-rc1",
+    version="0.9.0-rc2",
     author="Toshihiko Yanase, Hiroyuki Vincent Yamazaki",
     author_email="toshihiko.yanase@gmail.com, hiroyuki.vincent.yamazaki@gmail.com",
     description="Hydra Optuna Sweeper plugin",


### PR DESCRIPTION
## Motivation

This PR backports the change in #1293 to the 1.0 branch. It cherry-picked the commit https://github.com/facebookresearch/hydra/commit/e2938da67396ea152cc13baae49e2bcf29bfef71. I'd like to release the change in #1293 as hydra-optuna-plugin 0.9.0rc2 in [pypi](https://pypi.org/project/hydra-optuna-sweeper/).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

The change was tested in #1293.

## Related Issues and PRs

The original PR is ##1293.