### PR TITLE
[Submitit-Plugin] Add support for SLURM parameters `cpus_per_gpu`, `gpus_per_task`, `mem_per_gpu` and `mem_per_cpu`

### DIFF
--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
@@ -14,13 +14,13 @@ class BaseQueueConf:
     # maximum time for the job in minutes
     timeout_min: int = 60
     # number of cpus to use for each task
-    cpus_per_task: int = 1
+    cpus_per_task: Optional[int] = None
     # number of gpus to use on each node
-    gpus_per_node: int = 0
+    gpus_per_node: Optional[int] = None
     # number of tasks to spawn on each node
     tasks_per_node: int = 1
     # memory to reserve for the job on each node (in GB)
-    mem_gb: int = 4
+    mem_gb: Optional[int] = None
     # number of nodes to use for the job
     nodes: int = 1
     # name of the job
@@ -46,6 +46,10 @@ class SlurmQueueConf(BaseQueueConf):
     comment: Optional[str] = None
     constraint: Optional[str] = None
     exclude: Optional[str] = None
+    cpus_per_gpu: Optional[int] = None
+    gpus_per_task: Optional[int] = None
+    mem_per_gpu: Optional[str] = None
+    mem_per_cpu: Optional[str] = None
 
     # Following parameters are submitit specifics
     #

--- a/plugins/hydra_submitit_launcher/news/1366.feature
+++ b/plugins/hydra_submitit_launcher/news/1366.feature
@@ -1,1 +1,1 @@
-Add support for advanced GPU scheduling parameters
+Add support for SLURM parameters `cpus_per_gpu`, `gpus_per_task`, `mem_per_gpu` and `mem_per_cpu`

--- a/plugins/hydra_submitit_launcher/news/1366.feature
+++ b/plugins/hydra_submitit_launcher/news/1366.feature
@@ -1,0 +1,1 @@
+Add support for advanced GPU scheduling parameters

--- a/website/docs/plugins/submitit_launcher.md
+++ b/website/docs/plugins/submitit_launcher.md
@@ -33,29 +33,41 @@ the launching host and the target host.
 Submitit actually implements 2 different launchers: `submitit_slurm` to run on a SLURM cluster, and `submitit_local` for basic local tests.
 
 You can discover the SLURM Launcher parameters with:
+
+<details><summary>Discover SLURM launcher's config</summary>
+
 ```yaml title="$ python your_app.py hydra/launcher=submitit_slurm --cfg hydra -p hydra.launcher"
 # @package hydra.launcher
-_target_: hydra_plugins.hydra_submitit_launcher.submitit_launcher.SlurmLauncher
-submitit_folder: ${hydra.sweep.dir}/.submitit/%j
+submitit_folder: $&#123;hydra.sweep.dir/.submitit/%j
 timeout_min: 60
-cpus_per_task: 1
-gpus_per_node: 0
+cpus_per_task: null
+gpus_per_node: null
 tasks_per_node: 1
-mem_gb: 4
+mem_gb: null
 nodes: 1
 name: ${hydra.job.name}
+_target_: hydra_plugins.hydra_submitit_launcher.submitit_launcher.SlurmLauncher
 partition: null
 comment: null
 constraint: null
 exclude: null
+cpus_per_gpu: null
+gpus_per_task: null
+mem_per_gpu: null
+mem_per_cpu: null
 signal_delay_s: 120
 max_num_timeout: 0
 additional_parameters: {}
 array_parallelism: 256
+setup: null
 
 ```
+</details>
 
 Similarly, you can discover the local launcher parameters with:
+
+<details><summary>Discover local launcher's config</summary>
+
 ```yaml title="$ python example/my_app.py hydra/launcher=submitit_local --cfg hydra -p hydra.launcher"
 # @package hydra.launcher
 _target_: hydra_plugins.hydra_submitit_launcher.submitit_launcher.LocalLauncher
@@ -68,6 +80,7 @@ mem_gb: 4
 nodes: 1
 name: ${hydra.job.name}
 ```
+</details>
 
 You can set all these parameters in your configuration file and/or override them in the commandline: 
 ```text

--- a/website/docs/plugins/submitit_launcher.md
+++ b/website/docs/plugins/submitit_launcher.md
@@ -60,7 +60,7 @@ array_parallelism: 256
 setup: null
 ```
 </details>
-<details><summary>Discover the local launcher parameters <b>(Expand)</b></summary>
+<details><summary>Discover the Local Launcher parameters <b>(Expand)</b></summary>
 
 ```yaml title="$ python example/my_app.py hydra/launcher=submitit_local --cfg hydra -p hydra.launcher"
 # @package hydra.launcher

--- a/website/docs/plugins/submitit_launcher.md
+++ b/website/docs/plugins/submitit_launcher.md
@@ -30,13 +30,11 @@ defaults:
 Note that this plugin expects a valid environment in the target host. usually this means a shared file system between
 the launching host and the target host.
 
-Submitit actually implements 2 different launchers: `submitit_slurm` to run on a SLURM cluster, and `submitit_local` for basic local tests.
+The Submitit Plugin implements 2 different launchers: `submitit_slurm` to run on a SLURM cluster, and `submitit_local` for basic local tests.
 
-You can discover the SLURM Launcher parameters with:
+<details><summary>Discover the SLURM Launcher parameters <b>(Expand)</b></summary>
 
-<details><summary>$ python your_app.py hydra/launcher=submitit_slurm --cfg hydra -p hydra.launcher <b>(Expand)<b/></summary>
-
-```yaml
+```yaml title="$ python your_app.py hydra/launcher=submitit_slurm --cfg hydra -p hydra.launcher"
 # @package hydra.launcher
 submitit_folder: $&#123;hydra.sweep.dir/.submitit/%j
 timeout_min: 60
@@ -62,12 +60,9 @@ array_parallelism: 256
 setup: null
 ```
 </details>
+<details><summary>Discover the local launcher parameters <b>(Expand)</b></summary>
 
-Similarly, you can discover the local launcher parameters with:
-
-<details><summary>$ python example/my_app.py hydra/launcher=submitit_local --cfg hydra -p hydra.launcher <b>(Expand)<b/></summary>
-
-```yaml
+```yaml title="$ python example/my_app.py hydra/launcher=submitit_local --cfg hydra -p hydra.launcher"
 # @package hydra.launcher
 _target_: hydra_plugins.hydra_submitit_launcher.submitit_launcher.LocalLauncher
 submitit_folder: ${hydra.sweep.dir}/.submitit/%j
@@ -81,7 +76,9 @@ name: ${hydra.job.name}
 ```
 </details>
 
-You can set all these parameters in your configuration file and/or override them in the commandline: 
+<br/>
+You can set all these parameters in your configuration file and/or override them in the command-line:
+
 ```text
 python foo.py --multirun hydra/launcher=submitit_slurm hydra.launcher.timeout_min=3
 ```

--- a/website/docs/plugins/submitit_launcher.md
+++ b/website/docs/plugins/submitit_launcher.md
@@ -34,7 +34,7 @@ Submitit actually implements 2 different launchers: `submitit_slurm` to run on a
 
 You can discover the SLURM Launcher parameters with:
 
-<details><summary>$ python your_app.py hydra/launcher=submitit_slurm --cfg hydra -p hydra.launcher (click to expand)</summary>
+<details><summary>$ python your_app.py hydra/launcher=submitit_slurm --cfg hydra -p hydra.launcher <b>(Expand)<b/></summary>
 
 ```yaml
 # @package hydra.launcher
@@ -65,7 +65,7 @@ setup: null
 
 Similarly, you can discover the local launcher parameters with:
 
-<details><summary>$ python example/my_app.py hydra/launcher=submitit_local --cfg hydra -p hydra.launcher (click to expand)</summary>
+<details><summary>$ python example/my_app.py hydra/launcher=submitit_local --cfg hydra -p hydra.launcher <b>(Expand)<b/></summary>
 
 ```yaml
 # @package hydra.launcher

--- a/website/docs/plugins/submitit_launcher.md
+++ b/website/docs/plugins/submitit_launcher.md
@@ -34,9 +34,9 @@ Submitit actually implements 2 different launchers: `submitit_slurm` to run on a
 
 You can discover the SLURM Launcher parameters with:
 
-<details><summary>Discover SLURM launcher's config</summary>
+<details><summary>$ python your_app.py hydra/launcher=submitit_slurm --cfg hydra -p hydra.launcher (click to expand)</summary>
 
-```yaml title="$ python your_app.py hydra/launcher=submitit_slurm --cfg hydra -p hydra.launcher"
+```yaml
 # @package hydra.launcher
 submitit_folder: $&#123;hydra.sweep.dir/.submitit/%j
 timeout_min: 60
@@ -60,15 +60,14 @@ max_num_timeout: 0
 additional_parameters: {}
 array_parallelism: 256
 setup: null
-
 ```
 </details>
 
 Similarly, you can discover the local launcher parameters with:
 
-<details><summary>Discover local launcher's config</summary>
+<details><summary>$ python example/my_app.py hydra/launcher=submitit_local --cfg hydra -p hydra.launcher (click to expand)</summary>
 
-```yaml title="$ python example/my_app.py hydra/launcher=submitit_local --cfg hydra -p hydra.launcher"
+```yaml
 # @package hydra.launcher
 _target_: hydra_plugins.hydra_submitit_launcher.submitit_launcher.LocalLauncher
 submitit_folder: ${hydra.sweep.dir}/.submitit/%j


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

It's currently impossible to set certain advanced scheduling options, mainly around GPUs, using the hydra submitit plugin because they conflict with each other. In order to make it work, some of the base options need to be made `Optional`.

This PR makes two updates to the submitit laucher:

1. It makes the following parameters optional: [`cpus_per_task`, `gpus_per_node`, `mem_gb`] which conflict with the advanced options.
2. It adds in some parameters that are supported in the slurm executor but were missing from the hydra plugin.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

I've confirmed that the generated sbatch is correct based on the given options

## Related Issues and PRs

Closes #1366
