### PR TITLE
Deprecating .yml file extension for primary config file

### DIFF
--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -16,7 +16,7 @@ from omegaconf.errors import OmegaConfBaseException
 
 from hydra._internal.config_search_path_impl import ConfigSearchPathImpl
 from hydra.core.config_search_path import ConfigSearchPath, SearchPathQuery
-from hydra.core.utils import get_valid_filename, split_config_path
+from hydra.core.utils import get_valid_filename, validate_config_path
 from hydra.errors import (
     CompactHydraException,
     InstantiationException,
@@ -310,10 +310,10 @@ def _run_hydra(
         task_name,
     ) = detect_calling_file_or_module_from_task_function(task_function)
 
-    config_dir, config_name = split_config_path(config_path, config_name)
+    validate_config_path(config_path)
 
     search_path = create_automatic_config_search_path(
-        calling_file, calling_module, config_dir
+        calling_file, calling_module, config_path
     )
 
     def add_conf_dir() -> None:

--- a/hydra/plugins/config_source.py
+++ b/hydra/plugins/config_source.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import warnings
 import re
 
 from abc import abstractmethod
@@ -116,6 +117,11 @@ class ConfigSource(Plugin):
 
     @staticmethod
     def _normalize_file_name(filename: str) -> str:
+        if filename.endswith(".yml"):
+            # DEPRECATED: remove in 1.2
+            warnings.warn(
+                "Support for .yml files is deprecated. Use .yaml extension for Hydra config files"
+            )
         if not any(filename.endswith(ext) for ext in [".yaml", ".yml"]):
             filename += ".yaml"
         return filename

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -202,9 +202,17 @@ class TestConfigLoader:
         config_loader = ConfigLoaderImpl(
             config_search_path=create_config_search_path(path)
         )
-        cfg = config_loader.load_configuration(
-            config_name="config.yml", overrides=[], strict=False, run_mode=RunMode.RUN
-        )
+        with pytest.warns(
+            UserWarning,
+            match="Support for .yml files is deprecated. Use .yaml extension for Hydra config files",
+        ):
+            cfg = config_loader.load_configuration(
+                config_name="config.yml",
+                overrides=[],
+                strict=False,
+                run_mode=RunMode.RUN,
+            )
+
         with open_dict(cfg):
             del cfg["hydra"]
 

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -186,12 +186,14 @@ def test_app_with_config_path_backward_compatibility(
     calling_file: str,
     calling_module: str,
 ) -> None:
-    msg = (
-        "\nUsing config_path to specify the config name is deprecated, specify the config name via config_name"
-        "\nSee https://hydra.cc/docs/next/upgrades/0.11_to_1.0/config_path_changes"
+    msg = dedent(
+        """\
+    Using config_path to specify the config name is not supported, specify the config name via config_name.
+    See https://hydra.cc/docs/next/upgrades/0.11_to_1.0/config_path_changes
+    """
     )
 
-    with pytest.warns(expected_warning=UserWarning, match=re.escape(msg)):
+    with pytest.raises(ValueError, match=re.escape(msg)):
         task = hydra_task_runner(
             calling_file=calling_file,
             calling_module=calling_module,


### PR DESCRIPTION
Closes #1308

.yml was supported as an extension for the primary config (and only it).
This deprecates that support.