### PR TITLE
Blocked automatic schema maching with defaults list in schema

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -343,17 +343,29 @@ class ConfigLoaderImpl(ConfigLoader):
             if schema is not None:
                 try:
                     url = "https://hydra.cc/docs/next/upgrades/1.0_to_1.1/automatic_schema_matching"
-                    warnings.warn(
-                        dedent(
-                            f"""\
-
+                    if "defaults" in schema.config:
+                        raise ConfigCompositionException(
+                            dedent(
+                                f"""\
                             '{config_path}' is validated against ConfigStore schema with the same name.
                             This behavior is deprecated in Hydra 1.1 and will be removed in Hydra 1.2.
+                            In addition, the automatically matched schema contains a defaults list.
+                            This combination is no longer supported.
                             See {url} for migration instructions."""
-                        ),
-                        category=UserWarning,
-                        stacklevel=11,
-                    )
+                            )
+                        )
+                    else:
+                        warnings.warn(
+                            dedent(
+                                f"""\
+    
+                                '{config_path}' is validated against ConfigStore schema with the same name.
+                                This behavior is deprecated in Hydra 1.1 and will be removed in Hydra 1.2.
+                                See {url} for migration instructions."""
+                            ),
+                            category=UserWarning,
+                            stacklevel=11,
+                        )
 
                     # if primary config has a hydra node, remove it during validation and add it back.
                     # This allows overriding Hydra's configuration without declaring it's node

--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -358,7 +358,7 @@ class ConfigLoaderImpl(ConfigLoader):
                         warnings.warn(
                             dedent(
                                 f"""\
-    
+
                                 '{config_path}' is validated against ConfigStore schema with the same name.
                                 This behavior is deprecated in Hydra 1.1 and will be removed in Hydra 1.2.
                                 See {url} for migration instructions."""


### PR DESCRIPTION
Automatic schema matching with a defaults list in the automatically matched schema does not work.
The reason is that the final defaults list have already been computed when the automatic schema is being discovered and used.

Automatic schema matching is deprecated in 1.1, but this combination cause the defaults list in the automatically matched schema to be ignored - rendering it very confusing.

This PR makes the normal deprecation warning about automatic schema matching into a hard error to eliminate confusion.