### PR TITLE
[Ax] implements `is_noisy` parameter for errorless measurements

### DIFF
--- a/plugins/hydra_ax_sweeper/example/conf/config.yaml
+++ b/plugins/hydra_ax_sweeper/example/conf/config.yaml
@@ -26,6 +26,10 @@ hydra:
         # An Epoch is defined as a batch of trials executed in parallel
         max_epochs_without_improvement: 10
 
+      # the synthetic measurements in this example have 0 error
+      # which is specified by setting is_errorless to true
+      is_errorless: true
+
       params:
         banana.x:
           type: range

--- a/plugins/hydra_ax_sweeper/example/conf/config.yaml
+++ b/plugins/hydra_ax_sweeper/example/conf/config.yaml
@@ -27,8 +27,8 @@ hydra:
         max_epochs_without_improvement: 10
 
       # the synthetic measurements in this example have 0 error
-      # which is specified by setting is_errorless to true
-      is_errorless: true
+      # which is specified by setting is_noisy to false
+      is_noisy: False
 
       params:
         banana.x:

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
@@ -227,10 +227,10 @@ class CoreAxSweeper(Sweeper):
                 # if true (default), the error of each measurement is inferred by Ax.
                 # if false, the error of each measurement is set to 0.
                 if isinstance(val, (int, float)):
-                    if not self.is_noisy:
-                        val = (val, 0)
+                    if self.is_noisy:
+                        val = (val, None) # specify unknown noise
                     else:
-                        val = (val, None)
+                        val = (val, 0) # specify no noise
                 ax_client.complete_trial(
                     trial_index=batch[idx].trial_index, raw_data=val
                 )

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
@@ -126,6 +126,7 @@ class CoreAxSweeper(Sweeper):
         self.sweep_dir: str
         self.job_idx: Optional[int] = None
         self.max_batch_size = max_batch_size
+        self.is_errorless: bool = ax_config.is_errorless
 
     def setup(
         self,
@@ -218,7 +219,18 @@ class CoreAxSweeper(Sweeper):
             )
             self.job_idx += len(rets)
             for idx in range(len(batch)):
-                val = rets[idx].return_value
+                val: Any = rets[idx].return_value
+                # Ax expects a measured value (int or float), which can optionally
+                # be given in a tuple along with the error of that measurement
+                assert isinstance(val, (int, float, tuple))
+                # is_errorless specifies how Ax should behave when not given an error value.
+                # if false (default), the error of each measurement is inferred by Ax.
+                # if true, the error of each measurement is set to 0.
+                if isinstance(val, (int, float)):
+                    if self.is_errorless:
+                        val = (val, 0)
+                    else:
+                        val = (val, None)
                 ax_client.complete_trial(
                     trial_index=batch[idx].trial_index, raw_data=val
                 )

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
@@ -228,9 +228,9 @@ class CoreAxSweeper(Sweeper):
                 # if false, the error of each measurement is set to 0.
                 if isinstance(val, (int, float)):
                     if self.is_noisy:
-                        val = (val, None) # specify unknown noise
+                        val = (val, None)  # specify unknown noise
                     else:
-                        val = (val, 0) # specify no noise
+                        val = (val, 0)  # specify no noise
                 ax_client.complete_trial(
                     trial_index=batch[idx].trial_index, raw_data=val
                 )

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
@@ -126,7 +126,7 @@ class CoreAxSweeper(Sweeper):
         self.sweep_dir: str
         self.job_idx: Optional[int] = None
         self.max_batch_size = max_batch_size
-        self.is_errorless: bool = ax_config.is_errorless
+        self.is_noisy: bool = ax_config.is_noisy
 
     def setup(
         self,
@@ -223,11 +223,11 @@ class CoreAxSweeper(Sweeper):
                 # Ax expects a measured value (int or float), which can optionally
                 # be given in a tuple along with the error of that measurement
                 assert isinstance(val, (int, float, tuple))
-                # is_errorless specifies how Ax should behave when not given an error value.
-                # if false (default), the error of each measurement is inferred by Ax.
-                # if true, the error of each measurement is set to 0.
+                # is_noisy specifies how Ax should behave when not given an error value.
+                # if true (default), the error of each measurement is inferred by Ax.
+                # if false, the error of each measurement is set to 0.
                 if isinstance(val, (int, float)):
-                    if self.is_errorless:
+                    if not self.is_noisy:
                         val = (val, 0)
                     else:
                         val = (val, None)

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/config.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/config.py
@@ -50,7 +50,7 @@ class AxConfig:
     experiment: ExperimentConfig = ExperimentConfig()
     client: ClientConfig = ClientConfig()
     params: Dict[str, Any] = field(default_factory=dict)
-    is_errorless: bool = False
+    is_noisy: bool = True
 
 
 @dataclass

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/config.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/config.py
@@ -50,6 +50,7 @@ class AxConfig:
     experiment: ExperimentConfig = ExperimentConfig()
     client: ClientConfig = ClientConfig()
     params: Dict[str, Any] = field(default_factory=dict)
+    is_errorless: bool = False
 
 
 @dataclass

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/config.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/config.py
@@ -50,6 +50,8 @@ class AxConfig:
     experiment: ExperimentConfig = ExperimentConfig()
     client: ClientConfig = ClientConfig()
     params: Dict[str, Any] = field(default_factory=dict)
+    # is_noisy = True indicates measurements have unknown uncertainty
+    # is_noisy = False indicates measurements have an uncertainty of zero
     is_noisy: bool = True
 
 

--- a/plugins/hydra_ax_sweeper/news/1395.feature
+++ b/plugins/hydra_ax_sweeper/news/1395.feature
@@ -1,1 +1,1 @@
-Support for errorless measurements in an Ax experiment via `is_noisy` input parameter
+Support for deterministic functions in an Ax experiment via `is_noisy` input parameter

--- a/plugins/hydra_ax_sweeper/news/1395.feature
+++ b/plugins/hydra_ax_sweeper/news/1395.feature
@@ -1,0 +1,1 @@
+Support for errorless measurements in an Ax experiment via `is_errorless` input parameter

--- a/plugins/hydra_ax_sweeper/news/1395.feature
+++ b/plugins/hydra_ax_sweeper/news/1395.feature
@@ -1,1 +1,1 @@
-Support for errorless measurements in an Ax experiment via `is_errorless` input parameter
+Support for errorless measurements in an Ax experiment via `is_noisy` input parameter

--- a/website/docs/plugins/ax_sweeper.md
+++ b/website/docs/plugins/ax_sweeper.md
@@ -35,7 +35,7 @@ The return value of the function should be the value that we want to optimize.
 To compute the best parameters for the Banana function, clone the code and run the following command in the `plugins/hydra_ax_sweeper` directory:
 
 ```
-python example/banana.py -m 'banana.x=int(interval(-5, 5))' 'banana.y=interval(-5, 10.1)' hydra.sweeper.ax_config.is_noisy=false
+python example/banana.py -m 'banana.x=int(interval(-5, 5))' 'banana.y=interval(-5, 10.1)'
 ```
 
 The output of a run looks like:

--- a/website/docs/plugins/ax_sweeper.md
+++ b/website/docs/plugins/ax_sweeper.md
@@ -12,7 +12,7 @@ import {ExampleGithubLink} from "@site/src/components/GithubLink"
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/hydra-ax-sweeper.svg)](https://pypistats.org/packages/hydra-ax-sweeper)<ExampleGithubLink text="Example application" to="plugins/hydra_ax_sweeper/example"/><ExampleGithubLink text="Plugin source" to="plugins/hydra_ax_sweeper"/>
 
 
-This plugin provides a mechanism for Hydra applications to use the [Adaptive Experimentation Platform, aka Ax](https://ax.dev/). Ax can optimize any experiment - machine learning experiments, A/B tests, and simulations. 
+This plugin provides a mechanism for Hydra applications to use the [Adaptive Experimentation Platform, aka Ax](https://ax.dev/). Ax can optimize any experiment - machine learning experiments, A/B tests, and simulations.
 
 ### Installation
 ```commandline
@@ -28,14 +28,14 @@ defaults:
 ```
 
 We include an example of how to use this plugin. The file <GithubLink to="plugins/hydra_ax_sweeper/example/banana.py">example/banana.py</GithubLink>
-implements the [Rosenbrock function (aka Banana function)](https://en.wikipedia.org/wiki/Rosenbrock_function). 
+implements the [Rosenbrock function (aka Banana function)](https://en.wikipedia.org/wiki/Rosenbrock_function).
 The return value of the function should be the value that we want to optimize.
 
 
 To compute the best parameters for the Banana function, clone the code and run the following command in the `plugins/hydra_ax_sweeper` directory:
 
 ```
-python example/banana.py -m 'banana.x=int(interval(-5, 5))' 'banana.y=interval(-5, 10.1)' hydra.sweeper.ax_config.is_errorless=true
+python example/banana.py -m 'banana.x=int(interval(-5, 5))' 'banana.y=interval(-5, 10.1)' hydra.sweeper.ax_config.is_noisy=false
 ```
 
 The output of a run looks like:
@@ -81,11 +81,14 @@ In general, the plugin supports setting all the Ax supported [Parameters](https:
 * `type` - Type of the parameter. It can take the following values: `range`, `fixed`, or `choice`.
 * `bounds` - Required only for the `range` parameters. It should be a list of two values, with the lower bound first.
 * `values` - Required only for the `choice` parameters. It should be a list of values.
-* `value` - Required only for the `fixed` parameters. It should be a single value. 
+* `value` - Required only for the `fixed` parameters. It should be a single value.
 
 Note that if you want to sample integers in the range `-5` to `5`, you need to specify the range as `int(interval(-5, 5))` (in the command line) or `[-5, 5]` (in config). If you want to sample floats in range `-5` to `5`, you need to specify the range as `interval(-5, 5)` (in the command line) or `[-5.0, 5.0]` (in config).
 
-Generally, Ax expects the function being optimized to return a tuple of `(measurement_value, measurement_uncertainty)`. If the return value is instead a scalar, Ax by default treats the uncertainty as an unknown and infers its value as the experiment progresses. The example above uses an exact function, so the `is_errorless` parameter is set to `True`. As a result, the uncertainty of each scalar measurement is set to 0. Note that returning a `(measurement_value, measurement_uncertainty)` tuple will override this behavior.
+The Ax Sweeper assumes the optimized function is a noisy function with unknown measurement uncertainty.
+This can be changed by overriding the `is_noisy` parameter to False, which specifies that each measurement is exact, i.e., each measurement has a measurement uncertainty of zero.
+
+If measurement uncertainty is known or can be estimated (e.g., via a heuristic or via the [standard error of the mean](https://en.wikipedia.org/wiki/Standard_error) of repeated measurements), the measurement function can return the tuple `(measurement_value, measurement_uncertainty)` instead of a scalar value.
 
 The parameters for the optimization process can also be set in the config file. Specifying the Ax config is optional. You can discover the Ax Sweeper parameters with:
 
@@ -109,6 +112,6 @@ ax_config:
   client:
     verbose_logging: false
     random_seed: null
-  is_errorless: false
+  is_noisy: true
   params: {}
 ```

--- a/website/docs/plugins/ax_sweeper.md
+++ b/website/docs/plugins/ax_sweeper.md
@@ -35,29 +35,29 @@ The return value of the function should be the value that we want to optimize.
 To compute the best parameters for the Banana function, clone the code and run the following command in the `plugins/hydra_ax_sweeper` directory:
 
 ```
-python example/banana.py -m 'banana.x=int(interval(-5, 5))' 'banana.y=interval(-5, 10.1)'
+python example/banana.py -m 'banana.x=int(interval(-5, 5))' 'banana.y=interval(-5, 10.1)' hydra.sweeper.ax_config.is_errorless=true
 ```
 
 The output of a run looks like:
 
 ```
 [HYDRA] AxSweeper is optimizing the following parameters:
-banana.x: range=[-5, 5], type = int
-banana.y: range=[-5.0, 10.1], type = float
-ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 arms, GPEI for subsequent arms], generated 0 arm(s) so far). Iterations after 5 will take longer to generate due to model-fitting.
-AxSweeper is launching 5 jobs
+banana.x: range=[-5, 5]
+banana.y: range=[-5.0, 10.1]
+ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to model-fitting.
+[HYDRA] AxSweeper is launching 5 jobs
 [HYDRA] Launching 5 jobs locally
-[HYDRA]   #0 : banana.x=4 banana.y=-1.484
-[__main__][INFO] - Banana_Function(x=4, y=-1.484)=30581.473
-[HYDRA]   #1 : banana.x=3 banana.y=-3.653
-[__main__][INFO] - Banana_Function(x=3, y=-3.653)=16014.261
-[HYDRA]   #2 : banana.x=0 banana.y=9.409
-[__main__][INFO] - Banana_Function(x=0, y=9.409)=8855.340
-[HYDRA]   #3 : banana.x=-4 banana.y=2.059
-[__main__][INFO] - Banana_Function(x=-4, y=2.059)=19459.063
-[HYDRA]   #4 : banana.x=-3 banana.y=-1.338
-[__main__][INFO] - Banana_Function(x=-3, y=-1.338)=10704.497
-[HYDRA] New best value: 8855.340, best parameters: {'banana.x': 0, 'banana.y': 9.409}
+[HYDRA]        #0 : banana.x=2 banana.y=-0.988
+[__main__][INFO] - Banana_Function(x=2, y=-0.988)=2488.883
+[HYDRA]        #1 : banana.x=-1 banana.y=7.701
+[__main__][INFO] - Banana_Function(x=-1, y=7.701)=4493.987
+[HYDRA]        #2 : banana.x=-1 banana.y=-3.901
+[__main__][INFO] - Banana_Function(x=-1, y=-3.901)=2406.259
+[HYDRA]        #3 : banana.x=-1 banana.y=0.209
+[__main__][INFO] - Banana_Function(x=-1, y=0.209)=66.639
+[HYDRA]        #4 : banana.x=4 banana.y=-4.557
+[__main__][INFO] - Banana_Function(x=4, y=-4.557)=42270.006
+[HYDRA] New best value: 66.639, best parameters: {'banana.x': -1, 'banana.y': 0.209}
 ```
 
 In this example, we set the range of `x` parameter as an integer in the interval `[-5, 5]` and the range of `y` parameter as a float in the interval `[-5, 10.1]`. Note that in the case of `x`, we used `int(interval(...))` and hence only integers are sampled. In the case of `y`, we used `interval(...)` which refers to a floating-point interval. Other supported formats are fixed parameters (e.g.` banana.x=5.0`), choice parameters (eg `banana.x=choice(1,2,3)`) and range (eg `banana.x=range(1, 10)`). Note that `interval`, `choice` etc. are functions provided by Hydra, and you can read more about them [here](https://hydra.cc/docs/next/advanced/override_grammar/extended/). An important thing to remember is, use [`interval`](https://hydra.cc/docs/next/advanced/override_grammar/extended/#interval-sweep) when we want Ax to sample values from an interval. [`RangeParameter`](https://ax.dev/api/ax.html#ax.RangeParameter) in Ax is equivalent to `interval` in Hydra. Remember to use `int(interval(...))` if you want to sample only integer points from the interval. [`range`](https://hydra.cc/docs/next/advanced/override_grammar/extended/#range-sweep) can be used as an alternate way of specifying choice parameters. For example `python example/banana.py -m banana.x=choice(1, 2, 3, 4)` is equivalent to `python example/banana.py -m banana.x=range(1, 5)`.
@@ -85,6 +85,8 @@ In general, the plugin supports setting all the Ax supported [Parameters](https:
 
 Note that if you want to sample integers in the range `-5` to `5`, you need to specify the range as `int(interval(-5, 5))` (in the command line) or `[-5, 5]` (in config). If you want to sample floats in range `-5` to `5`, you need to specify the range as `interval(-5, 5)` (in the command line) or `[-5.0, 5.0]` (in config).
 
+Generally, Ax expects the function being optimized to return a tuple of `(measurement_value, measurement_uncertainty)`. If the return value is instead a scalar, Ax by default treats the uncertainty as an unknown and infers its value as the experiment progresses. The example above uses an exact function, so the `is_errorless` parameter is set to `True`. As a result, the uncertainty of each scalar measurement is set to 0. Note that returning a `(measurement_value, measurement_uncertainty)` tuple will override this behavior.
+
 The parameters for the optimization process can also be set in the config file. Specifying the Ax config is optional. You can discover the Ax Sweeper parameters with:
 
 ```yaml title="$ python your_app.py hydra/sweeper=ax --cfg hydra -p hydra.sweeper"
@@ -107,5 +109,6 @@ ax_config:
   client:
     verbose_logging: false
     random_seed: null
+  is_errorless: false
   params: {}
 ```


### PR DESCRIPTION
Closes #1352

## Motivation

Generally, Ax expects the function being optimized to return a tuple of `(measurement_value, measurement_uncertainty)`. If the return value is instead a scalar, Ax by default treats the uncertainty as an unknown and infers its value as the experiment progresses. For exact functions, this is not the desired behavior, so users may now leverage the `is_errorless` parameter. When `is_noisy` is `False`, the uncertainty of each scalar measurement is set to zero, whereas `True` (the default) leads Ax to infer the uncertainty as discussed above. Note that returning a `(measurement_value, measurement_uncertainty)` tuple will override this behavior in either circumstance.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Tested by logging that hydra follows the correct codepath when run with `is_errorless: true/false`. Currently, all new code is covered by previous unit tests since the `banana` example has `is_errorless = True` and all others follow the default which is false.

## Related Issues and PRs

https://github.com/facebookresearch/hydra/issues/1352