### PR TITLE
Fix typo in test username

### DIFF
--- a/examples/advanced/ad_hoc_composition/conf/db/postgresql.yaml
+++ b/examples/advanced/ad_hoc_composition/conf/db/postgresql.yaml
@@ -1,4 +1,4 @@
 driver: postgresql
-user: postgre_user
+user: postgres_user
 pass: drowssap
 timeout: 10

--- a/examples/advanced/package_overrides/conf/db/postgresql.yaml
+++ b/examples/advanced/package_overrides/conf/db/postgresql.yaml
@@ -1,4 +1,4 @@
 driver: postgresql
-user: postgre_user
+user: postgres_user
 pass: drowssap
 timeout: 10

--- a/examples/configure_hydra/custom_help/conf/db/postgresql.yaml
+++ b/examples/configure_hydra/custom_help/conf/db/postgresql.yaml
@@ -1,4 +1,4 @@
 driver: postgresql
-user: postgre_user
+user: postgres_user
 pass: drowssap
 timeout: 10

--- a/examples/plugins/example_launcher_plugin/README.md
+++ b/examples/plugins/example_launcher_plugin/README.md
@@ -21,7 +21,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 10
-  user: postgre_user
+  user: postgres_user
 
 [2019-10-22 19:45:05,135] -     #1 : db=mysql
 db:

--- a/examples/plugins/example_launcher_plugin/example/conf/db/postgresql.yaml
+++ b/examples/plugins/example_launcher_plugin/example/conf/db/postgresql.yaml
@@ -1,4 +1,4 @@
 driver: postgresql
-user: postgre_user
+user: postgres_user
 pass: drowssap
 timeout: 10

--- a/examples/plugins/example_sweeper_plugin/README.md
+++ b/examples/plugins/example_sweeper_plugin/README.md
@@ -27,5 +27,5 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 10
-  user: postgre_user
+  user: postgres_user
 ```

--- a/examples/plugins/example_sweeper_plugin/example/conf/db/postgresql.yaml
+++ b/examples/plugins/example_sweeper_plugin/example/conf/db/postgresql.yaml
@@ -1,4 +1,4 @@
 driver: postgresql
-user: postgre_user
+user: postgres_user
 pass: drowssap
 timeout: 10

--- a/examples/tutorials/basic/your_first_hydra_app/4_config_groups/conf/db/postgresql.yaml
+++ b/examples/tutorials/basic/your_first_hydra_app/4_config_groups/conf/db/postgresql.yaml
@@ -1,4 +1,4 @@
 driver: postgresql
-user: postgre_user
+user: postgres_user
 password: drowssap
 timeout: 10

--- a/examples/tutorials/basic/your_first_hydra_app/5_defaults/conf/db/postgresql.yaml
+++ b/examples/tutorials/basic/your_first_hydra_app/5_defaults/conf/db/postgresql.yaml
@@ -1,4 +1,4 @@
 driver: postgresql
-user: postgre_user
+user: postgres_user
 pass: drowssap
 timeout: 10

--- a/examples/tutorials/basic/your_first_hydra_app/6_composition/conf/db/postgresql.yaml
+++ b/examples/tutorials/basic/your_first_hydra_app/6_composition/conf/db/postgresql.yaml
@@ -1,4 +1,4 @@
 driver: postgresql
-user: postgre_user
+user: postgres_user
 pass: drowssap
 timeout: 10

--- a/examples/tutorials/structured_configs/4_defaults/my_app.py
+++ b/examples/tutorials/structured_configs/4_defaults/my_app.py
@@ -23,7 +23,7 @@ class PostGreSQLConfig:
     host: str = "localhost"
     port: int = 5432
     timeout: int = 10
-    user: str = "postgre_user"
+    user: str = "postgres_user"
     password: str = "drowssap"
 
 

--- a/examples/tutorials/structured_configs/5.1_structured_config_schema_same_config_group/conf/db/postgresql.yaml
+++ b/examples/tutorials/structured_configs/5.1_structured_config_schema_same_config_group/conf/db/postgresql.yaml
@@ -1,5 +1,5 @@
 defaults:
   - base_postgresql
 
-user: postgre_user
+user: postgres_user
 password: drowssap

--- a/examples/tutorials/structured_configs/5.2_structured_config_schema_different_config_group/conf/db/postgresql.yaml
+++ b/examples/tutorials/structured_configs/5.2_structured_config_schema_different_config_group/conf/db/postgresql.yaml
@@ -1,5 +1,5 @@
 defaults:
   - /database_lib/db/postgresql@_here_
 
-user: postgre_user
+user: postgres_user
 password: drowssap

--- a/hydra/test_utils/configs/db/postgresql.yaml
+++ b/hydra/test_utils/configs/db/postgresql.yaml
@@ -1,4 +1,4 @@
 driver: postgresql
-user: postgre_user
+user: postgres_user
 password: drowssap
 timeout: 10

--- a/hydra/test_utils/configs/db/validated_postgresql.yaml
+++ b/hydra/test_utils/configs/db/validated_postgresql.yaml
@@ -2,6 +2,6 @@ defaults:
   - base_postgresql
 
 driver: postgresql
-user: postgre_user
+user: postgres_user
 password: drowssap
 timeout: 10

--- a/tests/test_examples/test_tutorials_basic.py
+++ b/tests/test_examples/test_tutorials_basic.py
@@ -135,7 +135,7 @@ def test_tutorial_config_file_bad_key(
                         "driver": "postgresql",
                         "password": "drowssap",
                         "timeout": 10,
-                        "user": "postgre_user",
+                        "user": "postgres_user",
                     }
                 }
             ),
@@ -165,7 +165,7 @@ def test_tutorial_config_groups(
                     "driver": "postgresql",
                     "pass": "drowssap",
                     "timeout": 10,
-                    "user": "postgre_user",
+                    "user": "postgres_user",
                 }
             },
         ),
@@ -176,7 +176,7 @@ def test_tutorial_config_groups(
                     "driver": "postgresql",
                     "pass": "drowssap",
                     "timeout": 20,
-                    "user": "postgre_user",
+                    "user": "postgres_user",
                 }
             },
         ),

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -107,7 +107,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 20
-  user: postgre_user
+  user: postgres_user
 website:
   domain: example.com
 ```
@@ -134,7 +134,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 10
-  user: postgre_user
+  user: postgres_user
 website:
     domain: example.com
 ```

--- a/website/docs/tutorials/basic/your_first_app/4_config_groups.md
+++ b/website/docs/tutorials/basic/your_first_app/4_config_groups.md
@@ -42,7 +42,7 @@ password: secret
 
 ```yaml title="db/postgresql.yaml"
 driver: postgresql
-user: postgre_user
+user: postgres_user
 password: drowssap
 timeout: 10
 
@@ -73,7 +73,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 10
-  user: postgre_user
+  user: postgres_user
 ```
 
 By default, the config group determines where the config content is placed inside the final config object. 
@@ -88,7 +88,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 20
-  user: postgre_user
+  user: postgres_user
 ```
 
 ### Advanced topics

--- a/website/docs/tutorials/basic/your_first_app/5_defaults.md
+++ b/website/docs/tutorials/basic/your_first_app/5_defaults.md
@@ -59,7 +59,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 20
-  user: postgre_user
+  user: postgres_user
 ```
 
 You can remove a default entry from the defaults list by prefixing it with ~:

--- a/website/docs/tutorials/structured_config/3_config_groups.md
+++ b/website/docs/tutorials/structured_config/3_config_groups.md
@@ -53,7 +53,7 @@ db:
   password: drowssap
   port: 5432
   timeout: 10
-  user: postgre_user
+  user: postgres_user
 ```
 
 The `+` above is required because there is no default choice for the config group `db`.

--- a/website/docs/tutorials/structured_config/5_schema.md
+++ b/website/docs/tutorials/structured_config/5_schema.md
@@ -58,7 +58,7 @@ password: secret
 defaults:
   - base_postgresql
 
-user: postgre_user
+user: postgres_user
 password: drowssap
 ```
 </div>
@@ -262,7 +262,7 @@ password: secret
 defaults:
   - /database_lib/db/postgresql@_here_
 
-user: postgre_user
+user: postgres_user
 password: drowssap
 ```
 </div>

--- a/website/versioned_docs/version-0.11/intro.md
+++ b/website/versioned_docs/version-0.11/intro.md
@@ -109,7 +109,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 20
-  user: postgre_user
+  user: postgres_user
 website:
     domain: example.com
 ```
@@ -136,7 +136,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 10
-  user: postgre_user
+  user: postgres_user
 website:
     domain: example.com
 ```

--- a/website/versioned_docs/version-0.11/tutorial/3_config_groups.md
+++ b/website/versioned_docs/version-0.11/tutorial/3_config_groups.md
@@ -49,7 +49,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 10
-  user: postgre_user
+  user: postgres_user
 ```
 
 Like before, you can still override individual values in the resulting config:
@@ -59,7 +59,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 20
-  user: postgre_user
+  user: postgres_user
 ```
 
 This simple example demonstrated a very powerful feature of Hydra:

--- a/website/versioned_docs/version-0.11/tutorial/4_defaults.md
+++ b/website/versioned_docs/version-0.11/tutorial/4_defaults.md
@@ -42,7 +42,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 20
-  user: postgre_user
+  user: postgres_user
 ```
 
 You can prevent a default from being loaded by assigning `null` to it in the command line:

--- a/website/versioned_docs/version-1.0/intro.md
+++ b/website/versioned_docs/version-1.0/intro.md
@@ -106,7 +106,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 20
-  user: postgre_user
+  user: postgres_user
 website:
   domain: example.com
 ```
@@ -133,7 +133,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 10
-  user: postgre_user
+  user: postgres_user
 website:
     domain: example.com
 ```

--- a/website/versioned_docs/version-1.0/tutorials/basic/your_first_app/4_config_groups.md
+++ b/website/versioned_docs/version-1.0/tutorials/basic/your_first_app/4_config_groups.md
@@ -67,7 +67,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 10
-  user: postgre_user
+  user: postgres_user
 ```
 
 Like before, you can still override individual values in the resulting config:
@@ -77,7 +77,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 20
-  user: postgre_user
+  user: postgres_user
 ```
 
 ### More advanced usages of config groups

--- a/website/versioned_docs/version-1.0/tutorials/basic/your_first_app/5_defaults.md
+++ b/website/versioned_docs/version-1.0/tutorials/basic/your_first_app/5_defaults.md
@@ -56,7 +56,7 @@ db:
   driver: postgresql
   pass: drowssap
   timeout: 20
-  user: postgre_user
+  user: postgres_user
 ```
 
 You can remove a default entry from the defaults list by prefixing it with ~:

--- a/website/versioned_docs/version-1.0/tutorials/structured_config/3_config_groups.md
+++ b/website/versioned_docs/version-1.0/tutorials/structured_config/3_config_groups.md
@@ -53,7 +53,7 @@ db:
   password: drowssap
   port: 5432
   timeout: 10
-  user: postgre_user
+  user: postgres_user
 ```
 
 The `+` above is required because there is no default choice for the config group `db`.


### PR DESCRIPTION
## Motivation

I have a feeling 'postgre_user' is a typo for 'postgres_user'

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

eyes