### PR TITLE
Use internaldocs-fb preset

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -19,7 +19,6 @@ module.exports = {
             current: "https://github.com/facebookresearch/hydra/blob/master/",
         },
     },    
-    plugins: [require.resolve('docusaurus-plugin-internaldocs-fb')],
     themeConfig: {
         googleAnalytics: {
             trackingID: 'UA-149862507-1',
@@ -110,7 +109,7 @@ module.exports = {
     },
     presets: [
         [
-            '@docusaurus/preset-classic',
+            require.resolve('docusaurus-plugin-internaldocs-fb/docusaurus-preset'),
             {
                 docs: {
                     sidebarPath: require.resolve('./sidebars.js'),


### PR DESCRIPTION
## Motivation

I saw @omry 's comment about code-snippets not working and remembered that you need to use this preset.

Enables the facebook docusaurus preset, which brings various plugins, including internal/external content helper functions and code-snippets.

The reason the preset replaces the docs preset, is that it has to add to the remark (markdown) plugins used by the content plugin.

You can do achieve this without using this preset if you want, by reproducing [this](https://www.internalfb.com/intern/diffusion/FBS/browsefile/master/xplat/staticdocs/packages/docusaurus-plugin-internaldocs-fb/docusaurus-preset.js?commit=d6f28e365058b4fac570fff87e97ba986d967516&lines=17-20) in your docusaurus.config.js, but this preset makes it easier. It also acts as a single point of integration for all facebook plugins, so you'll just need to bump this preset version to get all the new features.

### Have you read the [Contributing Guidelines on pull requests?

Yes

## Test Plan

Example of using the code-snippets plugin

## Related Issues and PRs

https://github.com/facebookresearch/hydra/pull/1378
