### PR TITLE
274 searchpath

### DIFF
--- a/hydra/_internal/config_search_path_impl.py
+++ b/hydra/_internal/config_search_path_impl.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from typing import List, Optional, Sequence
+from typing import List, MutableSequence, Optional
 
 from hydra.core.config_search_path import (
     ConfigSearchPath,
@@ -14,7 +14,7 @@ class ConfigSearchPathImpl(ConfigSearchPath):
     def __init__(self) -> None:
         self.config_search_path = []
 
-    def get_path(self) -> Sequence[SearchPathElement]:
+    def get_path(self) -> MutableSequence[SearchPathElement]:
         return self.config_search_path
 
     def find_last_match(self, reference: SearchPathQuery) -> int:

--- a/hydra/conf/__init__.py
+++ b/hydra/conf/__init__.py
@@ -101,6 +101,10 @@ class HydraConf:
         ]
     )
 
+    # Elements to append to the config search path.
+    # Note: This can only be configured in the primary config.
+    searchpath: List[str] = field(default_factory=list)
+
     # Normal run output configuration
     run: RunDir = RunDir()
     # Multi-run output configuration

--- a/hydra/core/config_search_path.py
+++ b/hydra/core/config_search_path.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional, Sequence
+from typing import MutableSequence, Optional
 
 
 class SearchPathElement:
@@ -28,7 +28,7 @@ class SearchPathQuery:
 
 class ConfigSearchPath(ABC):
     @abstractmethod
-    def get_path(self) -> Sequence[SearchPathElement]:
+    def get_path(self) -> MutableSequence[SearchPathElement]:
         ...
 
     @abstractmethod

--- a/news/274.feature
+++ b/news/274.feature
@@ -1,0 +1,1 @@
+Support for configuring the config search path from the primary config

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -108,8 +108,6 @@ db:
   pass: drowssap
   timeout: 20
   user: postgres_user
-website:
-  domain: example.com
 ```
 You can have as many config groups as you need.
 
@@ -126,8 +124,6 @@ db:
   driver: mysql
   pass: secret
   user: omry
-website:
-    domain: example.com
 
 [HYDRA]        #1 : db=postgresql
 db:
@@ -135,8 +131,6 @@ db:
   pass: drowssap
   timeout: 10
   user: postgres_user
-website:
-    domain: example.com
 ```
 
 There is a whole lot more to Hydra. Read the [tutorial](tutorials/basic/your_first_app/1_simple_cli.md) to learn more.

--- a/website/docs/patterns/specializing_config.md
+++ b/website/docs/patterns/specializing_config.md
@@ -40,7 +40,7 @@ the value `${dataset}_${model}` is using OmegaConf's [variable interpolation](ht
 At runtime, that value would resolve to *imagenet_alexnet*, or *cifar_resnet* - depending on the values of defaults.dataset and defaults.model.
 
 :::info
-This is not standard interpolations and there are some subtle differences and limitations.
+This is non-standard interpolation and there are some subtle differences and limitations.
 :::
 
 


### PR DESCRIPTION
Closes #274 

Adds support for configuring the config search path from the primary config (and only the primary config).

Example:
config.yaml
```yaml
foo: bar
hydra:
  searchpath:
    - pkg://foo.bar
    - file:///etc/foo
```

NOTE:
Does not include documentation yet. followup task to document #1449.