### PR TITLE
Pin omegaconf-2.1.0dev16 in preperation to dev17

### DIFF
--- a/plugins/hydra_ax_sweeper/setup.py
+++ b/plugins/hydra_ax_sweeper/setup.py
@@ -23,6 +23,10 @@ with open("README.md", "r") as fh:
             "Operating System :: MacOS",
             "Development Status :: 4 - Beta",
         ],
-        install_requires=["hydra-core>=1.0.0", "ax-platform>=0.1.13"],
+        install_requires=[
+            "hydra-core>=1.0.0",
+            "ax-platform>=0.1.13",
+            "numpy<1.20.0",  # remove once ax is upgraded to support numpy 1.20
+        ],
         include_package_data=True,
     )

--- a/plugins/hydra_nevergrad_sweeper/setup.py
+++ b/plugins/hydra_nevergrad_sweeper/setup.py
@@ -23,6 +23,10 @@ with open("README.md", "r") as fh:
             "Operating System :: OS Independent",
             "Development Status :: 4 - Beta",
         ],
-        install_requires=["hydra-core>=1.0.0", "nevergrad>=0.4.1.post4"],
+        install_requires=[
+            "hydra-core>=1.0.0",
+            "nevergrad>=0.4.1.post4",
+            "numpy<1.20.0",  # remove once nevergrad is upgraded to support numpy 1.20
+        ],
         include_package_data=True,
     )

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -31,6 +31,10 @@ setup(
         "Operating System :: MacOS",
         "Development Status :: 4 - Beta",
     ],
-    install_requires=["hydra-core", "optuna"],
+    install_requires=[
+        "hydra-core",
+        "optuna<2.5.0",
+        "numpy<1.20.0",  # remove once optuna is upgraded to support numpy 1.20
+    ],
     include_package_data=True,
 )

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
-omegaconf>=2.1.0dev16
+omegaconf==2.1.0dev16
 antlr4-python3-runtime==4.8
 importlib-resources;python_version<'3.9'


### PR DESCRIPTION
1. pin omegaconf 2.1.0dev16 to avoid errors when dev17 comes out.
2. pin Optuna to 2.4.0
3. Pin numpy in all HPO plugins to < 1.20 to avoid new deprecation warning.