### PR TITLE
pin pyzmq==21.0.2 

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -468,7 +468,9 @@ def test_jupyter_notebooks(session):
         session.skip(
             f"Not testing Jupyter notebook on Python {session.python}, supports [{','.join(versions)}]"
         )
-    session.install("jupyter", "nbval")
+    # pyzmq fails on Windows py 3.8
+    # https://github.com/zeromq/pyzmq/issues/1496
+    session.install("jupyter", "nbval", "pyzmq==21.0.2")
     install_hydra(session, ["pip", "install", "-e"])
     args = pytest_args(
         "--nbval", "examples/jupyter_notebooks/compose_configs_in_notebook.ipynb"


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation
CI on master is failing with [this](https://app.circleci.com/pipelines/github/facebookresearch/hydra/7100/workflows/82caaac0-6863-44d7-a3d9-ee63fa0f724c/jobs/57555)

I tried to ssh to the windows box and it seems like the error can only be reproed in `nox`, but not in the local conda env. The only difference seems to be the `pyzmq` version. when installing in local conda, `pyzmq==20.0.0`, but in nox, the [`pyzmq==22.0.0`](https://app.circleci.com/pipelines/github/facebookresearch/hydra/7124/workflows/7c189873-1293-4844-a7de-60525a76c18d/jobs/57822)

This diff pins the `pyzmq` version for windows.



### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
