### PR TITLE
Fix incorrect package name in pyproject.toml in plugins.

### DIFF
--- a/plugins/hydra_ax_sweeper/pyproject.toml
+++ b/plugins/hydra_ax_sweeper/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
-    package = "hydra"
-    package_dir = ""
+    package = "hydra_ax_sweeper"
+    package_dir = "hydra_plugins"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_colorlog/pyproject.toml
+++ b/plugins/hydra_colorlog/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
-    package = "hydra"
-    package_dir = ""
+    package = "hydra_colorlog"
+    package_dir = "hydra_plugins"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_joblib_launcher/pyproject.toml
+++ b/plugins/hydra_joblib_launcher/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
-    package = "hydra"
-    package_dir = ""
+    package = "hydra_joblib_launcher"
+    package_dir = "hydra_plugins"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_nevergrad_sweeper/pyproject.toml
+++ b/plugins/hydra_nevergrad_sweeper/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
-    package = "hydra"
-    package_dir = ""
+    package = "hydra_nevergrad_sweeper"
+    package_dir = "hydra_plugins"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_optuna_sweeper/pyproject.toml
+++ b/plugins/hydra_optuna_sweeper/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
-    package = "hydra"
-    package_dir = ""
+    package = "hydra_optuna_sweeper"
+    package_dir = "hydra_plugins"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_ray_launcher/pyproject.toml
+++ b/plugins/hydra_ray_launcher/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
-    package = "hydra"
-    package_dir = ""
+    package = "hydra_ray_launcher"
+    package_dir = hydra_plugins""
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_ray_launcher/pyproject.toml
+++ b/plugins/hydra_ray_launcher/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
     package = "hydra_ray_launcher"
-    package_dir = hydra_plugins""
+    package_dir = "hydra_plugins"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_rq_launcher/pyproject.toml
+++ b/plugins/hydra_rq_launcher/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
-    package = "hydra"
-    package_dir = ""
+    package = "hydra_rq_launcher"
+    package_dir = "hydra_plugins"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_submitit_launcher/pyproject.toml
+++ b/plugins/hydra_submitit_launcher/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
-    package = "hydra"
-    package_dir = ""
+    package = "hydra_submitit_launcher"
+    package_dir = "hydra_plugins"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"


### PR DESCRIPTION
Fixes #1360.

<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Fix incorrect package name in pyproject.toml in plugins.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Verified locally

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)

#1360