### PR TITLE
Add documentation for hydra.job.override_dirname

### DIFF
--- a/examples/configure_hydra/job_override_dirname/config.yaml
+++ b/examples/configure_hydra/job_override_dirname/config.yaml
@@ -8,6 +8,6 @@ hydra:
         exclude_keys:
           - seed
 
-a: 1
-b: 2
-seed: 111
+a: a1
+b: b1
+seed: 1

--- a/examples/configure_hydra/job_override_dirname/config.yaml
+++ b/examples/configure_hydra/job_override_dirname/config.yaml
@@ -8,6 +8,6 @@ hydra:
         exclude_keys:
           - seed
 
-a: a1
-b: b1
+lr: 0.1
+optimizer: adam
 seed: 1

--- a/examples/configure_hydra/job_override_dirname/config.yaml
+++ b/examples/configure_hydra/job_override_dirname/config.yaml
@@ -1,0 +1,13 @@
+hydra:
+  sweep:
+    dir: multirun
+    subdir: ${hydra.job.override_dirname}/seed=${seed}
+  job:
+    config:
+      override_dirname:
+        exclude_keys:
+          - seed
+
+a: 1
+b: 2
+seed: 111

--- a/examples/configure_hydra/job_override_dirname/config.yaml
+++ b/examples/configure_hydra/job_override_dirname/config.yaml
@@ -8,6 +8,6 @@ hydra:
         exclude_keys:
           - seed
 
-lr: 0.1
-optimizer: adam
+learning_rate: 0.1
+batch_size: 32
 seed: 1

--- a/examples/configure_hydra/job_override_dirname/my_app.py
+++ b/examples/configure_hydra/job_override_dirname/my_app.py
@@ -1,0 +1,15 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import os
+
+from omegaconf import DictConfig
+
+import hydra
+
+
+@hydra.main(config_name="config")
+def my_app(_cfg: DictConfig) -> None:
+    print(f"Working dir {os.getcwd()}")
+
+
+if __name__ == "__main__":
+    my_app()

--- a/examples/configure_hydra/workdir/conf/config.yaml
+++ b/examples/configure_hydra/workdir/conf/config.yaml
@@ -5,3 +5,5 @@ hydra:
   sweep:
     dir: sweep_dir
     subdir: ${hydra.job.num}
+
+a: a1

--- a/tests/test_examples/test_configure_hydra.py
+++ b/tests/test_examples/test_configure_hydra.py
@@ -73,13 +73,14 @@ def test_job_override_dirname(tmpdir: Path) -> None:
     cmd = [
         "examples/configure_hydra/job_override_dirname/my_app.py",
         "hydra.sweep.dir=" + str(tmpdir),
-        "a=10",
-        "b=20",
+        "a=a1,a2",
+        "b=b1",
         "seed=999",
         "-m",
     ]
     run_python_script(cmd)
-    assert Path(tmpdir / "a=10,b=20/seed=999/my_app.log").exists()
+    assert Path(tmpdir / "a=a1,b=b1/seed=999/my_app.log").exists()
+    assert Path(tmpdir / "a=a2,b=b1/seed=999/my_app.log").exists()
 
 
 def test_logging(tmpdir: Path) -> None:

--- a/tests/test_examples/test_configure_hydra.py
+++ b/tests/test_examples/test_configure_hydra.py
@@ -73,14 +73,14 @@ def test_job_override_dirname(tmpdir: Path) -> None:
     cmd = [
         "examples/configure_hydra/job_override_dirname/my_app.py",
         "hydra.sweep.dir=" + str(tmpdir),
-        "lr=0.1,0.01",
-        "optimizer=adam",
+        "learning_rate=0.1,0.01",
+        "batch_size=32",
         "seed=999",
         "-m",
     ]
     run_python_script(cmd)
-    assert Path(tmpdir / "lr=0.1,optimizer=adam/seed=999/my_app.log").exists()
-    assert Path(tmpdir / "lr=0.01,optimizer=adam/seed=999/my_app.log").exists()
+    assert Path(tmpdir / "batch_size=32,learning_rate=0.01/seed=999/").is_dir()
+    assert Path(tmpdir / "batch_size=32,learning_rate=0.1/seed=999/").is_dir()
 
 
 def test_logging(tmpdir: Path) -> None:

--- a/tests/test_examples/test_configure_hydra.py
+++ b/tests/test_examples/test_configure_hydra.py
@@ -69,6 +69,19 @@ def test_job_name_with_config_override(tmpdir: Path) -> None:
     assert result == "name_from_config_file"
 
 
+def test_job_override_dirname(tmpdir: Path) -> None:
+    cmd = [
+        "examples/configure_hydra/job_override_dirname/my_app.py",
+        "hydra.sweep.dir=" + str(tmpdir),
+        "a=10",
+        "b=20",
+        "seed=999",
+        "-m",
+    ]
+    run_python_script(cmd)
+    assert Path(tmpdir / "a=10,b=20/seed=999/my_app.log").exists()
+
+
 def test_logging(tmpdir: Path) -> None:
     cmd = [
         "examples/configure_hydra/logging/my_app.py",

--- a/tests/test_examples/test_configure_hydra.py
+++ b/tests/test_examples/test_configure_hydra.py
@@ -73,14 +73,14 @@ def test_job_override_dirname(tmpdir: Path) -> None:
     cmd = [
         "examples/configure_hydra/job_override_dirname/my_app.py",
         "hydra.sweep.dir=" + str(tmpdir),
-        "a=a1,a2",
-        "b=b1",
+        "lr=0.1,0.01",
+        "optimizer=adam",
         "seed=999",
         "-m",
     ]
     run_python_script(cmd)
-    assert Path(tmpdir / "a=a1,b=b1/seed=999/my_app.log").exists()
-    assert Path(tmpdir / "a=a2,b=b1/seed=999/my_app.log").exists()
+    assert Path(tmpdir / "lr=0.1,optimizer=adam/seed=999/my_app.log").exists()
+    assert Path(tmpdir / "lr=0.01,optimizer=adam/seed=999/my_app.log").exists()
 
 
 def test_logging(tmpdir: Path) -> None:

--- a/website/docs/configure_hydra/job.md
+++ b/website/docs/configure_hydra/job.md
@@ -80,9 +80,9 @@ hydra:
 then run the application with command-line overrides:
 
 ```bash
-python my_app.py --multirun a=10 b=20
+python my_app.py --multirun a=a1 b=b1
 ```
-Would result in creating a output dir `multirun/a=10,b=20`
+Would result in creating a output dir `multirun/a=a1,b=b1`
 
 You can further customized the output dir creation by configuring`hydra.job.override_dirname`.
 
@@ -102,19 +102,19 @@ hydra:
 ```
 With this configuration, running
 ```bash
-$ python my_app.py --multirun a=10 b=20 seed=777,999
+$ python my_app.py --multirun a=a1,a2 b=b1 seed=1,2
 ```
 
 Would result in a directory like:
 ```
-$ tree multirun/
-multirun/
-├── a=10,b=20
-│   ├── seed=777
-│   │   └── my_app.log
-│   └── seed=999
-│       └── my_app.log
-└── multirun.yaml
+$ tree multirun -d
+multirun
+├── a=a1,b=b1
+│   ├── seed=1
+│   └── seed=2
+└── a=a2,b=b1
+    ├── seed=1
+    └── seed=2
 ```
 
 ### hydra.job.id

--- a/website/docs/configure_hydra/job.md
+++ b/website/docs/configure_hydra/job.md
@@ -63,59 +63,8 @@ It is normally derived from the Python file name (The job name of the file `trai
 You can override it via the command line, or your config file. 
 
 ### hydra.job.override_dirname
-<ExampleGithubLink text="Example application" to="examples/configure_hydra/job_override_dirname"/>
-
-This field is populated automatically using your command line arguments and is typically being used as a part of your 
-output directory pattern. It is meant to be used along with [working dir configuration](/configure_hydra/workdir.md), especially
-in `hydra.sweep.subdir`.
-
-For example, we configure the example application like the following
-```yaml
-hydra:
-  sweep:
-    dir: multirun
-    subdir: ${hydra.job.override_dirname}
-```
-
-then run the application with command-line overrides:
-
-```bash
-python my_app.py --multirun a=a1 b=b1
-```
-Would result in creating a output dir `multirun/a=a1,b=b1`
-
-You can further customized the output dir creation by configuring`hydra.job.override_dirname`.
-
-In particular, the separator char `=` and the item separator char `,` can be modified, and some command line
-override keys can be automatically excluded from the generated `override_dirname`.
-An example of a case where the exclude is useful is a random seed.
-
-```yaml
-hydra:
-  run:
-    dir: output/${hydra.job.override_dirname}/seed=${seed}
-  job:
-    config:
-      override_dirname:
-        exclude_keys:
-          - seed
-```
-With this configuration, running
-```bash
-$ python my_app.py --multirun a=a1,a2 b=b1 seed=1,2
-```
-
-Would result in a directory like:
-```
-$ tree multirun -d
-multirun
-├── a=a1,b=b1
-│   ├── seed=1
-│   └── seed=2
-└── a=a2,b=b1
-    ├── seed=1
-    └── seed=2
-```
+This config enables creating working dir based on command line overrides. 
+For more information, check [here](/configure_hydra/workdir.md).
 
 ### hydra.job.id
 The job ID is populated by active Hydra launcher. For the basic launcher, the job ID is just a serial job number, but

--- a/website/docs/configure_hydra/job.md
+++ b/website/docs/configure_hydra/job.md
@@ -63,23 +63,30 @@ It is normally derived from the Python file name (The job name of the file `trai
 You can override it via the command line, or your config file. 
 
 ### hydra.job.override_dirname
+<ExampleGithubLink text="Example application" to="examples/configure_hydra/job_override_dirname"/>
+
 This field is populated automatically using your command line arguments and is typically being used as a part of your 
-output directory pattern.
-For example, the command line arguments:
-```bash
-$ python foo.py a=10 b=20
-```
-Would result in `hydra.job.override_dirname` getting the value a=10,b=20.
-When used with the output directory override, it can automatically generate directories that represent the 
-command line arguments used in your run.   
+output directory pattern. It is meant to be used along with [working dir configuration](/configure_hydra/workdir.md), especially
+in `hydra.sweep.subdir`.
+
+For example, we configure the example application like the following
 ```yaml
 hydra:
-  run:
-    dir: output/${hydra.job.override_dirname}
+  sweep:
+    dir: multirun
+    subdir: ${hydra.job.override_dirname}
 ```
 
-The generation of override_dirname can be controlled by `hydra.job.config.override_dirname`.
-In particular, the separator char `=` and the item separator char `,` can be modified, and in addition some command line
+then run the application with command-line overrides:
+
+```bash
+python my_app.py --multirun a=10 b=20
+```
+Would result in creating a output dir `multirun/a=10,b=20`
+
+You can further customized the output dir creation by configuring`hydra.job.override_dirname`.
+
+In particular, the separator char `=` and the item separator char `,` can be modified, and some command line
 override keys can be automatically excluded from the generated `override_dirname`.
 An example of a case where the exclude is useful is a random seed.
 
@@ -95,14 +102,20 @@ hydra:
 ```
 With this configuration, running
 ```bash
-$ python foo.py a=10 b=20 seed=999
+$ python my_app.py --multirun a=10 b=20 seed=777,999
 ```
 
 Would result in a directory like:
 ```
-output/a=10,b=20/seed=999
+$ tree multirun/
+multirun/
+├── a=10,b=20
+│   ├── seed=777
+│   │   └── my_app.log
+│   └── seed=999
+│       └── my_app.log
+└── multirun.yaml
 ```
-Allowing you to more easily group identical runs with different random seeds together.
 
 ### hydra.job.id
 The job ID is populated by active Hydra launcher. For the basic launcher, the job ID is just a serial job number, but

--- a/website/docs/configure_hydra/job.md
+++ b/website/docs/configure_hydra/job.md
@@ -63,8 +63,8 @@ It is normally derived from the Python file name (The job name of the file `trai
 You can override it via the command line, or your config file. 
 
 ### hydra.job.override_dirname
-This config enables creating working dir based on command line overrides. 
-For more information, check [here](/configure_hydra/workdir.md).
+Enables the creation of an output directory which is based on command line overrides.
+See [this](/configure_hydra/workdir.md) for more information.
 
 ### hydra.job.id
 The job ID is populated by active Hydra launcher. For the basic launcher, the job ID is just a serial job number, but

--- a/website/docs/configure_hydra/workdir.md
+++ b/website/docs/configure_hydra/workdir.md
@@ -75,14 +75,14 @@ hydra:
 then run the application with command-line overrides:
 
 ```bash
-python my_app.py --multirun lr=0.1,0.01 optimizer=adam
+python my_app.py --multirun batch_size=32 learning_rate=0.1,0.01
 ```
 Would result in creating the following output structure
 ```bash
 $ tree multirun -d
 multirun
-├── lr=0.01,optimizer=adam
-└── lr=0.1,optimizer=adam
+├── batch_size=32,learning_rate=0.01
+└── batch_size=32,learning_rate=0.1
 ```
 
 You can further customized the output dir creation by configuring`hydra.job.override_dirname`.
@@ -105,17 +105,17 @@ hydra:
 ```
 With this configuration, running
 ```bash
-$ python my_app.py --multirun lr=0.1,0.01 optimizer=adam seed=1,2
+$ python my_app.py --multirun  batch_size=32 learning_rate=0.1,0.01 seed=1,2
 ```
 
 Would result in a directory structure like:
 ```
 $ tree multirun -d
 multirun
-├── lr=0.01,optimizer=adam
+├── batch_size=32,learning_rate=0.01
 │   ├── seed=1
 │   └── seed=2
-└── lr=0.1,optimizer=adam
+└── batch_size=32,learning_rate=0.1
     ├── seed=1
     └── seed=2
 ```

--- a/website/docs/configure_hydra/workdir.md
+++ b/website/docs/configure_hydra/workdir.md
@@ -75,9 +75,15 @@ hydra:
 then run the application with command-line overrides:
 
 ```bash
-python my_app.py --multirun a=a1 b=b1
+python my_app.py --multirun lr=0.1,0.01 optimizer=adam
 ```
-Would result in creating a output dir `multirun/a=a1,b=b1`
+Would result in creating the following output structure
+```bash
+u$ tree multirun -d
+multirun
+├── lr=0.01,optimizer=adam
+└── lr=0.1,optimizer=adam
+```
 
 You can further customized the output dir creation by configuring`hydra.job.override_dirname`.
 
@@ -99,17 +105,17 @@ hydra:
 ```
 With this configuration, running
 ```bash
-$ python my_app.py --multirun a=a1,a2 b=b1 seed=1,2
+$ python my_app.py --multirun lr=0.1,0.01 optimizer=adam seed=1,2
 ```
 
 Would result in a directory structure like:
 ```
 $ tree multirun -d
 multirun
-├── a=a1,b=b1
+├── lr=0.01,optimizer=adam
 │   ├── seed=1
 │   └── seed=2
-└── a=a2,b=b1
+└── lr=0.1,optimizer=adam
     ├── seed=1
     └── seed=2
 ```

--- a/website/docs/configure_hydra/workdir.md
+++ b/website/docs/configure_hydra/workdir.md
@@ -10,18 +10,13 @@ import {ExampleGithubLink} from "@site/src/components/GithubLink"
 
 Below are a few examples of customizing output directory patterns.
 
-Run output directory grouped by day:
+### Configuration for run
+
+Run output directory grouped by date:
 ```yaml
 hydra:
   run:
     dir: ./outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
-```
-
-Sweep sub directory contains the the job number and the override parameters for the job instance:
-```yaml
-hydra:
-  sweep:
-    subdir: ${hydra.job.num}_${hydra.job.override_dirname}
 ```
 
 Run output directory grouped by job name:
@@ -36,16 +31,85 @@ Run output directory can contain user configuration variables:
 hydra:
   run:
     dir: outputs/${now:%Y-%m-%d_%H-%M-%S}/opt:${optimizer.type}
-
 ```
 
-Run output directory can contain override parameters for the job:
+### Configuration for multirun
 
-See [Override dirname](./job#hydrajoboverride_dirname) in the Job configuration page for details on how to customize
-`hydra.job.override_dirname`.
+Sweep sub directory contains the job number for the job instance:
+```yaml
+hydra:
+  sweep:
+    dir: sweep_dir
+    subdir: ${hydra.job.num}
+```
+Run the example application
+```bash
+python my_app.py --multirun a=a1,a2,a3 
+```
+
+Would create working dir structure like:
+```bash
+$ tree sweep_dir -d
+sweep_dir
+├── 0
+├── 1
+└── 2
+```
+
+### Using `hydra.job.override_dirname`
+
+<ExampleGithubLink text="Example application" to="examples/configure_hydra/job_override_dirname"/>
+
+This field is populated automatically using your command line arguments and is typically being used as a part of your 
+output directory pattern. It is meant to be used along with the configuration for working dir, especially
+in `hydra.sweep.subdir`.
+
+For example, we configure the example application like the following
+```yaml
+hydra:
+  sweep:
+    dir: multirun
+    subdir: ${hydra.job.override_dirname}
+```
+
+then run the application with command-line overrides:
+
+```bash
+python my_app.py --multirun a=a1 b=b1
+```
+Would result in creating a output dir `multirun/a=a1,b=b1`
+
+You can further customized the output dir creation by configuring`hydra.job.override_dirname`.
+
+In particular, the separator char `=` and the item separator char `,` can be modified by overriding 
+`hydra.job.config.override_dirname.kv_sep` and `hydra.job.config.override_dirname.item_sep`.
+Command line override keys can also be automatically excluded from the generated `override_dirname`.
+
+An example of a case where the exclude is useful is a random seed.
 
 ```yaml
 hydra:
   run:
-    dir: output/${hydra.job.override_dirname}
+    dir: output/${hydra.job.override_dirname}/seed=${seed}
+  job:
+    config:
+      override_dirname:
+        exclude_keys:
+          - seed
+```
+With this configuration, running
+```bash
+$ python my_app.py --multirun a=a1,a2 b=b1 seed=1,2
+```
+
+Would result in a directory structure like:
+```
+$ tree multirun -d
+multirun
+├── a=a1,b=b1
+│   ├── seed=1
+│   └── seed=2
+└── a=a2,b=b1
+    ├── seed=1
+    └── seed=2
 ```

--- a/website/docs/configure_hydra/workdir.md
+++ b/website/docs/configure_hydra/workdir.md
@@ -79,7 +79,7 @@ python my_app.py --multirun lr=0.1,0.01 optimizer=adam
 ```
 Would result in creating the following output structure
 ```bash
-u$ tree multirun -d
+$ tree multirun -d
 multirun
 ├── lr=0.01,optimizer=adam
 └── lr=0.1,optimizer=adam

--- a/website/docs/configure_hydra/workdir.md
+++ b/website/docs/configure_hydra/workdir.md
@@ -35,11 +35,11 @@ hydra:
 
 ### Configuration for multirun
 
-Sweep sub directory contains the job number for the job instance:
+Default multirun dir configurations:
 ```yaml
 hydra:
   sweep:
-    dir: sweep_dir
+    dir: multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
     subdir: ${hydra.job.num}
 ```
 Run the example application
@@ -47,13 +47,24 @@ Run the example application
 python my_app.py --multirun a=a1,a2,a3 
 ```
 
-Would create working dir structure like:
+would create working dir structure like:
 ```bash
-$ tree sweep_dir -d
-sweep_dir
-├── 0
-├── 1
-└── 2
+$ tree -d multirun/
+multirun/
+└── 2021-03-10
+    └── 17-21-00
+        ├── 0
+        ├── 1
+        └── 2
+```
+Similar configuration patterns in run can be applied to config multirun dir as well.
+
+For example, multirun output directory grouped by job name, and sub dir by job num:
+```yaml
+hydra:
+  sweep:
+    dir: ${hydra.job.name}
+    subdir: ${hydra.job.num}
 ```
 
 ### Using `hydra.job.override_dirname`

--- a/website/docs/configure_hydra/workdir.md
+++ b/website/docs/configure_hydra/workdir.md
@@ -34,38 +34,64 @@ hydra:
 ```
 
 ### Configuration for multirun
+We will run the application with same command but different configurations:
 
-Default multirun dir configurations:
-```yaml
-hydra:
-  sweep:
-    dir: multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
-    subdir: ${hydra.job.num}
-```
-Run the example application
 ```bash
 python my_app.py --multirun a=a1,a2,a3 
 ```
 
-would create working dir structure like:
-```bash
-$ tree -d multirun/
-multirun/
-└── 2021-03-10
-    └── 17-21-00
-        ├── 0
-        ├── 1
-        └── 2
+
+Default multirun dir configurations:
+<div className="row">
+<div className="col col--8">
+
+```yaml title="config.yaml"
+hydra:
+  sweep:
+    dir: multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}
+
 ```
+</div>
+<div className="col  col--4">
+
+```bash title="workding dir created"
+$ tree my_app -d
+my_app
+├── 0
+├── 1
+└── 2
+```
+</div>
+</div>
+
+
 Similar configuration patterns in run can be applied to config multirun dir as well.
 
 For example, multirun output directory grouped by job name, and sub dir by job num:
-```yaml
+<div className="row">
+<div className="col col--6">
+
+```yaml title="config.yaml"
 hydra:
   sweep:
     dir: ${hydra.job.name}
     subdir: ${hydra.job.num}
+
 ```
+</div>
+<div className="col  col--6">
+
+```bash title="workding dir created"
+$ tree my_app -d
+my_app
+├── 0
+├── 1
+└── 2
+```
+</div>
+</div>
+
 
 ### Using `hydra.job.override_dirname`
 
@@ -75,26 +101,33 @@ This field is populated automatically using your command line arguments and is t
 output directory pattern. It is meant to be used along with the configuration for working dir, especially
 in `hydra.sweep.subdir`.
 
-For example, we configure the example application like the following
-```yaml
+If we run the example application with the following commandline overrides and configs:
+
+```bash
+python my_app.py --multirun batch_size=32 learning_rate=0.1,0.01
+```
+
+
+<div className="row">
+<div className="col col--6">
+
+```yaml title="config.yaml"
 hydra:
   sweep:
     dir: multirun
     subdir: ${hydra.job.override_dirname}
 ```
+</div>
+<div className="col  col--6">
 
-then run the application with command-line overrides:
-
-```bash
-python my_app.py --multirun batch_size=32 learning_rate=0.1,0.01
-```
-Would result in creating the following output structure
-```bash
+```bash title="working dir created"
 $ tree multirun -d
 multirun
 ├── batch_size=32,learning_rate=0.01
 └── batch_size=32,learning_rate=0.1
 ```
+</div>
+</div>
 
 You can further customized the output dir creation by configuring`hydra.job.override_dirname`.
 
@@ -130,3 +163,4 @@ multirun
     ├── seed=1
     └── seed=2
 ```
+


### PR DESCRIPTION
addressed #1384 
- add an example app for the config
- update example to show sweep instead of single run. 