### PR TITLE
Cleanup pytest imports to reduce tests boilerplate

### DIFF
--- a/build_helpers/test_helpers.py
+++ b/build_helpers/test_helpers.py
@@ -3,16 +3,16 @@ import os.path
 from pathlib import Path
 from typing import List
 
-import pytest
+from pytest import mark, param
 
 from build_helpers.build_helpers import find, matches
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "path,include_files,include_dirs,excludes,scan_exclude,expected",
     [
-        pytest.param("test_files", [], [], [], [], [], id="none"),
-        pytest.param(
+        param("test_files", [], [], [], [], [], id="none"),
+        param(
             "test_files",
             [".*"],
             [],
@@ -30,7 +30,7 @@ from build_helpers.build_helpers import find, matches
             ],
             id="all",
         ),
-        pytest.param(
+        param(
             "test_files",
             [".*"],
             [],
@@ -39,7 +39,7 @@ from build_helpers.build_helpers import find, matches
             ["c/bad_dir/.gitkeep", "c/file2.txt", "c/file1.txt", "c/junk.txt"],
             id="filter_a",
         ),
-        pytest.param(
+        param(
             "test_files",
             ["^a/.*"],
             [],
@@ -48,7 +48,7 @@ from build_helpers.build_helpers import find, matches
             ["a/b/bad_dir/.gitkeep", "a/b/file2.txt", "a/b/file1.txt", "a/b/junk.txt"],
             id="include_a",
         ),
-        pytest.param(
+        param(
             "test_files",
             ["^a/.*"],
             [],
@@ -57,7 +57,7 @@ from build_helpers.build_helpers import find, matches
             ["a/b/bad_dir/.gitkeep", "a/b/file2.txt", "a/b/junk.txt"],
             id="include_a,exclude_file1",
         ),
-        pytest.param(
+        param(
             "test_files",
             [".*"],
             [],
@@ -73,7 +73,7 @@ from build_helpers.build_helpers import find, matches
             ],
             id="no_junk",
         ),
-        pytest.param(
+        param(
             "test_files",
             ["^.*/junk.txt"],
             [],
@@ -82,8 +82,8 @@ from build_helpers.build_helpers import find, matches
             ["a/b/junk.txt", "c/junk.txt"],
             id="junk_only",
         ),
-        pytest.param("test_files", [], ["^a$"], [], [], ["a"], id="exact_a"),
-        pytest.param(
+        param("test_files", [], ["^a$"], [], [], ["a"], id="exact_a"),
+        param(
             "test_files",
             [],
             [".*bad_dir$"],
@@ -117,7 +117,7 @@ def test_find(
     assert ret_set == expected_set
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "patterns,query,expected",
     [
         (["^a/.*"], "a/", True),

--- a/examples/advanced/hydra_app_example/tests/test_example.py
+++ b/examples/advanced/hydra_app_example/tests/test_example.py
@@ -2,7 +2,7 @@
 import unittest
 from typing import List
 
-import pytest
+from pytest import mark
 
 import hydra_app.main
 from hydra.experimental import compose, initialize, initialize_config_module
@@ -48,7 +48,7 @@ class TestWithUnittest(unittest.TestCase):
 
 # This example drives some user logic with the composed config.
 # In this case it calls hydra_app.main.add(), passing it the composed config.
-@pytest.mark.parametrize(
+@mark.parametrize(
     "overrides, expected",
     [
         (["app.user=test_user"], 30),

--- a/examples/plugins/example_configsource_plugin/tests/test_example_config_source.py
+++ b/examples/plugins/example_configsource_plugin/tests/test_example_config_source.py
@@ -1,15 +1,16 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import pytest
 from hydra.core.plugins import Plugins
 from hydra.plugins.config_source import ConfigSource
 from hydra.test_utils.config_source_common_tests import ConfigSourceTestSuite
+
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from pytest import mark
 
 from hydra_plugins.example_configsource_plugin.example_configsource_plugin import (
     ConfigSourceExample,
 )
 
 
-@pytest.mark.parametrize("type_, path", [(ConfigSourceExample, "example://valid_path")])
+@mark.parametrize("type_, path", [(ConfigSourceExample, "example://valid_path")])
 class TestCoreConfigSources(ConfigSourceTestSuite):
     pass
 

--- a/examples/plugins/example_launcher_plugin/tests/test_example_launcher_plugin.py
+++ b/examples/plugins/example_launcher_plugin/tests/test_example_launcher_plugin.py
@@ -1,11 +1,12 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import pytest
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
 from hydra.test_utils.launcher_common_tests import (
     IntegrationTestSuite,
     LauncherTestSuite,
 )
+
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from pytest import mark
 
 from hydra_plugins.example_launcher_plugin.example_launcher import ExampleLauncher
 
@@ -17,7 +18,7 @@ def test_discovery() -> None:
     ]
 
 
-@pytest.mark.parametrize("launcher_name, overrides", [("example", [])])
+@mark.parametrize("launcher_name, overrides", [("example", [])])
 class TestExampleLauncher(LauncherTestSuite):
     """
     Run the Launcher test suite on this launcher.
@@ -27,7 +28,7 @@ class TestExampleLauncher(LauncherTestSuite):
     pass
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "task_launcher_cfg, extra_flags",
     [({}, ["-m", "hydra/launcher=example"])],
 )

--- a/examples/plugins/example_sweeper_plugin/tests/test_example_sweeper_plugin.py
+++ b/examples/plugins/example_sweeper_plugin/tests/test_example_sweeper_plugin.py
@@ -1,5 +1,3 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import pytest
 from hydra.core.plugins import Plugins
 from hydra.plugins.sweeper import Sweeper
 from hydra.test_utils.launcher_common_tests import (
@@ -8,6 +6,9 @@ from hydra.test_utils.launcher_common_tests import (
     LauncherTestSuite,
 )
 from hydra.test_utils.test_utils import TSweepRunner
+
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from pytest import mark
 
 from hydra_plugins.example_sweeper_plugin.example_sweeper import ExampleSweeper
 
@@ -39,7 +40,7 @@ def test_launched_jobs(hydra_sweep_runner: TSweepRunner) -> None:
 
 
 # Run launcher test suite with the basic launcher and this sweeper
-@pytest.mark.parametrize(
+@mark.parametrize(
     "launcher_name, overrides",
     [
         (
@@ -57,7 +58,7 @@ class TestExampleSweeper(LauncherTestSuite):
 
 # Many sweepers are batching jobs in groups.
 # This test suite verifies that the spawned jobs are not overstepping the directories of one another.
-@pytest.mark.parametrize(
+@mark.parametrize(
     "launcher_name, overrides",
     [
         (
@@ -77,7 +78,7 @@ class TestExampleSweeperWithBatching(BatchedSweeperTestSuite):
 
 
 # Run integration test suite with the basic launcher and this sweeper
-@pytest.mark.parametrize(
+@mark.parametrize(
     "task_launcher_cfg, extra_flags",
     [
         (

--- a/examples/tutorials/basic/your_first_hydra_app/3_using_config/my_app.py
+++ b/examples/tutorials/basic/your_first_hydra_app/3_using_config/my_app.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import pytest
 from omegaconf import DictConfig, MissingMandatoryValue, open_dict
+from pytest import raises
 
 import hydra
 
@@ -14,7 +14,7 @@ def my_app(cfg: DictConfig) -> None:
     assert cfg.node.do == "oompa 10"  # string interpolation
 
     # Accessing a field that is not in the config results in an exception:
-    with pytest.raises(AttributeError):
+    with raises(AttributeError):
         cfg.new_field = 10
 
     # you can enable config field addition in a context with open_dict:
@@ -27,7 +27,7 @@ def my_app(cfg: DictConfig) -> None:
     assert hasattr(cfg, "new_field")  # attribute style
 
     # Accessing a field marked as missing ('???') raises in an exception
-    with pytest.raises(MissingMandatoryValue):
+    with raises(MissingMandatoryValue):
         cfg.node.waldo
 
 

--- a/hydra/extra/pytest_plugin.py
+++ b/hydra/extra/pytest_plugin.py
@@ -3,14 +3,14 @@ import copy
 from pathlib import Path
 from typing import Callable, List, Optional
 
-import pytest
+from pytest import fixture
 
 from hydra.core.singleton import Singleton
 from hydra.test_utils.test_utils import SweepTaskFunction, TaskTestFunction
 from hydra.types import TaskFunction
 
 
-@pytest.fixture(scope="function")  # type: ignore
+@fixture(scope="function")  # type: ignore
 def hydra_restore_singletons() -> None:
     """
     Restore singletons state after the function returns
@@ -20,7 +20,7 @@ def hydra_restore_singletons() -> None:
     Singleton.set_state(state)
 
 
-@pytest.fixture(scope="function")  # type: ignore
+@fixture(scope="function")  # type: ignore
 def hydra_sweep_runner() -> Callable[
     [
         Optional[str],
@@ -61,7 +61,7 @@ def hydra_sweep_runner() -> Callable[
     return _
 
 
-@pytest.fixture(scope="function")  # type: ignore
+@fixture(scope="function")  # type: ignore
 def hydra_task_runner() -> Callable[
     [
         Optional[str],

--- a/hydra/test_utils/config_source_common_tests.py
+++ b/hydra/test_utils/config_source_common_tests.py
@@ -1,8 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from typing import Any, List, Optional, Type
 
-import pytest
-from pytest import mark, param, raises
+from pytest import mark, param, raises, skip
 
 from hydra.core.default_element import InputDefault
 from hydra.core.object_type import ObjectType
@@ -34,19 +33,19 @@ class ConfigSourceTestSuite:
     @mark.parametrize(
         "config_path, expected",
         [
-            pytest.param("", True, id="empty"),
-            pytest.param("dataset", True, id="dataset"),
-            pytest.param("optimizer", True, id="optimizer"),
-            pytest.param(
+            param("", True, id="empty"),
+            param("dataset", True, id="dataset"),
+            param("optimizer", True, id="optimizer"),
+            param(
                 "configs_with_defaults_list",
                 True,
                 id="configs_with_defaults_list",
             ),
-            pytest.param("dataset/imagenet", False, id="dataset/imagenet"),
-            pytest.param("level1", True, id="level1"),
-            pytest.param("level1/level2", True, id="level1/level2"),
-            pytest.param("level1/level2/nested1", False, id="level1/level2/nested1"),
-            pytest.param("not_found", False, id="not_found"),
+            param("dataset/imagenet", False, id="dataset/imagenet"),
+            param("level1", True, id="level1"),
+            param("level1/level2", True, id="level1/level2"),
+            param("level1/level2/nested1", False, id="level1/level2/nested1"),
+            param("not_found", False, id="not_found"),
         ],
     )
     def test_is_group(
@@ -89,7 +88,7 @@ class ConfigSourceTestSuite:
         self, type_: Type[ConfigSource], path: str, config_path: str, expected: bool
     ) -> None:
         if self.skip_overlap_config_path_name():
-            pytest.skip(
+            skip(
                 f"ConfigSourcePlugin {type_.__name__} does not support config objects and config groups "
                 f"with overlapping names."
             )
@@ -151,7 +150,7 @@ class ConfigSourceTestSuite:
         expected: List[str],
     ) -> None:
         if self.skip_overlap_config_path_name():
-            pytest.skip(
+            skip(
                 f"ConfigSourcePlugin {type_.__name__} does not support config objects and config groups "
                 f"with overlapping names."
             )

--- a/hydra/test_utils/launcher_common_tests.py
+++ b/hydra/test_utils/launcher_common_tests.py
@@ -8,8 +8,8 @@ import re
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Set
 
-import pytest
 from omegaconf import DictConfig, OmegaConf
+from pytest import mark, param, raises
 
 from hydra import TaskFunction
 from hydra.errors import HydraException
@@ -20,7 +20,7 @@ from hydra.test_utils.test_utils import (
 )
 
 
-@pytest.mark.usefixtures("hydra_restore_singletons")
+@mark.usefixtures("hydra_restore_singletons")
 class LauncherTestSuite:
     def get_task_function(self) -> Optional[Callable[[Any], Any]]:
         def task_func(_: DictConfig) -> Any:
@@ -63,7 +63,7 @@ class LauncherTestSuite:
         overrides: List[str],
         tmpdir: Path,
     ) -> None:
-        with pytest.raises(
+        with raises(
             HydraException,
             match=re.escape(
                 "Sweeping over Hydra's configuration is not supported : 'hydra.verbose=true,false'"
@@ -108,7 +108,7 @@ class LauncherTestSuite:
     ) -> None:
         # Ideally this would be KeyError, This can't be more specific because some launcher plugins
         # like submitit raises a different exception on job failure and not the underlying exception.
-        with pytest.raises(Exception):
+        with raises(Exception):
             sweep_1_job(
                 hydra_sweep_runner,
                 overrides=["hydra/launcher=" + launcher_name, "boo=bar"] + overrides,
@@ -242,7 +242,7 @@ class LauncherTestSuite:
             assert job_ret[0].return_value == "foo"
 
 
-@pytest.mark.usefixtures("hydra_restore_singletons")
+@mark.usefixtures("hydra_restore_singletons")
 class BatchedSweeperTestSuite:
     def test_sweep_2_jobs_2_batches(
         self,
@@ -427,7 +427,7 @@ def sweep_two_config_groups(
             verify_dir_outputs(job_ret, job_ret.overrides)
 
 
-@pytest.mark.usefixtures("hydra_restore_singletons")
+@mark.usefixtures("hydra_restore_singletons")
 class IntegrationTestSuite:
     def get_test_app_working_dir(self) -> Optional[Path]:
         """
@@ -438,7 +438,7 @@ class IntegrationTestSuite:
 
     def get_test_scratch_dir(self, tmpdir: Path) -> Path:
         """
-        By default test applications will use tmpdir provided by the pytest.
+        By default test applications will use tmpdir provided by the
         This can be customized by applications.
         """
         return tmpdir
@@ -459,25 +459,25 @@ class IntegrationTestSuite:
 
         return fun
 
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         "task_config, overrides, filename, expected_name",
         [
-            pytest.param(None, [], "no_config.py", "no_config", id="no_config"),
-            pytest.param(
+            param(None, [], "no_config.py", "no_config", id="no_config"),
+            param(
                 None,
                 ["hydra.job.name=overridden_name"],
                 "no_config.py",
                 "overridden_name",
                 id="different_filename",
             ),
-            pytest.param(
+            param(
                 {"hydra": {"job": {"name": "name_from_config_file"}}},
                 [],
                 "with_config.py",
                 "name_from_config_file",
                 id="different_filename_and_config_file_name_override",
             ),
-            pytest.param(
+            param(
                 {"hydra": {"job": {"name": "name_from_config_file"}}},
                 ["hydra.job.name=overridden_name"],
                 "with_config.py",
@@ -512,10 +512,10 @@ class IntegrationTestSuite:
             generate_custom_cmd=self.generate_custom_cmd(),
         )
 
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         "task_config, overrides, expected_dir",
         [
-            pytest.param(
+            param(
                 {
                     "hydra": {
                         "sweep": {
@@ -528,7 +528,7 @@ class IntegrationTestSuite:
                 "task_cfg/task_cfg_0",
                 id="sweep_dir_config_override",
             ),
-            pytest.param(
+            param(
                 {},
                 [
                     "hydra.sweep.dir=cli_dir",
@@ -537,7 +537,7 @@ class IntegrationTestSuite:
                 "cli_dir/cli_dir_0",
                 id="sweep_dir_cli_override",
             ),
-            pytest.param(
+            param(
                 {
                     "hydra": {
                         "sweep": {
@@ -553,7 +553,7 @@ class IntegrationTestSuite:
                 "cli_dir/cli_dir_0",
                 id="sweep_dir_cli_overridding_config",
             ),
-            pytest.param(
+            param(
                 {
                     "hydra": {
                         "sweep": {
@@ -568,7 +568,7 @@ class IntegrationTestSuite:
                 "hydra_cfg/a=1,b=2",
                 id="subdir:override_dirname",
             ),
-            pytest.param(
+            param(
                 # Test override_dirname integration
                 {
                     "hydra": {

--- a/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
+++ b/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
@@ -4,7 +4,6 @@ import os
 from pathlib import Path
 from typing import Any, List
 
-import pytest
 from hydra.core.plugins import Plugins
 from hydra.plugins.sweeper import Sweeper
 from hydra.test_utils.test_utils import (
@@ -13,6 +12,7 @@ from hydra.test_utils.test_utils import (
     run_python_script,
 )
 from omegaconf import DictConfig, OmegaConf
+from pytest import mark, raises
 
 from hydra_plugins.hydra_ax_sweeper.ax_sweeper import AxSweeper  # type: ignore
 
@@ -33,7 +33,7 @@ def quadratic(cfg: DictConfig) -> Any:
     return 100 * (cfg.quadratic.x ** 2) + 1 * cfg.quadratic.y
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "n,expected",
     [
         (None, [[1, 2, 3, 4, 5]]),
@@ -52,13 +52,13 @@ def test_chunk_method_for_valid_inputs(n: int, expected: List[List[int]]) -> Non
     assert out == expected
 
 
-@pytest.mark.parametrize("n", [-1, -11, 0])
+@mark.parametrize("n", [-1, -11, 0])
 def test_chunk_method_for_invalid_inputs(n: int) -> None:
     from hydra_plugins.hydra_ax_sweeper._core import CoreAxSweeper
 
     chunk_func = CoreAxSweeper.chunks
     batch = [1, 2, 3, 4, 5]
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         list(chunk_func(batch, n))
 
 
@@ -184,7 +184,7 @@ def test_configuration_set_via_cmd_and_default_config(
         assert "quadratic.y" in best_parameters
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cmd_arg, expected_str",
     [
         ("polynomial.y=choice(-1, 0, 1)", "polynomial.y: choice=[-1, 0, 1]"),
@@ -215,7 +215,7 @@ def test_ax_logging(tmpdir: Path, cmd_arg: str, expected_str: str) -> None:
     assert "polynomial.z: fixed=10" in result
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cmd_args",
     [
         ["polynomial.y=choice(-1, 0, 1)", "polynomial.x=range(2,4)"],
@@ -232,7 +232,7 @@ def test_search_space_exhausted_exception(tmpdir: Path, cmd_args: List[str]) -> 
     run_python_script(cmd, allow_warnings=True)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cmd_arg, serialized_encoding, best_coefficients, best_value",
     [
         (
@@ -268,7 +268,7 @@ def test_jobs_using_choice_between_lists(
     assert f"New best value: {best_value}" in result
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cmd_arg, serialized_encoding, best_coefficients, best_value",
     [
         (

--- a/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
+++ b/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
@@ -1,7 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from typing import Any
 
-import pytest
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
 from hydra.test_utils.launcher_common_tests import (
@@ -9,6 +8,7 @@ from hydra.test_utils.launcher_common_tests import (
     LauncherTestSuite,
 )
 from hydra.test_utils.test_utils import TSweepRunner, chdir_plugin_root
+from pytest import mark
 
 from hydra_plugins.hydra_joblib_launcher.joblib_launcher import JoblibLauncher
 
@@ -22,7 +22,7 @@ def test_discovery() -> None:
     ]
 
 
-@pytest.mark.parametrize("launcher_name, overrides", [("joblib", [])])
+@mark.parametrize("launcher_name, overrides", [("joblib", [])])
 class TestJoblibLauncher(LauncherTestSuite):
     """
     Run the Launcher test suite on this launcher.
@@ -31,7 +31,7 @@ class TestJoblibLauncher(LauncherTestSuite):
     pass
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "task_launcher_cfg, extra_flags",
     [
         # joblib with process-based backend (default)
@@ -70,7 +70,7 @@ def test_example_app(hydra_sweep_runner: TSweepRunner, tmpdir: Any) -> None:
             assert tuple(ret.overrides) in overrides
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "overrides",
     [
         "hydra.launcher.batch_size=1",

--- a/plugins/hydra_nevergrad_sweeper/tests/test_nevergrad_sweeper_plugin.py
+++ b/plugins/hydra_nevergrad_sweeper/tests/test_nevergrad_sweeper_plugin.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Any
 
 import nevergrad as ng
-import pytest
 from hydra.core.override_parser.overrides_parser import OverridesParser
 from hydra.core.plugins import Plugins
 from hydra.plugins.sweeper import Sweeper
@@ -13,6 +12,7 @@ from hydra.test_utils.test_utils import (
     run_python_script,
 )
 from omegaconf import DictConfig, OmegaConf
+from pytest import mark
 
 from hydra_plugins.hydra_nevergrad_sweeper import _impl
 from hydra_plugins.hydra_nevergrad_sweeper.nevergrad_sweeper import NevergradSweeper
@@ -44,7 +44,7 @@ def get_scalar_with_integer_bounds(lower: int, upper: int, type: Any) -> ng.p.Sc
     return scalar
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input, expected",
     [
         ([1, 2, 3], ng.p.Choice([1, 2, 3])),
@@ -69,7 +69,7 @@ def test_create_nevergrad_parameter_from_config(
     assert_ng_param_equals(expected, actual)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input, expected",
     [
         ("key=choice(1,2)", ng.p.Choice([1, 2])),
@@ -125,7 +125,7 @@ def test_launched_jobs(hydra_sweep_runner: TSweepRunner) -> None:
         assert sweep.returns is None
 
 
-@pytest.mark.parametrize("with_commandline", (True, False))
+@mark.parametrize("with_commandline", (True, False))
 def test_nevergrad_example(with_commandline: bool, tmpdir: Path) -> None:
     budget = 32 if with_commandline else 1  # make a full test only once (faster)
     cmd = [

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -2,7 +2,6 @@
 from pathlib import Path
 from typing import Any, List
 
-import pytest
 from hydra.core.override_parser.overrides_parser import OverridesParser
 from hydra.core.plugins import Plugins
 from hydra.plugins.sweeper import Sweeper
@@ -21,6 +20,7 @@ from optuna.distributions import (
     LogUniformDistribution,
     UniformDistribution,
 )
+from pytest import mark
 
 from hydra_plugins.hydra_optuna_sweeper import _impl
 from hydra_plugins.hydra_optuna_sweeper.optuna_sweeper import OptunaSweeper
@@ -29,7 +29,7 @@ chdir_plugin_root()
 
 
 # https://github.com/pyreadline/pyreadline/issues/65
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@mark.filterwarnings("ignore::DeprecationWarning")
 def test_discovery() -> None:
     assert OptunaSweeper.__name__ in [
         x.__name__ for x in Plugins.instance().discover(Sweeper)
@@ -47,8 +47,8 @@ def check_distribution(expected: BaseDistribution, actual: BaseDistribution) -> 
 
 
 # https://github.com/pyreadline/pyreadline/issues/65
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-@pytest.mark.parametrize(
+@mark.filterwarnings("ignore::DeprecationWarning")
+@mark.parametrize(
     "input, expected",
     [
         (
@@ -82,8 +82,8 @@ def test_create_optuna_distribution_from_config(input: Any, expected: Any) -> No
 
 
 # https://github.com/pyreadline/pyreadline/issues/65
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-@pytest.mark.parametrize(
+@mark.filterwarnings("ignore::DeprecationWarning")
+@mark.parametrize(
     "input, expected",
     [
         ("key=choice(1,2)", CategoricalDistribution([1, 2])),
@@ -105,7 +105,7 @@ def test_create_optuna_distribution_from_override(input: Any, expected: Any) -> 
 
 
 # https://github.com/pyreadline/pyreadline/issues/65
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@mark.filterwarnings("ignore::DeprecationWarning")
 def test_launch_jobs(hydra_sweep_runner: TSweepRunner) -> None:
     sweep = hydra_sweep_runner(
         calling_file=None,
@@ -125,8 +125,8 @@ def test_launch_jobs(hydra_sweep_runner: TSweepRunner) -> None:
 
 
 # https://github.com/pyreadline/pyreadline/issues/65
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-@pytest.mark.parametrize("with_commandline", (True, False))
+@mark.filterwarnings("ignore::DeprecationWarning")
+@mark.parametrize("with_commandline", (True, False))
 def test_optuna_example(with_commandline: bool, tmpdir: Path) -> None:
     cmd = [
         "example/sphere.py",
@@ -155,8 +155,8 @@ def test_optuna_example(with_commandline: bool, tmpdir: Path) -> None:
 
 
 # https://github.com/pyreadline/pyreadline/issues/65
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-@pytest.mark.parametrize("with_commandline", (True, False))
+@mark.filterwarnings("ignore::DeprecationWarning")
+@mark.parametrize("with_commandline", (True, False))
 def test_optuna_multi_objective_example(with_commandline: bool, tmpdir: Path) -> None:
     cmd = [
         "example/multi-objective.py",

--- a/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
@@ -11,7 +11,6 @@ from typing import Generator, Optional
 
 import boto3  # type: ignore
 import pkg_resources
-import pytest
 from botocore.exceptions import NoCredentialsError, NoRegionError  # type: ignore
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
@@ -21,6 +20,7 @@ from hydra.test_utils.launcher_common_tests import (
 )
 from hydra.test_utils.test_utils import chdir_hydra_root, chdir_plugin_root
 from omegaconf import OmegaConf
+from pytest import fixture, mark
 
 from hydra_plugins.hydra_ray_launcher._launcher_util import (  # type: ignore
     _run_command,
@@ -198,7 +198,7 @@ def validate_lib_version(yaml: str) -> None:
     ), f"Python version mismatch, local={local_python}, remote={remote_python}"
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason=win_msg)
+@mark.skipif(sys.platform.startswith("win"), reason=win_msg)
 def test_discovery() -> None:
     # Tests that this plugin can be discovered via the plugins subsystem when
     # looking for Launchers
@@ -207,7 +207,7 @@ def test_discovery() -> None:
     ]
 
 
-@pytest.fixture(scope="module")
+@fixture(scope="module")
 def manage_cluster() -> Generator[None, None, None]:
     # first assert the SHA of requirements hasn't changed
     # if changed, means we need to update test AMI.
@@ -253,10 +253,10 @@ launcher_test_suites_overrides = [
 launcher_test_suites_overrides.extend(common_overrides)
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason=win_msg)
-@pytest.mark.skipif(aws_not_configured, reason=aws_not_configured_msg)
-@pytest.mark.usefixtures("manage_cluster")
-@pytest.mark.parametrize(
+@mark.skipif(sys.platform.startswith("win"), reason=win_msg)
+@mark.skipif(aws_not_configured, reason=aws_not_configured_msg)
+@mark.usefixtures("manage_cluster")
+@mark.parametrize(
     "launcher_name, overrides, tmpdir",
     [
         (
@@ -279,10 +279,10 @@ integration_tests_override = [
 integration_tests_override.extend(common_overrides)
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason=win_msg)
-@pytest.mark.skipif(aws_not_configured, reason=aws_not_configured_msg)
-@pytest.mark.usefixtures("manage_cluster")
-@pytest.mark.parametrize(
+@mark.skipif(sys.platform.startswith("win"), reason=win_msg)
+@mark.skipif(aws_not_configured, reason=aws_not_configured_msg)
+@mark.usefixtures("manage_cluster")
+@mark.parametrize(
     "tmpdir,task_launcher_cfg,extra_flags",
     [
         (

--- a/plugins/hydra_ray_launcher/tests/test_ray_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_launcher.py
@@ -1,7 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import sys
 
-import pytest
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
 from hydra.test_utils.launcher_common_tests import (
@@ -9,6 +8,7 @@ from hydra.test_utils.launcher_common_tests import (
     LauncherTestSuite,
 )
 from hydra.test_utils.test_utils import chdir_plugin_root
+from pytest import mark
 
 from hydra_plugins.hydra_ray_launcher.ray_launcher import RayLauncher  # type: ignore
 
@@ -17,7 +17,7 @@ chdir_plugin_root()
 win_msg = "Ray doesn't support Windows."
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason=win_msg)
+@mark.skipif(sys.platform.startswith("win"), reason=win_msg)
 def test_discovery() -> None:
     # Tests that this plugin can be discovered via the plugins subsystem when looking for Launchers
     assert RayLauncher.__name__ in [
@@ -25,8 +25,8 @@ def test_discovery() -> None:
     ]
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason=win_msg)
-@pytest.mark.parametrize("launcher_name, overrides", [("ray", [])])
+@mark.skipif(sys.platform.startswith("win"), reason=win_msg)
+@mark.parametrize("launcher_name, overrides", [("ray", [])])
 class TestRayLauncher(LauncherTestSuite):
     """
     Run the Launcher test suite on this launcher.
@@ -35,8 +35,8 @@ class TestRayLauncher(LauncherTestSuite):
     pass
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason=win_msg)
-@pytest.mark.parametrize(
+@mark.skipif(sys.platform.startswith("win"), reason=win_msg)
+@mark.parametrize(
     "task_launcher_cfg, extra_flags",
     [
         (

--- a/plugins/hydra_rq_launcher/tests/conftest.py
+++ b/plugins/hydra_rq_launcher/tests/conftest.py
@@ -1,10 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from typing import Any
 
-import pytest
+from pytest import fixture
 
 
-@pytest.fixture(autouse=True)
+@fixture(autouse=True)
 def env_setup(monkeypatch: Any) -> None:
     # Tests use fake redis server by setting REDIS_MOCK to True
     monkeypatch.setenv("REDIS_MOCK", "True")

--- a/plugins/hydra_rq_launcher/tests/test_rq_launcher.py
+++ b/plugins/hydra_rq_launcher/tests/test_rq_launcher.py
@@ -1,5 +1,3 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import pytest
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
 from hydra.test_utils.launcher_common_tests import (
@@ -7,6 +5,9 @@ from hydra.test_utils.launcher_common_tests import (
     LauncherTestSuite,
 )
 from hydra.test_utils.test_utils import TSweepRunner, chdir_plugin_root
+
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from pytest import mark
 
 from hydra_plugins.hydra_rq_launcher.rq_launcher import RQLauncher
 
@@ -21,8 +22,8 @@ def test_discovery() -> None:
 
 
 # https://github.com/rq/rq/issues/1244
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-@pytest.mark.parametrize("launcher_name, overrides", [("rq", [])])
+@mark.filterwarnings("ignore::DeprecationWarning")
+@mark.parametrize("launcher_name, overrides", [("rq", [])])
 class TestRQLauncher(LauncherTestSuite):
     """
     Run the Launcher test suite on this launcher.
@@ -32,8 +33,8 @@ class TestRQLauncher(LauncherTestSuite):
 
 
 # https://github.com/rq/rq/issues/1244
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-@pytest.mark.parametrize(
+@mark.filterwarnings("ignore::DeprecationWarning")
+@mark.parametrize(
     "task_launcher_cfg, extra_flags",
     [({}, ["-m", "hydra/launcher=rq"])],
 )
@@ -46,7 +47,7 @@ class TestRQLauncherIntegration(IntegrationTestSuite):
 
 
 # https://github.com/rq/rq/issues/1244
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@mark.filterwarnings("ignore::DeprecationWarning")
 def test_example_app(hydra_sweep_runner: TSweepRunner) -> None:
     with hydra_sweep_runner(
         calling_file="example/my_app.py",

--- a/plugins/hydra_submitit_launcher/tests/test_submitit_launcher.py
+++ b/plugins/hydra_submitit_launcher/tests/test_submitit_launcher.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 from typing import Type
 
-import pytest
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
 from hydra.test_utils.launcher_common_tests import (
@@ -12,13 +11,14 @@ from hydra.test_utils.launcher_common_tests import (
     LauncherTestSuite,
 )
 from hydra.test_utils.test_utils import chdir_plugin_root
+from pytest import mark
 
 from hydra_plugins.hydra_submitit_launcher import submitit_launcher
 
 chdir_plugin_root()
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cls", [submitit_launcher.LocalLauncher, submitit_launcher.SlurmLauncher]
 )
 def test_discovery(cls: Type[Launcher]) -> None:
@@ -26,14 +26,14 @@ def test_discovery(cls: Type[Launcher]) -> None:
     assert cls.__name__ in [x.__name__ for x in Plugins.instance().discover(Launcher)]
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "launcher_name, overrides", [("submitit_local", ["hydra.launcher.timeout_min=2"])]
 )
 class TestSubmititLauncher(LauncherTestSuite):
     pass
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "task_launcher_cfg, extra_flags",
     [
         (

--- a/tests/standalone_apps/initialization_test_app/tests/test_app.py
+++ b/tests/standalone_apps/initialization_test_app/tests/test_app.py
@@ -3,11 +3,10 @@ import subprocess
 import sys
 from typing import List
 
-import pytest
-from pytest import param
+from pytest import mark, param
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "run_cmd",
     [
         param(["initialization-test-app", "module_installed"], id="run_as_app"),

--- a/tests/standalone_apps/namespace_pkg_config_source_test/namespace_test/test_namespace.py
+++ b/tests/standalone_apps/namespace_pkg_config_source_test/namespace_test/test_namespace.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import pytest
+from pytest import mark, param
 
 from hydra._internal.core_plugins.importlib_resources_config_source import (
     ImportlibResourcesConfigSource,
@@ -12,10 +12,10 @@ from hydra.test_utils.test_utils import chdir_plugin_root
 chdir_plugin_root()
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "type_, path",
     [
-        pytest.param(
+        param(
             ImportlibResourcesConfigSource,
             "pkg://some_namespace.namespace_test.dir",
             id="pkg_in_namespace",

--- a/tests/test_basic_launcher.py
+++ b/tests/test_basic_launcher.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import pytest
+from pytest import mark, param
 
 from hydra.test_utils.launcher_common_tests import (
     BatchedSweeperTestSuite,
@@ -8,15 +8,15 @@ from hydra.test_utils.launcher_common_tests import (
 )
 
 
-@pytest.mark.parametrize("launcher_name, overrides", [("basic", [])])
+@mark.parametrize("launcher_name, overrides", [("basic", [])])
 class TestBasicLauncher(LauncherTestSuite):
     pass
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "task_launcher_cfg, extra_flags",
     [
-        pytest.param(
+        param(
             {},
             [
                 "-m",
@@ -36,7 +36,7 @@ class TestBasicLauncherIntegration(IntegrationTestSuite):
     pass
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "launcher_name, overrides",
     [
         (

--- a/tests/test_basic_sweeper.py
+++ b/tests/test_basic_sweeper.py
@@ -1,31 +1,31 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from typing import List, Optional
 
-import pytest
+from pytest import mark, param
 
 from hydra._internal.core_plugins.basic_sweeper import BasicSweeper
 from hydra.core.override_parser.overrides_parser import OverridesParser
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "args,max_batch_size,expected",
     [
-        pytest.param(["x=10"], None, [[["x=10"]]], id="simple"),
-        pytest.param(["x=10,20"], None, [[["x=10"], ["x=20"]]], id="split_1d"),
-        pytest.param(["x=[10,20]"], None, [[["x=[10,20]"]]], id="not_split_yaml_list"),
-        pytest.param(
+        param(["x=10"], None, [[["x=10"]]], id="simple"),
+        param(["x=10,20"], None, [[["x=10"], ["x=20"]]], id="split_1d"),
+        param(["x=[10,20]"], None, [[["x=[10,20]"]]], id="not_split_yaml_list"),
+        param(
             ["x=[a,b,c],[d,e,f]"],
             None,
             [[["x=[a,b,c]"], ["x=[d,e,f]"]]],
             id="list_of_lists",
         ),
-        pytest.param(
+        param(
             ["a=1,2", "b=10,11"],
             None,
             [[["a=1", "b=10"], ["a=1", "b=11"], ["a=2", "b=10"], ["a=2", "b=11"]]],
             id="no_batching",
         ),
-        pytest.param(
+        param(
             ["a=1,2", "b=10,11"],
             1,
             [
@@ -36,13 +36,13 @@ from hydra.core.override_parser.overrides_parser import OverridesParser
             ],
             id="batches_of_1",
         ),
-        pytest.param(
+        param(
             ["a=1,2", "b=10,11"],
             2,
             [[["a=1", "b=10"], ["a=1", "b=11"]], [["a=2", "b=10"], ["a=2", "b=11"]]],
             id="batches_of_2",
         ),
-        pytest.param(["a=range(0,3)"], None, [[["a=0"], ["a=1"], ["a=2"]]], id="range"),
+        param(["a=range(0,3)"], None, [[["a=0"], ["a=1"], ["a=2"]]], id="range"),
     ],
 )
 def test_split(

--- a/tests/test_config_repository.py
+++ b/tests/test_config_repository.py
@@ -3,7 +3,7 @@ import copy
 import re
 from typing import Any, List
 
-import pytest
+from pytest import mark, param, raises
 
 from hydra._internal.config_repository import ConfigRepository
 from hydra._internal.config_search_path_impl import ConfigSearchPathImpl
@@ -27,20 +27,20 @@ chdir_hydra_root()
 state = copy.deepcopy(Singleton.get_state())
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "type_, path",
     [
-        pytest.param(
+        param(
             FileConfigSource,
             "file://tests/test_apps/config_source_test/dir",
             id="FileConfigSource",
         ),
-        pytest.param(
+        param(
             ImportlibResourcesConfigSource,
             "pkg://tests.test_apps.config_source_test.dir",
             id="ImportlibResourcesConfigSource",
         ),
-        pytest.param(
+        param(
             StructuredConfigSource,
             "structured://tests.test_apps.config_source_test.structured",
             id="StructuredConfigSource",
@@ -57,7 +57,7 @@ def create_config_search_path(path: str) -> ConfigSearchPathImpl:
     return csp
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "path",
     [
         "file://tests/test_apps/config_source_test/dir",
@@ -85,30 +85,30 @@ class TestConfigRepository:
         assert repo.config_exists("dataset/imagenet.yaml")
         assert not repo.config_exists("not_found.yaml")
 
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         "config_path,expected",
         [
-            pytest.param(
+            param(
                 "primary_config",
                 [],
                 id="no_defaults",
             ),
-            pytest.param(
+            param(
                 "config_with_defaults_list",
                 [GroupDefault(group="dataset", value="imagenet")],
                 id="defaults_in_root",
             ),
-            pytest.param(
+            param(
                 "configs_with_defaults_list/global_package",
                 [GroupDefault(group="foo", value="bar")],
                 id="configs_with_defaults_list/global_package",
             ),
-            pytest.param(
+            param(
                 "configs_with_defaults_list/group_package",
                 [GroupDefault(group="foo", value="bar")],
                 id="configs_with_defaults_list/group_package",
             ),
-            pytest.param(
+            param(
                 "configs_with_defaults_list/no_package",
                 [GroupDefault(group="foo", value="bar")],
                 id="configs_with_defaults_list/no_package",
@@ -130,8 +130,8 @@ class TestConfigRepository:
         assert ret.defaults_list == expected
 
 
-@pytest.mark.parametrize("sep", [" "])
-@pytest.mark.parametrize(
+@mark.parametrize("sep", [" "])
+@mark.parametrize(
     "cfg_text, expected",
     [
         ("# @package{sep}foo.bar", {"package": "foo.bar"}),
@@ -141,11 +141,11 @@ class TestConfigRepository:
         ("#@package{sep}foo.bar ", {"package": "foo.bar"}),
         (
             "#@package{sep}foo.bar bah",
-            pytest.raises(ValueError, match=re.escape("Too many components in")),
+            raises(ValueError, match=re.escape("Too many components in")),
         ),
         (
             "#@package",
-            pytest.raises(
+            raises(
                 ValueError, match=re.escape("Expected header format: KEY VALUE, got")
             ),
         ),

--- a/tests/test_config_search_path.py
+++ b/tests/test_config_search_path.py
@@ -3,7 +3,7 @@ import os
 from os.path import realpath
 from typing import List, Optional, Tuple
 
-import pytest
+from pytest import mark
 
 from hydra._internal.config_search_path_impl import ConfigSearchPathImpl
 from hydra._internal.utils import compute_search_path_dir
@@ -22,7 +22,7 @@ def to_tuples_list(
     return [(x.provider, x.path) for x in search_path.config_search_path]
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_list, reference, expected_idx",
     [
         ([], ("", ""), -1),
@@ -41,7 +41,7 @@ def test_find_last_match(
     )
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_list, reference, expected_idx",
     [
         ([], ("", ""), -1),
@@ -59,7 +59,7 @@ def test_find_first_match(
     assert csp.find_first_match(sp) == expected_idx
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "base_list, provider, path, anchor_provider, result_list",
     [
         # appending to an empty list
@@ -104,7 +104,7 @@ def test_append(
     assert to_tuples_list(csp) == result_list
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "base_list, provider, path, anchor_provider, result_list",
     [
         # prepending to an empty list
@@ -149,7 +149,7 @@ def test_prepend(
     assert to_tuples_list(csp) == result_list
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module, config_path, expected",
     [
         ("foo.py", None, None, realpath("")),

--- a/tests/test_examples/test_instantiate_examples.py
+++ b/tests/test_examples/test_instantiate_examples.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any, List
 
-import pytest
+from pytest import mark
 
 from hydra.test_utils.test_utils import (
     assert_text_same,
@@ -14,7 +14,7 @@ from hydra.test_utils.test_utils import (
 chdir_hydra_root()
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "overrides,output",
     [
         ([], "MySQL connecting to localhost"),
@@ -30,7 +30,7 @@ def test_instantiate_object(
     assert result == output
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "overrides,output",
     [
         ([], "Driver : James Bond, 4 wheels"),
@@ -49,7 +49,7 @@ def test_instantiate_object_recursive(
     assert result == output
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "overrides,output",
     [
         ([], "MySQL connecting to localhost"),
@@ -65,7 +65,7 @@ def test_instantiate_schema(
     assert result == output
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "overrides,expected",
     [
         (
@@ -91,7 +91,7 @@ def test_instantiate_schema_recursive(
     assert_text_same(result, expected)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "overrides,expected",
     [
         (

--- a/tests/test_examples/test_structured_configs_tutorial.py
+++ b/tests/test_examples/test_structured_configs_tutorial.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any
 
-import pytest
 from omegaconf import OmegaConf
+from pytest import mark
 
 from hydra.test_utils.test_utils import (
     chdir_hydra_root,
@@ -81,7 +81,7 @@ def test_2_static_complex(tmpdir: Path) -> None:
     assert result == "Title=My app, size=1024x768 pixels"
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "overrides,expected",
     [
         ([], {"db": "???"}),
@@ -102,7 +102,7 @@ def test_3_config_groups(tmpdir: Path, overrides: Any, expected: Any) -> None:
     assert res == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "overrides,expected",
     [
         ([], {"db": "???"}),
@@ -152,7 +152,7 @@ def test_4_defaults(tmpdir: Path) -> None:
     }
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "path",
     [
         "examples/tutorials/structured_configs/5.1_structured_config_schema_same_config_group/my_app.py",

--- a/tests/test_examples/test_tutorials_basic.py
+++ b/tests/test_examples/test_tutorials_basic.py
@@ -4,9 +4,9 @@ import subprocess
 from pathlib import Path
 from typing import Any, List
 
-import pytest
 from _pytest.python_api import RaisesContext
 from omegaconf import DictConfig, OmegaConf
+from pytest import mark, raises
 
 from hydra.test_utils.test_utils import (
     TSweepRunner,
@@ -19,7 +19,7 @@ from hydra.test_utils.test_utils import (
 chdir_hydra_root()
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "args,output_conf",
     [
         ([], OmegaConf.create()),
@@ -52,7 +52,7 @@ def test_tutorial_working_directory(tmpdir: Path) -> None:
     assert result == "Working directory : {}".format(tmpdir)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "args,expected",
     [
         ([], ["Info level message"]),
@@ -72,7 +72,7 @@ def test_tutorial_logging(tmpdir: Path, args: List[str], expected: List[str]) ->
         assert re.findall(re.escape(expected[i]), lines[i])
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "args,output_conf",
     [
         (
@@ -93,7 +93,7 @@ def test_tutorial_config_file(tmpdir: Path, args: List[str], output_conf: Any) -
     assert OmegaConf.create(result) == output_conf
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "args,expected",
     [
         (
@@ -102,7 +102,7 @@ def test_tutorial_config_file(tmpdir: Path, args: List[str], output_conf: Any) -
                 {"db": {"driver": "mysql", "user": "omry", "password": "secret"}}
             ),
         ),
-        (["dataset.path=abc"], pytest.raises(subprocess.CalledProcessError)),
+        (["dataset.path=abc"], raises(subprocess.CalledProcessError)),
     ],
 )
 def test_tutorial_config_file_bad_key(
@@ -123,7 +123,7 @@ def test_tutorial_config_file_bad_key(
         assert OmegaConf.create(stdout) == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "args,output_conf",
     [
         ([], OmegaConf.create()),
@@ -154,7 +154,7 @@ def test_tutorial_config_groups(
     assert OmegaConf.create(result) == output_conf
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "args,expected",
     [
         ([], {"db": {"driver": "mysql", "pass": "secret", "user": "omry"}}),
@@ -251,7 +251,7 @@ def test_sweeping_example(
             assert tuple(ret.overrides) in overrides
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "args,expected",
     [
         (

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any, List, Optional, Set
 
-import pytest
 from omegaconf import DictConfig, OmegaConf
+from pytest import mark, param, raises
 
 from hydra import MissingConfigException
 from hydra.test_utils.test_utils import (
@@ -28,14 +28,14 @@ from hydra.test_utils.test_utils import (
 chdir_hydra_root()
 
 
-@pytest.mark.parametrize("calling_file, calling_module", [(".", None), (None, ".")])
+@mark.parametrize("calling_file, calling_module", [(".", None), (None, ".")])
 def test_missing_conf_dir(
     hydra_restore_singletons: Any,
     hydra_task_runner: TTaskRunner,
     calling_file: str,
     calling_module: str,
 ) -> None:
-    with pytest.raises(MissingConfigException):
+    with raises(MissingConfigException):
         with hydra_task_runner(
             calling_file=calling_file,
             calling_module=calling_module,
@@ -45,7 +45,7 @@ def test_missing_conf_dir(
             pass
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
         ("tests/test_apps/app_without_config/my_app.py", None),
@@ -58,7 +58,7 @@ def test_missing_conf_file(
     calling_file: str,
     calling_module: str,
 ) -> None:
-    with pytest.raises(MissingConfigException):
+    with raises(MissingConfigException):
         with hydra_task_runner(
             calling_file=calling_file,
             calling_module=calling_module,
@@ -72,7 +72,7 @@ def test_run_dir() -> None:
     run_python_script(["tests/test_apps/run_dir_test/my_app.py"])
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
         ("tests/test_apps/app_without_config/my_app.py", None),
@@ -95,7 +95,7 @@ def test_app_without_config___no_overrides(
         assert task.job_ret.cfg == {}
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
         ("tests/test_apps/hydra_main_rerun/my_app.py", None),
@@ -118,7 +118,7 @@ def test_hydra_main_rerun(
         assert task.job_ret.cfg == {}
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
         ("tests/test_apps/app_without_config/my_app.py", None),
@@ -145,7 +145,7 @@ def test_app_without_config__with_append(
         verify_dir_outputs(task.job_ret, task.overrides)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
         ("tests/test_apps/app_with_cfg/my_app.py", None),
@@ -173,7 +173,7 @@ def test_app_with_config_file__no_overrides(
         verify_dir_outputs(task.job_ret)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
         ("tests/test_apps/app_with_cfg_groups/my_app.py", None),
@@ -193,7 +193,7 @@ def test_app_with_config_path_backward_compatibility(
     """
     )
 
-    with pytest.raises(ValueError, match=re.escape(msg)):
+    with raises(ValueError, match=re.escape(msg)):
         task = hydra_task_runner(
             calling_file=calling_file,
             calling_module=calling_module,
@@ -209,7 +209,7 @@ def test_app_with_config_path_backward_compatibility(
             verify_dir_outputs(task.job_ret)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
         ("tests/test_apps/app_with_cfg/my_app.py", None),
@@ -236,7 +236,7 @@ def test_app_with_config_file__with_overide(
         verify_dir_outputs(task.job_ret, task.overrides)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
         ("tests/test_apps/app_with_split_cfg/my_app.py", None),
@@ -263,7 +263,7 @@ def test_app_with_split_config(
         verify_dir_outputs(task.job_ret)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
         ("tests/test_apps/app_with_cfg_groups/my_app.py", None),
@@ -276,7 +276,7 @@ def test_app_with_config_groups__override_dataset__wrong(
     calling_file: str,
     calling_module: str,
 ) -> None:
-    with pytest.raises(MissingConfigException) as ex:
+    with raises(MissingConfigException) as ex:
         with hydra_task_runner(
             calling_file=calling_file,
             calling_module=calling_module,
@@ -288,7 +288,7 @@ def test_app_with_config_groups__override_dataset__wrong(
     assert sorted(ex.value.options) == sorted(["adam", "nesterov"])  # type: ignore
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
         ("tests/test_apps/app_with_cfg_groups/my_app.py", None),
@@ -315,7 +315,7 @@ def test_app_with_config_groups__override_all_configs(
         verify_dir_outputs(task.job_ret, overrides=task.overrides)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
         ("tests/test_apps/app_with_custom_launcher/my_app.py", None),
@@ -368,7 +368,7 @@ def test_hydra_main_module_override_name(tmpdir: Path) -> None:
     )
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "env_name", ["HYDRA_MAIN_MODULE", "FB_PAR_MAIN_MODULE", "FB_XAR_MAIN_MODULE"]
 )
 def test_module_env_override(tmpdir: Path, env_name: str) -> None:
@@ -385,7 +385,7 @@ def test_module_env_override(tmpdir: Path, env_name: str) -> None:
     assert OmegaConf.create(result) == {"normal_yaml_config": True}
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "flag,expected_keys",
     [("--cfg=all", ["db", "hydra"]), ("--cfg=hydra", ["hydra"]), ("--cfg=job", ["db"])],
 )
@@ -401,10 +401,10 @@ def test_cfg(tmpdir: Path, flag: str, expected_keys: List[str]) -> None:
         assert key in conf
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "flags,expected",
     [
-        pytest.param(
+        param(
             ["--cfg=job"],
             dedent(
                 """\
@@ -416,7 +416,7 @@ def test_cfg(tmpdir: Path, flag: str, expected_keys: List[str]) -> None:
             ),
             id="no-package",
         ),
-        pytest.param(
+        param(
             ["--cfg=job", "--package=_global_"],
             dedent(
                 """\
@@ -428,7 +428,7 @@ def test_cfg(tmpdir: Path, flag: str, expected_keys: List[str]) -> None:
             ),
             id="package=_global_",
         ),
-        pytest.param(
+        param(
             ["--cfg=job", "--package=db"],
             dedent(
                 """\
@@ -440,9 +440,7 @@ def test_cfg(tmpdir: Path, flag: str, expected_keys: List[str]) -> None:
             ),
             id="package=db",
         ),
-        pytest.param(
-            ["--cfg=job", "--package=db.driver"], "mysql\n", id="package=db.driver"
-        ),
+        param(["--cfg=job", "--package=db.driver"], "mysql\n", id="package=db.driver"),
     ],
 )
 def test_cfg_with_package(tmpdir: Path, flags: List[str], expected: str) -> None:
@@ -455,14 +453,14 @@ def test_cfg_with_package(tmpdir: Path, flags: List[str], expected: str) -> None
     assert normalize_newlines(result) == expected.rstrip()
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
         ("tests/test_apps/app_with_config_with_free_group/my_app.py", None),
         (None, "tests.test_apps.app_with_config_with_free_group.my_app"),
     ],
 )
-@pytest.mark.parametrize("overrides", [["+free_group=opt1,opt2"]])
+@mark.parametrize("overrides", [["+free_group=opt1,opt2"]])
 def test_multirun_with_free_override(
     hydra_restore_singletons: Any,
     hydra_sweep_runner: TSweepRunner,
@@ -486,15 +484,11 @@ def test_multirun_with_free_override(
         assert sweep.returns[0][1].cfg == {"group_opt1": True, "free_group_opt2": True}
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
-        pytest.param(
-            "tests/test_apps/sweep_complex_defaults/my_app.py", None, id="file_path"
-        ),
-        pytest.param(
-            None, "tests.test_apps.sweep_complex_defaults.my_app", id="pkg_path"
-        ),
+        param("tests/test_apps/sweep_complex_defaults/my_app.py", None, id="file_path"),
+        param(None, "tests.test_apps.sweep_complex_defaults.my_app", id="pkg_path"),
     ],
 )
 def test_sweep_complex_defaults(
@@ -516,24 +510,24 @@ def test_sweep_complex_defaults(
         assert sweep.returns[0][1].overrides == ["optimizer=nesterov"]
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "script, flag, overrides,expected",
     [
-        pytest.param(
+        param(
             "examples/tutorials/basic/your_first_hydra_app/1_simple_cli/my_app.py",
             "--help",
             ["hydra.help.template=foo"],
             "foo\n",
             id="simple_cli_app",
         ),
-        pytest.param(
+        param(
             "examples/tutorials/basic/your_first_hydra_app/2_config_file/my_app.py",
             "--help",
             ["hydra.help.template=foo"],
             "foo\n",
             id="overriding_help_template",
         ),
-        pytest.param(
+        param(
             "examples/tutorials/basic/your_first_hydra_app/2_config_file/my_app.py",
             "--help",
             ["hydra.help.template=$CONFIG", "db.user=root"],
@@ -547,7 +541,7 @@ def test_sweep_complex_defaults(
             ),
             id="overriding_help_template:$CONFIG",
         ),
-        pytest.param(
+        param(
             "examples/tutorials/basic/your_first_hydra_app/2_config_file/my_app.py",
             "--help",
             ["hydra.help.template=$FLAGS_HELP"],
@@ -589,21 +583,21 @@ for details.
             ),
             id="overriding_help_template:$FLAGS_HELP",
         ),
-        pytest.param(
+        param(
             "examples/tutorials/basic/your_first_hydra_app/4_config_groups/my_app.py",
             "--help",
             ["hydra.help.template=$APP_CONFIG_GROUPS"],
             "db: mysql, postgresql",
             id="overriding_help_template:$APP_CONFIG_GROUPS",
         ),
-        pytest.param(
+        param(
             "examples/tutorials/basic/your_first_hydra_app/2_config_file/my_app.py",
             "--hydra-help",
             ["hydra.hydra_help.template=foo"],
             "foo\n",
             id="overriding_hydra_help_template",
         ),
-        pytest.param(
+        param(
             "examples/tutorials/basic/your_first_hydra_app/2_config_file/my_app.py",
             "--hydra-help",
             ["hydra.hydra_help.template=$FLAGS_HELP"],
@@ -657,7 +651,7 @@ def test_help(
     assert_text_same(result, expected.format(script=script))
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
         ("tests/test_apps/interpolating_dir_hydra_to_app/my_app.py", None),
@@ -693,7 +687,7 @@ def test_sys_exit(tmpdir: Path) -> None:
     assert subprocess.run(cmd).returncode == 42
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "task_config, overrides, expected_dir",
     [
         ({"hydra": {"run": {"dir": "foo"}}}, [], "foo"),
@@ -732,7 +726,7 @@ def test_local_run_workdir(
     )
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "task_config",
     [
         ({"hydra": {"run": {"dir": "${now:%Y%m%d_%H%M%S_%f}"}}}),
@@ -771,18 +765,18 @@ def test_hydra_env_set_with_override(tmpdir: Path) -> None:
     )
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "override",
     [
-        pytest.param("xyz", id="db=xyz"),
-        pytest.param("", id="db="),
+        param("xyz", id="db=xyz"),
+        param("", id="db="),
     ],
 )
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
-        pytest.param("hydra/test_utils/example_app.py", None, id="file"),
-        pytest.param(None, "hydra.test_utils.example_app", id="module"),
+        param("hydra/test_utils/example_app.py", None, id="file"),
+        param(None, "hydra.test_utils.example_app", id="module"),
     ],
 )
 def test_override_with_invalid_group_choice(
@@ -802,7 +796,7 @@ def test_override_with_invalid_group_choice(
     """
     )
 
-    with pytest.raises(MissingConfigException) as e:
+    with raises(MissingConfigException) as e:
         with hydra_task_runner(
             calling_file=calling_file,
             calling_module=calling_module,
@@ -816,8 +810,8 @@ def test_override_with_invalid_group_choice(
     assert re.search(msg, str(e.value)) is not None
 
 
-@pytest.mark.parametrize("config_path", ["dir1", "dir2"])
-@pytest.mark.parametrize("config_name", ["cfg1", "cfg2"])
+@mark.parametrize("config_path", ["dir1", "dir2"])
+@mark.parametrize("config_name", ["cfg1", "cfg2"])
 def test_config_name_and_path_overrides(
     tmpdir: Path, config_path: str, config_name: str
 ) -> None:
@@ -834,7 +828,7 @@ def test_config_name_and_path_overrides(
     assert result == f"{config_path}_{config_name}: true"
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "overrides, expected_files",
     [
         ([], {".hydra"}),
@@ -842,7 +836,7 @@ def test_config_name_and_path_overrides(
         (["hydra.output_subdir=null"], set()),
     ],
 )
-@pytest.mark.parametrize(
+@mark.parametrize(
     "calling_file, calling_module",
     [
         ("tests/test_apps/app_with_cfg/my_app.py", None),
@@ -870,7 +864,7 @@ def test_hydra_output_dir(
         assert files == expected_files
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "directory,file,module, error",
     [
         (
@@ -902,11 +896,11 @@ def test_module_run(
         assert OmegaConf.create(result) == {"x": 10}
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "overrides,error,expected",
     [
-        pytest.param(["test.param=1"], False, "1", id="run:value"),
-        pytest.param(
+        param(["test.param=1"], False, "1", id="run:value"),
+        param(
             ["test.param=1,2"],
             True,
             dedent(
@@ -920,7 +914,7 @@ def test_module_run(
             ),
             id="run:choice_sweep",
         ),
-        pytest.param(
+        param(
             ["test.param=[1,2]"],
             True,
             dedent(
@@ -934,10 +928,8 @@ def test_module_run(
             ),
             id="run:list_value",
         ),
-        pytest.param(["test.param=1", "-m"], False, "1", id="multirun:value"),
-        pytest.param(
-            ["test.param=1,2", "-m"], False, "1\n2", id="multirun:choice_sweep"
-        ),
+        param(["test.param=1", "-m"], False, "1", id="multirun:value"),
+        param(["test.param=1,2", "-m"], False, "1\n2", id="multirun:choice_sweep"),
     ],
 )
 def test_multirun_structured_conflict(
@@ -962,16 +954,16 @@ def test_multirun_structured_conflict(
         assert ret == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cmd_base",
     [(["tests/test_apps/simple_app/my_app.py", "hydra/hydra_logging=disabled"])],
 )
 class TestVariousRuns:
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         "sweep",
         [
-            pytest.param(False, id="run"),
-            pytest.param(True, id="sweep"),
+            param(False, id="run"),
+            param(True, id="sweep"),
         ],
     )
     def test_run_with_missing_default(
@@ -1093,13 +1085,13 @@ def test_hydra_to_job_config_interpolation(tmpdir: Any) -> Any:
     assert result == expected.strip()
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "overrides,expected",
     [
-        pytest.param(
+        param(
             ["dataset=imagenet"], {"dataset": {"name": "imagenet"}}, id="no_conf_dir"
         ),
-        pytest.param(
+        param(
             ["dataset=cifar10", "--config-dir=user-dir"],
             {"dataset": {"name": "cifar10"}},
             id="no_conf_dir",
@@ -1159,7 +1151,7 @@ class TestTaskRunnerLogging:
         logger.info("test_2")
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "expected",
     [
         (

--- a/tests/test_hydra_cli_errors.py
+++ b/tests/test_hydra_cli_errors.py
@@ -3,7 +3,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-import pytest
+from pytest import mark, param
 
 from hydra.test_utils.test_utils import (
     chdir_hydra_root,
@@ -14,33 +14,33 @@ from hydra.test_utils.test_utils import (
 chdir_hydra_root()
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "override,expected",
     [
-        pytest.param(
+        param(
             "+key=int(",
             "no viable alternative at input 'int('",
             id="parse_error_in_function",
         ),
-        pytest.param(
+        param(
             "+key=sort()",
             """Error parsing override '+key=sort()'
 ValueError while evaluating 'sort()': empty sort input""",
             id="empty_sort",
         ),
-        pytest.param(
+        param(
             "key=sort(interval(1,10))",
             """Error parsing override 'key=sort(interval(1,10))'
 TypeError while evaluating 'sort(interval(1,10))': mismatch type argument args[0]""",
             id="sort_interval",
         ),
-        pytest.param(
+        param(
             "+key=choice()",
             """Error parsing override '+key=choice()'
 ValueError while evaluating 'choice()': empty choice is not legal""",
             id="empty choice",
         ),
-        pytest.param(
+        param(
             ["+key=choice(choice(a,b))", "-m"],
             """Error parsing override '+key=choice(choice(a,b))'
 ValueError while evaluating 'choice(choice(a,b))': nesting choices is not supported
@@ -50,7 +50,7 @@ Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
 """,
             id="empty choice",
         ),
-        pytest.param(
+        param(
             "--config-dir=/dir/not/found",
             f"""Additional config directory '{Path('/dir/not/found').absolute()}' not found
 

--- a/tests/test_internal_utils.py
+++ b/tests/test_internal_utils.py
@@ -2,16 +2,16 @@
 import re
 from typing import Any
 
-import pytest
 from _pytest.python_api import RaisesContext
 from omegaconf import DictConfig, OmegaConf
+from pytest import mark, param, raises
 
 from hydra._internal import utils
 from hydra._internal.utils import _locate
 from tests import AClass, Adam, AnotherClass, ASubclass, NestingClass, Parameters
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "matrix,expected",
     [
         ([["a"]], [1]),
@@ -28,19 +28,17 @@ def test_get_column_widths(matrix: Any, expected: Any) -> None:
     assert utils.get_column_widths(matrix) == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "config, expected",
     [
-        pytest.param(
-            OmegaConf.create({"_target_": "foo"}), "foo", id="ObjectConf:target"
-        ),
+        param(OmegaConf.create({"_target_": "foo"}), "foo", id="ObjectConf:target"),
     ],
 )
 def test_get_class_name(config: DictConfig, expected: Any) -> None:
     assert utils._get_cls_name(config) == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "name,expected",
     [
         ("tests.Adam", Adam),
@@ -49,16 +47,14 @@ def test_get_class_name(config: DictConfig, expected: Any) -> None:
         ("tests.ASubclass", ASubclass),
         ("tests.NestingClass", NestingClass),
         ("tests.AnotherClass", AnotherClass),
-        ("", pytest.raises(ImportError, match=re.escape("Empty path"))),
+        ("", raises(ImportError, match=re.escape("Empty path"))),
         (
             "not_found",
-            pytest.raises(
-                ImportError, match=re.escape("Error loading module 'not_found'")
-            ),
+            raises(ImportError, match=re.escape("Error loading module 'not_found'")),
         ),
         (
             "tests.b.c.Door",
-            pytest.raises(ImportError, match=re.escape("No module named 'tests.b'")),
+            raises(ImportError, match=re.escape("No module named 'tests.b'")),
         ),
     ],
 )

--- a/tests/test_plugin_interface.py
+++ b/tests/test_plugin_interface.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from typing import List, Type
 
-import pytest
+from pytest import mark
 
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
@@ -17,7 +17,7 @@ sweepers = ["hydra._internal.core_plugins.basic_sweeper.BasicSweeper"]
 search_path_plugins: List[str] = []
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "plugin_type, expected",
     [
         (Launcher, launchers),

--- a/tools/configen/tests/test_generate.py
+++ b/tools/configen/tests/test_generate.py
@@ -3,9 +3,9 @@ from textwrap import dedent
 
 from difflib import unified_diff
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
-import pytest
+from pytest import mark, param
 
 from hydra.utils import get_class, instantiate, ConvertMode
 from omegaconf import OmegaConf
@@ -100,15 +100,13 @@ def test_generated_code() -> None:
         assert False, f"Mismatch between {expected_file} and generated code"
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "classname, default_flags, expected_filename",
     [
-        pytest.param("Empty", Flags(), "noflags.py", id="noflags"),
-        pytest.param(
-            "Empty", Flags(_convert_=ConvertMode.ALL), "convert.py", id="convert"
-        ),
-        pytest.param("Empty", Flags(_recursive_=True), "recursive.py", id="recursive"),
-        pytest.param(
+        param("Empty", Flags(), "noflags.py", id="noflags"),
+        param("Empty", Flags(_convert_=ConvertMode.ALL), "convert.py", id="convert"),
+        param("Empty", Flags(_recursive_=True), "recursive.py", id="recursive"),
+        param(
             "Empty",
             Flags(
                 _convert_=ConvertMode.ALL,
@@ -150,14 +148,14 @@ def test_generated_code_with_default_flags(
         assert False, f"Mismatch between {expected_file} and generated code"
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "classname, params, args, kwargs, expected",
     [
-        pytest.param("Empty", {}, [], {}, Empty(), id="Empty"),
-        pytest.param(
+        param("Empty", {}, [], {}, Empty(), id="Empty"),
+        param(
             "UntypedArg", {"param": 11}, [], {}, UntypedArg(param=11), id="UntypedArg"
         ),
-        pytest.param(
+        param(
             "UntypedArg",
             {},
             [],
@@ -165,15 +163,11 @@ def test_generated_code_with_default_flags(
             UntypedArg(param=LibraryClass()),
             id="UntypedArg_passthrough_lib_class",
         ),
-        pytest.param("IntArg", {"param": 1}, [], {}, IntArg(param=1), id="IntArg"),
-        pytest.param(
-            "UnionArg", {"param": 1}, [], {}, UnionArg(param=1), id="UnionArg"
-        ),
-        pytest.param(
-            "UnionArg", {"param": 3.14}, [], {}, UnionArg(param=3.14), id="UnionArg"
-        ),
+        param("IntArg", {"param": 1}, [], {}, IntArg(param=1), id="IntArg"),
+        param("UnionArg", {"param": 1}, [], {}, UnionArg(param=1), id="UnionArg"),
+        param("UnionArg", {"param": 3.14}, [], {}, UnionArg(param=3.14), id="UnionArg"),
         # This is okay because Union is not supported and is treated as Any
-        pytest.param(
+        param(
             "UnionArg",
             {"param": "str"},
             [],
@@ -181,7 +175,7 @@ def test_generated_code_with_default_flags(
             UnionArg(param="str"),
             id="UnionArg:illegal_but_ok_arg",
         ),
-        pytest.param(
+        param(
             "WithLibraryClassArg",
             {"num": 10},
             [],
@@ -189,7 +183,7 @@ def test_generated_code_with_default_flags(
             WithLibraryClassArg(num=10, param=LibraryClass()),
             id="WithLibraryClassArg",
         ),
-        pytest.param(
+        param(
             "IncompatibleDataclassArg",
             {"num": 10},
             [],
@@ -197,7 +191,7 @@ def test_generated_code_with_default_flags(
             IncompatibleDataclassArg(num=10, incompat=IncompatibleDataclass()),
             id="IncompatibleDataclassArg",
         ),
-        pytest.param(
+        param(
             "WithStringDefault",
             {"no_default": "foo"},
             [],
@@ -205,7 +199,7 @@ def test_generated_code_with_default_flags(
             WithStringDefault(no_default="foo"),
             id="WithStringDefault",
         ),
-        pytest.param(
+        param(
             "WithUntypedStringDefault",
             {"default_str": "foo"},
             [],
@@ -213,7 +207,7 @@ def test_generated_code_with_default_flags(
             WithUntypedStringDefault(default_str="foo"),
             id="WithUntypedStringDefault",
         ),
-        pytest.param(
+        param(
             "ListValues",
             {
                 "lst": ["1"],
@@ -230,7 +224,7 @@ def test_generated_code_with_default_flags(
             ),
             id="ListValues",
         ),
-        pytest.param(
+        param(
             "DictValues",
             {
                 "dct": {"foo": "bar"},
@@ -247,10 +241,8 @@ def test_generated_code_with_default_flags(
             ),
             id="DictValues",
         ),
-        pytest.param(
-            "Tuples", {"t1": [1.0, 2.1]}, [], {}, Tuples(t1=(1.0, 2.1)), id="Tuples"
-        ),
-        pytest.param(
+        param("Tuples", {"t1": [1.0, 2.1]}, [], {}, Tuples(t1=(1.0, 2.1)), id="Tuples"),
+        param(
             "PeskySentinelUsage",
             {},
             [],


### PR DESCRIPTION
switching the codebase from using 
```python
import pytest
```
to 
```python
from pytest import mark, param, raises, warns
```

To eliminate usage of `pytest.` everywhere in tests, making lines shorter and code formatting cleaner.