### PR TITLE
Plugins are now obtaining version from hydra_plugins.PLUGIN.__version__

### DIFF
--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/__init__.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/__init__.py
@@ -1,1 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+__version__ = "1.1.0rc1"

--- a/plugins/hydra_ax_sweeper/pyproject.toml
+++ b/plugins/hydra_ax_sweeper/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.towncrier]
-    package = "hydra_ax_sweeper"
-    package_dir = "hydra_plugins"
+    package = "hydra_plugins.hydra_ax_sweeper"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_ax_sweeper/setup.py
+++ b/plugins/hydra_ax_sweeper/setup.py
@@ -1,12 +1,22 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 # type: ignore
+# isort: skip_file
 from setuptools import find_namespace_packages, setup
+
+import sys
+from os.path import abspath, dirname, join
+
+helpers = join(dirname(dirname(dirname(abspath(__file__)))))
+sys.path.append(helpers)
+from build_helpers.build_helpers import find_version  # noqa E402
 
 with open("README.md", "r") as fh:
     LONG_DESC = fh.read()
     setup(
         name="hydra-ax-sweeper",
-        version="1.1.0rc1",
+        version=find_version(
+            dirname(__file__), "hydra_plugins/hydra_ax_sweeper/__init__.py"
+        ),
         author="Omry Yadan, Shagun Sodhani",
         author_email="omry@fb.com, sshagunsodhani@gmail.com",
         description="Hydra Ax Sweeper plugin",

--- a/plugins/hydra_colorlog/hydra_plugins/hydra_colorlog/__init__.py
+++ b/plugins/hydra_colorlog/hydra_plugins/hydra_colorlog/__init__.py
@@ -1,1 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+__version__ = "1.0.1"

--- a/plugins/hydra_colorlog/pyproject.toml
+++ b/plugins/hydra_colorlog/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.towncrier]
-    package = "hydra_colorlog"
-    package_dir = "hydra_plugins"
+    package = "hydra_plugins.hydra_colorlog"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_colorlog/setup.py
+++ b/plugins/hydra_colorlog/setup.py
@@ -1,12 +1,23 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 # type: ignore
+# isort: skip_file
 from setuptools import find_namespace_packages, setup
+
+import sys
+from os.path import abspath, dirname, join
+
+helpers = join(dirname(dirname(dirname(abspath(__file__)))))
+sys.path.append(helpers)
+from build_helpers.build_helpers import find_version  # noqa E402
+
 
 with open("README.md", "r") as fh:
     LONG_DESC = fh.read()
     setup(
         name="hydra-colorlog",
-        version="1.0.1",
+        version=find_version(
+            dirname(__file__), "hydra_plugins/hydra_colorlog/__init__.py"
+        ),
         author="Omry Yadan",
         author_email="omry@fb.com",
         description="Enables colorlog for Hydra apps",

--- a/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/__init__.py
+++ b/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/__init__.py
@@ -1,1 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+__version__ = "1.1.2"

--- a/plugins/hydra_joblib_launcher/pyproject.toml
+++ b/plugins/hydra_joblib_launcher/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.towncrier]
-    package = "hydra_joblib_launcher"
-    package_dir = "hydra_plugins"
+    package = "hydra_plugins.hydra_joblib_launcher"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_joblib_launcher/setup.py
+++ b/plugins/hydra_joblib_launcher/setup.py
@@ -1,12 +1,23 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 # type: ignore
+# isort: skip_file
 from setuptools import find_namespace_packages, setup
+
+import sys
+from os.path import abspath, dirname, join
+
+helpers = join(dirname(dirname(dirname(abspath(__file__)))))
+sys.path.append(helpers)
+from build_helpers.build_helpers import find_version  # noqa E402
+
 
 with open("README.md", "r") as fh:
     LONG_DESC = fh.read()
     setup(
         name="hydra-joblib-launcher",
-        version="1.1.2",
+        version=find_version(
+            dirname(__file__), "hydra_plugins/hydra_joblib_launcher/__init__.py"
+        ),
         author="Jan-Matthis Lueckmann, Omry Yadan",
         author_email="mail@jan-matthis.de, omry@fb.com",
         description="Joblib Launcher for Hydra apps",

--- a/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/__init__.py
+++ b/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/__init__.py
@@ -1,1 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+__version__ = "1.1.0rc1"

--- a/plugins/hydra_nevergrad_sweeper/pyproject.toml
+++ b/plugins/hydra_nevergrad_sweeper/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.towncrier]
-    package = "hydra_nevergrad_sweeper"
-    package_dir = "hydra_plugins"
+    package = "hydra_plugins.hydra_nevergrad_sweeper"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_nevergrad_sweeper/setup.py
+++ b/plugins/hydra_nevergrad_sweeper/setup.py
@@ -1,12 +1,23 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 # type: ignore
+# isort: skip_file
 from setuptools import find_namespace_packages, setup
+
+import sys
+from os.path import abspath, dirname, join
+
+helpers = join(dirname(dirname(dirname(abspath(__file__)))))
+sys.path.append(helpers)
+from build_helpers.build_helpers import find_version  # noqa E402
+
 
 with open("README.md", "r") as fh:
     LONG_DESC = fh.read()
     setup(
         name="hydra-nevergrad-sweeper",
-        version="1.1.0rc1",
+        version=find_version(
+            dirname(__file__), "hydra_plugins/hydra_nevergrad_sweeper/__init__.py"
+        ),
         author="Jeremy Rapin, Omry Yadan, Jieru Hu",
         author_email="jrapin@fb.com, omry@fb.com, jieru@fb.com",
         description="Hydra Nevergrad Sweeper plugin",

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/__init__.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/__init__.py
@@ -1,1 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+__version__ = "0.0.1"

--- a/plugins/hydra_optuna_sweeper/pyproject.toml
+++ b/plugins/hydra_optuna_sweeper/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.towncrier]
-    package = "hydra_optuna_sweeper"
-    package_dir = "hydra_plugins"
+    package = "hydra_plugins.hydra_optuna_sweeper"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -1,41 +1,44 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import os
-
+# type: ignore
+# isort: skip_file
 from setuptools import find_namespace_packages, setup
 
+import sys
+from os.path import abspath, dirname, join
 
-def get_long_description() -> str:
+helpers = join(dirname(dirname(dirname(abspath(__file__)))))
+sys.path.append(helpers)
+from build_helpers.build_helpers import find_version  # noqa E402
 
-    readme_filepath = os.path.join(os.path.dirname(__file__), "README.md")
-    with open(readme_filepath) as f:
-        return f.read()
-
-
-setup(
-    name="hydra-optuna-sweeper",
-    version="0.0.1",
-    author="Toshihiko Yanase, Hiroyuki Vincent Yamazaki",
-    author_email="toshihiko.yanase@gmail.com, hiroyuki.vincent.yamazaki@gmail.com",
-    description="Hydra Optuna Sweeper plugin",
-    long_description=get_long_description(),
-    long_description_content_type="text/markdown",
-    url="https://github.com/facebookresearch/hydra/",
-    packages=find_namespace_packages(include=["hydra_plugins.*"]),
-    classifiers=[
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Operating System :: POSIX :: Linux",
-        "Operating System :: MacOS",
-        "Development Status :: 4 - Beta",
-    ],
-    install_requires=[
-        # TODO(toshihikoyanase): Change version restriction to hydra-core>=1.1 after hydra-core=1.1.0 is released.
-        "hydra-core>1.0",
-        "optuna<2.5.0",
-        "numpy<1.20.0",  # remove once optuna is upgraded to support numpy 1.20
-    ],
-    include_package_data=True,
-)
+with open("README.md", "r") as fh:
+    LONG_DESC = fh.read()
+    setup(
+        name="hydra-optuna-sweeper",
+        version=find_version(
+            dirname(__file__), "hydra_plugins/hydra_optuna_sweeper/__init__.py"
+        ),
+        author="Toshihiko Yanase, Hiroyuki Vincent Yamazaki",
+        author_email="toshihiko.yanase@gmail.com, hiroyuki.vincent.yamazaki@gmail.com",
+        description="Hydra Optuna Sweeper plugin",
+        long_description=LONG_DESC,
+        long_description_content_type="text/markdown",
+        url="https://github.com/facebookresearch/hydra/",
+        packages=find_namespace_packages(include=["hydra_plugins.*"]),
+        classifiers=[
+            "License :: OSI Approved :: MIT License",
+            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
+            "Operating System :: POSIX :: Linux",
+            "Operating System :: MacOS",
+            "Development Status :: 4 - Beta",
+        ],
+        install_requires=[
+            # TODO(toshihikoyanase): Change version restriction to hydra-core>=1.1 after hydra-core=1.1.0 is released.
+            "hydra-core>1.0",
+            "optuna<2.5.0",
+            "numpy<1.20.0",  # remove once optuna is upgraded to support numpy 1.20
+        ],
+        include_package_data=True,
+    )

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/__init__.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/__init__.py
@@ -1,1 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+__version__ = "0.1.3"

--- a/plugins/hydra_ray_launcher/pyproject.toml
+++ b/plugins/hydra_ray_launcher/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.towncrier]
-    package = "hydra_ray_launcher"
-    package_dir = "hydra_plugins"
+    package = "hydra_plugins.hydra_ray_launcher"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_ray_launcher/setup.py
+++ b/plugins/hydra_ray_launcher/setup.py
@@ -1,11 +1,22 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+# type: ignore
+# isort: skip_file
 from setuptools import find_namespace_packages, setup
+
+import sys
+from os.path import abspath, dirname, join
+
+helpers = join(dirname(dirname(dirname(abspath(__file__)))))
+sys.path.append(helpers)
+from build_helpers.build_helpers import find_version  # noqa E402
 
 with open("README.md", "r") as fh:
     LONG_DESC = fh.read()
     setup(
         name="hydra-ray-launcher",
-        version="0.1.3",
+        version=find_version(
+            dirname(__file__), "hydra_plugins/hydra_ray_launcher/__init__.py"
+        ),
         author="Jieru Hu",
         author_email="jieru@fb.com",
         description="Hydra Ray launcher plugin",

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/__init__.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/__init__.py
@@ -1,1 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+__version__ = "1.0.2"

--- a/plugins/hydra_rq_launcher/pyproject.toml
+++ b/plugins/hydra_rq_launcher/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.towncrier]
-    package = "hydra_rq_launcher"
-    package_dir = "hydra_plugins"
+    package = "hydra_plugins.hydra_rq_launcher"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_rq_launcher/setup.py
+++ b/plugins/hydra_rq_launcher/setup.py
@@ -1,12 +1,22 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 # type: ignore
+# isort: skip_file
 from setuptools import find_namespace_packages, setup
+
+import sys
+from os.path import abspath, dirname, join
+
+helpers = join(dirname(dirname(dirname(abspath(__file__)))))
+sys.path.append(helpers)
+from build_helpers.build_helpers import find_version  # noqa E402
 
 with open("README.md", "r") as fh:
     LONG_DESC = fh.read()
     setup(
         name="hydra-rq-launcher",
-        version="1.0.2",
+        version=find_version(
+            dirname(__file__), "hydra_plugins/hydra_rq_launcher/__init__.py"
+        ),
         author="Jan-Matthis Lueckmann, Omry Yadan",
         author_email="mail@jan-matthis.de, omry@fb.com",
         description="Redis Queue (RQ) Launcher for Hydra apps",

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/__init__.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/__init__.py
@@ -1,1 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+__version__ = "1.2.0"

--- a/plugins/hydra_submitit_launcher/pyproject.toml
+++ b/plugins/hydra_submitit_launcher/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.towncrier]
-    package = "hydra_submitit_launcher"
-    package_dir = "hydra_plugins"
+    package = "hydra_plugins.hydra_submitit_launcher"
     filename = "NEWS.md"
     directory = "news/"
     title_format = "{version} ({project_date})"

--- a/plugins/hydra_submitit_launcher/setup.py
+++ b/plugins/hydra_submitit_launcher/setup.py
@@ -1,12 +1,23 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 # type: ignore
+# isort: skip_file
 from setuptools import find_namespace_packages, setup
+
+import sys
+from os.path import abspath, dirname, join
+
+helpers = join(dirname(dirname(dirname(abspath(__file__)))))
+sys.path.append(helpers)
+from build_helpers.build_helpers import find_version  # noqa E402
+
 
 with open("README.md", "r") as fh:
     LONG_DESC = fh.read()
     setup(
         name="hydra-submitit-launcher",
-        version="1.2.0",
+        version=find_version(
+            dirname(__file__), "hydra_plugins/hydra_submitit_launcher/__init__.py"
+        ),
         author="Jeremy Rapin, Jieru Hu, Omry Yadan",
         author_email="jrapin@fb.com, jieru@fb.com, omry@fb.com",
         description="Submitit Launcher for Hydra apps",


### PR DESCRIPTION
This is establishing a single source of truth for the plugin's version, both for towncrier and for package creation.
It's using the the build helpers in the core repo to parse the versions like hydra-core.
Sharing code between setup.py files is tricky, so this is a bit ugly.
The alternative (which I have been through) is to write the same function 9 times. That's even less fun.

tested with:
```
omry@Coronadev:~/dev/hydra/plugins/hydra_submitit_launcher$ python setup.py  --version
1.2.0
omry@Coronadev:~/dev/hydra/plugins/hydra_submitit_launcher$ towncrier  --draft
Loading template...
Finding news fragments...
Rendering news fragments...
Draft only -- nothing has been written.
What is seen below is what would be written.

1.2.0 (2021-03-25)
==================


### Features

- Add support for SLURM parameters `cpus_per_gpu`, `gpus_per_task`, `mem_per_gpu` and `mem_per_cpu` ([#1366](https://github.com/facebookresearch/hydra/issues/1366))
```