### PR TITLE
Improved handling of overriding in a nested config

### DIFF
--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -126,30 +126,25 @@ class Overrides:
     def ensure_overrides_used(self) -> None:
         for key, meta in self.override_metadata.items():
             if not meta.used:
-                err_key = key
-                choices = set()
-                if meta.relative_key is not None:
-                    err_key = meta.relative_key
-                else:
-                    group = key.split("@")[0]
-                    choices = (
-                        self.known_choices_per_group[group]
-                        if group in self.known_choices_per_group
-                        else set()
-                    )
+                group = key.split("@")[0]
+                choices = (
+                    self.known_choices_per_group[group]
+                    if group in self.known_choices_per_group
+                    else set()
+                )
 
                 if len(choices) > 1:
                     msg = (
-                        f"Could not override '{err_key}'."
+                        f"Could not override '{key}'."
                         f"\nDid you mean to override one of {', '.join(sorted(list(choices)))}?"
                     )
                 elif len(choices) == 1:
                     msg = (
-                        f"Could not override '{err_key}'."
+                        f"Could not override '{key}'."
                         f"\nDid you mean to override {copy.copy(choices).pop()}?"
                     )
                 elif len(choices) == 0:
-                    msg = f"Could not override '{err_key}'. No match in the defaults list."
+                    msg = f"Could not override '{key}'. No match in the defaults list."
                 else:
                     assert False
 

--- a/hydra/core/default_element.py
+++ b/hydra/core/default_element.py
@@ -247,7 +247,7 @@ class InputDefault:
         default_pkg = self.get_default_package()
         final_pkg = self.get_final_package(default_to_package_header=False)
         key = self.get_group_path()
-        if default_pkg != final_pkg:
+        if default_pkg != final_pkg and final_pkg != "":
             key = f"{key}@{final_pkg}"
         return key
 

--- a/tests/defaults_list/data/experiment/error_override_without_abs_and_header.yaml
+++ b/tests/defaults_list/data/experiment/error_override_without_abs_and_header.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - override group1: file1

--- a/tests/defaults_list/data/experiment/error_override_without_global.yaml
+++ b/tests/defaults_list/data/experiment/error_override_without_global.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - override /group1: file1

--- a/tests/defaults_list/data/experiment/override_with_global_default.yaml
+++ b/tests/defaults_list/data/experiment/override_with_global_default.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - override /group1@_global_: file2

--- a/tests/defaults_list/test_defaults_list.py
+++ b/tests/defaults_list/test_defaults_list.py
@@ -644,7 +644,7 @@ def test_group_default_pkg1(
         ),
         param(
             "include_nested_group_global_",
-            ["group1/group2@=file2"],
+            ["group1/group2=file2"],
             [
                 ResultDefault(
                     config_path="group1/group2/file2",


### PR DESCRIPTION
Closes #1365

1. proper handling of overriding an absolute config group from a nested config with @_global_:

nested/foo.yaml
```yaml
defaults:
 - /group@_global_: file1
```

2. improved error message when overriding a config group that is not found (from a nested group) to show the full override key and not the relative one. while more verbose it's much more helpful in understanding the problem.