### PR TITLE
pin mypy==0.790

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,7 @@ coverage
 flake8
 flake8-copyright
 isort==5.5.2
-mypy
+mypy==0.790
 nox
 packaging
 pre-commit


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

recent 0.800 release broke our CI with error
```
nox > [2021-01-22 16:56:45,409] mypy . --strict
nox > [2021-01-22 16:56:45,539] Command mypy . --strict failed with exit code 2:
schema-overrides-hydra is not a valid Python package name
nox > [2021-01-22 16:56:45,540] Session lint-3.8 failed.
```
The same issue can be reproed in 0.790 with a different command
```
mypy --strict tests/test_apps/
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
