### PR TITLE
fix fish tests

### DIFF
--- a/tests/scripts/test_fish_completion.exp
+++ b/tests/scripts/test_fish_completion.exp
@@ -32,7 +32,7 @@ send "complete --do-complete \"$command\"\r"
 puts "\nMatching:\n"
 foreach arg [lrange $argv 3 end] {
     expect {
-	-re "$arg" {puts "matched '$arg' to '$expect_out(0,string)'\nbuffer: '$expect_out(buffer)'";continue}
-        timeout {puts "Error matching $arg";exit 1}
+	"$arg" {puts "matched '$arg' to '$expect_out(0,string)'\nbuffer: '$expect_out(buffer)'";continue}
+        timeout {puts "Error matching $arg"; exit 1}
     }
 }

--- a/tests/scripts/test_fish_completion.exp
+++ b/tests/scripts/test_fish_completion.exp
@@ -3,12 +3,16 @@ log_user 0
 set timeout 4
 
 # Start fish without user configuration
-set env(HOME) /dev/null
+set env(HOME) [exec mktemp -d]
+puts "HOME: $env(HOME)"
 
-# Suppress coloring
-set env(TERM) dumb
+spawn fish -C "function fish_prompt; echo '> '; end; function fish_greeting; ; end"
+expect >
 
-spawn fish
+send "fish --version\r"
+expect >
+
+send "set TERM dumb\r"
 expect >
 
 set in_line [lindex $argv 1]
@@ -23,11 +27,10 @@ expect >
 set command "[lindex $argv 0] $line\t"
 puts "command: '$command'"
 
-send $command
+send "complete --do-complete \"$command\"\r"
 
 puts "\nMatching:\n"
 foreach arg [lrange $argv 3 end] {
-    send "\t"
     expect {
 	-re "$arg" {puts "matched '$arg' to '$expect_out(0,string)'\nbuffer: '$expect_out(buffer)'";continue}
         timeout {puts "Error matching $arg";exit 1}

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -179,12 +179,7 @@ class TestRunCompletion:
     @mark.parametrize("prog", [["python", "hydra/test_utils/completion.py"]])
     @mark.parametrize(
         "shell",
-        [
-            "bash",
-            # Temporarily disabled, see https://github.com/facebookresearch/hydra/issues/1442
-            # "fish",
-            "zsh",
-        ],
+        ["bash", "fish", "zsh"],
     )
     def test_shell_integration(
         self,
@@ -227,7 +222,7 @@ class TestRunCompletion:
 
         if shell == "fish":
             # Fish will add a space to an unambiguous completion.
-            expected = [x + " " if re.match(r".*=\w+$", x) else x for x in expected]
+            expected = [x + " " if re.search(r"\w$", x) else x for x in expected]
 
             # Exactly match token end. See
             # https://github.com/fish-shell/fish-shell/issues/6928

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -221,12 +221,8 @@ class TestRunCompletion:
         )
 
         if shell == "fish":
-            # Fish will add a space to an unambiguous completion.
-            expected = [x + " " if re.search(r"\w$", x) else x for x in expected]
-
-            # Exactly match token end. See
-            # https://github.com/fish-shell/fish-shell/issues/6928
-            expected = [re.escape(x) + "$" for x in expected]
+            # Escape special chars in the output
+            expected = [re.escape(x) for x in expected]
 
         cmd.extend(expected)
         if verbose:

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -220,10 +220,6 @@ class TestRunCompletion:
             ]
         )
 
-        if shell == "fish":
-            # Escape special chars in the output
-            expected = [re.escape(x) for x in expected]
-
         cmd.extend(expected)
         if verbose:
             print("\nCOMMAND:\n" + " ".join([f"'{x}'" for x in cmd]))


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Fix fish completion tests.

The failure was caused by a too strict regexp matching at preprocessing. `key=value` style completion was captured but `value_only` style completion was not. This PR fixes that.

Regarding HOME directory errors, I think we can safely ignore as fish is just complaining about not being able to save personal settings. Fish doesn't have a clean way to ignore configurations and dealing with this error is a bit over the top IMO.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

NA

## Related Issues and PRs

Fix #1442