### PR TITLE
Fix for 1483

### DIFF
--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
@@ -11,11 +11,11 @@ class RedisConf:
     # host address via REDIS_HOST environment variable, default: localhost
     host: str = II("oc.env:REDIS_HOST,localhost")
     # port via REDIS_PORT environment variable, default: 6379
-    port: int = II("oc.env:REDIS_PORT,6379")
+    port: int = II("oc.env:REDIS_PORT,'6379'")
     # database via REDIS_DB environment variable, default: 0
-    db: Optional[str] = II("oc.env:REDIS_DB,0")
+    db: Optional[str] = II("oc.env:REDIS_DB,'0'")
     # password via REDIS_PASSWORD environment variable, default: no password
-    password: str = II("oc.env:REDIS_PASSWORD,null")
+    password: Optional[str] = II("oc.env:REDIS_PASSWORD,null")
     # switch to run without redis server in single thread, for testing purposes only
     mock: bool = II("oc.env:REDIS_MOCK,'False'")
 

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -314,7 +314,7 @@ def test_class_instantiate_omegaconf_node(instantiate_func: Any, config: Any) ->
 
 @mark.parametrize("src", [{"_target_": "tests.instantiate.Adam"}])
 def test_instantiate_adam(instantiate_func: Any, config: Any) -> None:
-    with raises(Exception):
+    with raises(TypeError):
         # can't instantiate without passing params
         instantiate_func(config)
 
@@ -324,9 +324,9 @@ def test_instantiate_adam(instantiate_func: Any, config: Any) -> None:
 
 
 def test_instantiate_adam_conf(instantiate_func: Any) -> None:
-    with raises(Exception):
+    with raises(TypeError):
         # can't instantiate without passing params
-        instantiate_func({"_target_": "tests.Adam"})
+        instantiate_func(AdamConf())
 
     adam_params = Parameters([1, 2, 3])
     res = instantiate_func(AdamConf(lr=0.123), params=adam_params)

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -388,6 +388,7 @@ def test_strip(
     assert result_line == args_line
 
 
+@mark.skipif(sys.platform == "win32", reason="does not run on windows")
 @mark.parametrize(
     "shell,script,comp_func",
     [

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,5 +1,4 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import os
 import re
 from dataclasses import dataclass
 from textwrap import dedent


### PR DESCRIPTION
Instantiated object parameters that are OmegaConf containers now are passed after resolving their interpolations and detaching them from their parent.
This addresses the issue reported in #1483 and also #1295.

Closes #1483