### PR TITLE
rename CI run name to core_tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
 
 workflows:
   version: 2
-  build:
+  core_tests:
     unless: << pipeline.parameters.plugin_test >>
     jobs:
       - trigger_plugin_piplines


### PR DESCRIPTION
workflow name is `core_tests` now instead of `build`
https://app.circleci.com/pipelines/github/facebookresearch/hydra/7725/workflows/33d0d95d-9a28-4c0a-a69f-68696eb84664