### PR TITLE
Release all plugins for 1.0

### DIFF
--- a/plugins/hydra_ax_sweeper/NEWS.md
+++ b/plugins/hydra_ax_sweeper/NEWS.md
@@ -1,0 +1,10 @@
+1.1.0rc2 (2021-03-30)
+=====================
+
+### Features
+
+- Support for deterministic functions in an Ax experiment via `is_noisy` input parameter ([#1395](https://github.com/facebookresearch/hydra/issues/1395))
+
+### Maintenance Changes
+
+- Pin Hydra 1.0 plugins to hydra-core==1.0.* to discourage usage with Hydra 1.1 ([#1501](https://github.com/facebookresearch/hydra/issues/1501))

--- a/plugins/hydra_ax_sweeper/news/1395.feature
+++ b/plugins/hydra_ax_sweeper/news/1395.feature
@@ -1,1 +1,0 @@
-Support for deterministic functions in an Ax experiment via `is_noisy` input parameter

--- a/plugins/hydra_ax_sweeper/news/1501.maintenance
+++ b/plugins/hydra_ax_sweeper/news/1501.maintenance
@@ -1,1 +1,0 @@
-Pin Hydra 1.0 plugins to hydra-core==1.0.* to discourage usage with Hydra 1.1

--- a/plugins/hydra_colorlog/NEWS.md
+++ b/plugins/hydra_colorlog/NEWS.md
@@ -1,0 +1,22 @@
+1.0.1 (2021-03-30)
+==================
+
+### Features
+
+- Support Python 3.9 . ([#1062](https://github.com/facebookresearch/hydra/issues/1062))
+
+### Maintenance Changes
+
+- Pin Hydra 1.0 plugins to hydra-core==1.0.* to discourage usage with Hydra 1.1 ([#1501](https://github.com/facebookresearch/hydra/issues/1501))
+
+
+1.0.1 (2021-03-30)
+==================
+
+### Features
+
+- Support Python 3.9 . ([#1062](https://github.com/facebookresearch/hydra/issues/1062))
+
+### Maintenance Changes
+
+- Pin Hydra 1.0 plugins to hydra-core==1.0.* to discourage usage with Hydra 1.1 ([#1501](https://github.com/facebookresearch/hydra/issues/1501))

--- a/plugins/hydra_colorlog/hydra_plugins/hydra_colorlog/__init__.py
+++ b/plugins/hydra_colorlog/hydra_plugins/hydra_colorlog/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.0.2"
+__version__ = "1.0.1"

--- a/plugins/hydra_colorlog/news/1062.feature
+++ b/plugins/hydra_colorlog/news/1062.feature
@@ -1,1 +1,0 @@
-Support Python 3.9 .

--- a/plugins/hydra_colorlog/news/1501.maintenance
+++ b/plugins/hydra_colorlog/news/1501.maintenance
@@ -1,1 +1,0 @@
-Pin Hydra 1.0 plugins to hydra-core==1.0.* to discourage usage with Hydra 1.1

--- a/plugins/hydra_joblib_launcher/NEWS.md
+++ b/plugins/hydra_joblib_launcher/NEWS.md
@@ -1,0 +1,10 @@
+1.1.2 (2021-03-30)
+==================
+
+### Features
+
+- Support Python 3.9 . ([#1062](https://github.com/facebookresearch/hydra/issues/1062))
+
+### Maintenance Changes
+
+- Pin Hydra 1.0 plugins to hydra-core==1.0.* to discourage usage with Hydra 1.1 ([#1501](https://github.com/facebookresearch/hydra/issues/1501))

--- a/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/__init__.py
+++ b/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.1.3"
+__version__ = "1.1.2"

--- a/plugins/hydra_joblib_launcher/news/1062.feature
+++ b/plugins/hydra_joblib_launcher/news/1062.feature
@@ -1,1 +1,0 @@
-Support Python 3.9 .

--- a/plugins/hydra_joblib_launcher/news/1501.maintenance
+++ b/plugins/hydra_joblib_launcher/news/1501.maintenance
@@ -1,1 +1,0 @@
-Pin Hydra 1.0 plugins to hydra-core==1.0.* to discourage usage with Hydra 1.1

--- a/plugins/hydra_nevergrad_sweeper/NEWS.md
+++ b/plugins/hydra_nevergrad_sweeper/NEWS.md
@@ -1,0 +1,6 @@
+1.1.0rc2 (2021-03-30)
+=====================
+
+### Maintenance Changes
+
+- Pin Hydra 1.0 plugins to hydra-core==1.0.* to discourage usage with Hydra 1.1 ([#1501](https://github.com/facebookresearch/hydra/issues/1501))

--- a/plugins/hydra_nevergrad_sweeper/news/1501.maintenance
+++ b/plugins/hydra_nevergrad_sweeper/news/1501.maintenance
@@ -1,1 +1,0 @@
-Pin Hydra 1.0 plugins to hydra-core==1.0.* to discourage usage with Hydra 1.1

--- a/plugins/hydra_ray_launcher/NEWS.md
+++ b/plugins/hydra_ray_launcher/NEWS.md
@@ -1,0 +1,11 @@
+0.1.4 (2021-03-30)
+==================
+
+### Bug Fixes
+
+- Fixed docker support in the RayLauncher plugin. ([#1191](https://github.com/facebookresearch/hydra/issues/1191))
+
+### Maintenance Changes
+
+- Pin Hydra 1.0 plugins to hydra-core==1.0.* to discourage usage with Hydra 1.1 ([#1501](https://github.com/facebookresearch/hydra/issues/1501))
+

--- a/plugins/hydra_ray_launcher/news/1191.plugin
+++ b/plugins/hydra_ray_launcher/news/1191.plugin
@@ -1,1 +1,0 @@
-Fixed docker support in the RayLauncher plugin.

--- a/plugins/hydra_ray_launcher/news/1501.maintenance
+++ b/plugins/hydra_ray_launcher/news/1501.maintenance
@@ -1,1 +1,0 @@
-Pin Hydra 1.0 plugins to hydra-core==1.0.* to discourage usage with Hydra 1.1

--- a/plugins/hydra_rq_launcher/NEWS.md
+++ b/plugins/hydra_rq_launcher/NEWS.md
@@ -1,0 +1,10 @@
+1.0.2 (2021-03-30)
+==================
+
+### Features
+
+- Support Python 3.9 . ([#1062](https://github.com/facebookresearch/hydra/issues/1062))
+
+### Maintenance Changes
+
+- Pin Hydra 1.0 plugins to hydra-core==1.0.* to discourage usage with Hydra 1.1 ([#1501](https://github.com/facebookresearch/hydra/issues/1501))

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/__init__.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.0.3"
+__version__ = "1.0.2"

--- a/plugins/hydra_rq_launcher/news/1062.feature
+++ b/plugins/hydra_rq_launcher/news/1062.feature
@@ -1,1 +1,0 @@
-Support Python 3.9 .

--- a/plugins/hydra_rq_launcher/news/1501.maintenance
+++ b/plugins/hydra_rq_launcher/news/1501.maintenance
@@ -1,1 +1,0 @@
-Pin Hydra 1.0 plugins to hydra-core==1.0.* to discourage usage with Hydra 1.1

--- a/plugins/hydra_submitit_launcher/NEWS.md
+++ b/plugins/hydra_submitit_launcher/NEWS.md
@@ -1,0 +1,16 @@
+1.1.1 (2021-03-30)
+==================
+
+### Maintenance Changes
+
+- Pin Hydra 1.0 plugins to hydra-core==1.0.* to discourage usage with Hydra 1.1 ([#1501](https://github.com/facebookresearch/hydra/issues/1501))
+
+
+1.1 (2021-01-30)
+================
+
+### Features
+
+- Support `additional_parameters` as an optional param in the Submitit launcher plugin. ([#1036](https://github.com/facebookresearch/hydra/issues/1036))
+- Support Python 3.9 . ([#1062](https://github.com/facebookresearch/hydra/issues/1062))
+- Add support to Submitit's `setup` field for sbatch script [generation](https://github.com/facebookincubator/submitit/blob/2f784bae911cc1ce9112fb742499c5f55e239aa1/submitit/slurm/slurm.py#L387) ([#1227](https://github.com/facebookresearch/hydra/issues/1227))

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/__init__.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.0.3"
+__version__ = "1.1.1"

--- a/plugins/hydra_submitit_launcher/news/1062.feature
+++ b/plugins/hydra_submitit_launcher/news/1062.feature
@@ -1,1 +1,0 @@
-Support Python 3.9 .

--- a/plugins/hydra_submitit_launcher/news/1501.maintenance
+++ b/plugins/hydra_submitit_launcher/news/1501.maintenance
@@ -1,1 +1,0 @@
-Pin Hydra 1.0 plugins to hydra-core==1.0.* to discourage usage with Hydra 1.1


### PR DESCRIPTION
Just released all plugins on the 1.0_branch with NEWS file.
Motivation is to pin all of them to Hydra 1.0 to avoid unintentional usage with 1.0.

cc @shagunsodhani , @jieru-hu.