### PR TITLE
Fix sampler value in Optuna sweeper document

### DIFF
--- a/website/docs/plugins/optuna_sweeper.md
+++ b/website/docs/plugins/optuna_sweeper.md
@@ -57,7 +57,7 @@ optuna_config:
   study_name: sphere
   n_trials: 20
   n_jobs: 1
-  sampler: TPESampler
+  sampler: tpe
   seed: 123
 search_space:
   x:


### PR DESCRIPTION
## Motivation

Currently, a wrong value is set to the configuration in [Optuna sweeper document](https://hydra.cc/docs/next/plugins/optuna_sweeper/#example-1-single-objective-optimization). The value of `sampler` must be one of `tpe`, `random`, `cmaes`, `nsgaii` and `motpe`. So, we should replace `TPESampler` with `tpe` in the configuration. 

```yaml
optuna_config:
  direction: minimize
  storage: null
  study_name: sphere
  n_trials: 20
  n_jobs: 1
  sampler: TPESampler
  seed: 123
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

N/A

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
