### PR TITLE
add --info searchpath option

### DIFF
--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -372,7 +372,9 @@ class Hydra:
             for plugin_name in all_plugins:
                 log.debug("\t\t{}".format(plugin_name))
 
-    def _print_search_path(self) -> None:
+    def _print_search_path(
+        self, config_name: Optional[str], overrides: List[str]
+    ) -> None:
         assert log is not None
         log.debug("")
         self._log_header(header="Config search path", filler="*")
@@ -437,7 +439,7 @@ class Hydra:
         self, config_name: Optional[str], overrides: List[str]
     ) -> None:
         assert log is not None
-        self._print_search_path()
+        self._print_search_path(config_name=config_name, overrides=overrides)
         self._print_defaults_tree(config_name=config_name, overrides=overrides)
         self._print_defaults_list(config_name=config_name, overrides=overrides)
 
@@ -612,6 +614,7 @@ class Hydra:
             "defaults-tree": self._print_defaults_tree,
             "config": self._print_config_info,
             "plugins": self._print_plugins_info,
+            "searchpath": self._print_search_path,
         }
         simple_stdout_log_config(level=logging.DEBUG)
         global log

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -501,7 +501,14 @@ def get_args_parser() -> argparse.ArgumentParser:
         help="Adds an additional config dir to the config search path",
     )
 
-    info_choices = ["all", "defaults", "defaults-tree", "config", "plugins"]
+    info_choices = [
+        "all",
+        "defaults",
+        "defaults-tree",
+        "config",
+        "plugins",
+        "searchpath",
+    ]
     parser.add_argument(
         "--info",
         "-i",

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -503,9 +503,9 @@ def get_args_parser() -> argparse.ArgumentParser:
 
     info_choices = [
         "all",
+        "config",
         "defaults",
         "defaults-tree",
-        "config",
         "plugins",
         "searchpath",
     ]

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -577,7 +577,7 @@ for details.
                                     The config_path is relative to the Python file declaring @hydra.main()
                 --config-name,-cn : Overrides the config_name specified in hydra.main()
                 --config-dir,-cd : Adds an additional config dir to the config search path
-                --info,-i : Print Hydra information [all|defaults|defaults-tree|config|plugins|searchpath]
+                --info,-i : Print Hydra information [all|config|defaults|defaults-tree|plugins|searchpath]
                 Overrides : Any key=value arguments to override config values (use dots for.nested=overrides)
                 """
             ),
@@ -633,7 +633,7 @@ for details.
                                     The config_path is relative to the Python file declaring @hydra.main()
                 --config-name,-cn : Overrides the config_name specified in hydra.main()
                 --config-dir,-cd : Adds an additional config dir to the config search path
-                --info,-i : Print Hydra information [all|defaults|defaults-tree|config|plugins|searchpath]
+                --info,-i : Print Hydra information [all|config|defaults|defaults-tree|plugins|searchpath]
                 Overrides : Any key=value arguments to override config values (use dots for.nested=overrides)
                 """
             ),

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -577,7 +577,7 @@ for details.
                                     The config_path is relative to the Python file declaring @hydra.main()
                 --config-name,-cn : Overrides the config_name specified in hydra.main()
                 --config-dir,-cd : Adds an additional config dir to the config search path
-                --info,-i : Print Hydra information [all|defaults|defaults-tree|config|plugins]
+                --info,-i : Print Hydra information [all|defaults|defaults-tree|config|plugins|searchpath]
                 Overrides : Any key=value arguments to override config values (use dots for.nested=overrides)
                 """
             ),
@@ -633,7 +633,7 @@ for details.
                                     The config_path is relative to the Python file declaring @hydra.main()
                 --config-name,-cn : Overrides the config_name specified in hydra.main()
                 --config-dir,-cd : Adds an additional config dir to the config search path
-                --info,-i : Print Hydra information [all|defaults|defaults-tree|config|plugins]
+                --info,-i : Print Hydra information [all|defaults|defaults-tree|config|plugins|searchpath]
                 Overrides : Any key=value arguments to override config values (use dots for.nested=overrides)
                 """
             ),

--- a/website/docs/advanced/search_path.md
+++ b/website/docs/advanced/search_path.md
@@ -18,7 +18,7 @@ the Python `PYTHONPATH`.
 You can inspect the search path and the configurations loaded by Hydra via the `--info` flag:
 
 ```bash
-$ python my_app.py --info config
+$ python my_app.py --info searchpath
 ```
 
 There are a few ways to modify the config search path, enabling Hydra to access configuration in 


### PR DESCRIPTION
#1469
address the first issue - add `--info searchpath` option.


```
$ python my_app.py --info searchpath

Config search path
******************
| Provider                | Search path                                                                                               |
---------------------------------------------------------------------------------------------------------------------------------------
| hydra                   | pkg://hydra.conf                                                                                          |
| main                    | file:///Users/jieru/workspace/hydra-fork/hydra/examples/tutorials/basic/your_first_hydra_app/1_simple_cli |
| hydra-colorlog          | pkg://hydra_plugins.hydra_colorlog.conf                                                                   |
| hydra-submitit-launcher | pkg://hydra_plugins.hydra_submitit_launcher.conf                                                          |
| schema                  | structured://                                                                                             |
---------------------------------------------------------------------------------------------------------------------------------------

```