### PR TITLE
print out hydra.searchpath value if available

### DIFF
--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -609,6 +609,9 @@ class Hydra:
     def show_info(
         self, info: str, config_name: Optional[str], overrides: List[str]
     ) -> None:
+        self.config_loader.load_configuration(
+            config_name=config_name, overrides=overrides, run_mode=RunMode.RUN
+        )
         options = {
             "all": self._print_all_info,
             "defaults": self._print_defaults_list,

--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -609,6 +609,7 @@ class Hydra:
     def show_info(
         self, info: str, config_name: Optional[str], overrides: List[str]
     ) -> None:
+        # load configuration to update config sources.
         self.config_loader.load_configuration(
             config_name=config_name, overrides=overrides, run_mode=RunMode.RUN
         )

--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -382,8 +382,17 @@ class Hydra:
 
         box: List[List[str]] = [["Provider", "Search path"]]
 
-        for sp in self.config_loader.get_sources():
-            box.append([sp.provider, sp.full_path()])
+        cfg = self._get_cfg(
+            config_name=config_name,
+            overrides=overrides,
+            cfg_type="all",
+            with_log_configuration=False,
+        )
+
+        sources = cfg.hydra.runtime.config_sources
+
+        for sp in sources:
+            box.append([sp.provider, f"{sp.schema}://{sp.path}"])
 
         provider_pad, search_path_pad = get_column_widths(box)
         header = "| {} | {} |".format(
@@ -391,11 +400,11 @@ class Hydra:
         )
         self._log_header(header=header, filler="-")
 
-        for source in self.config_loader.get_sources():
+        for source in sources:
             log.debug(
                 "| {} | {} |".format(
                     source.provider.ljust(provider_pad),
-                    source.full_path().ljust(search_path_pad),
+                    f"{source.schema}://{source.path}".ljust(search_path_pad),
                 )
             )
         self._log_footer(header=header, filler="-")
@@ -609,10 +618,6 @@ class Hydra:
     def show_info(
         self, info: str, config_name: Optional[str], overrides: List[str]
     ) -> None:
-        # load configuration to update config sources.
-        self.config_loader.load_configuration(
-            config_name=config_name, overrides=overrides, run_mode=RunMode.RUN
-        )
         options = {
             "all": self._print_all_info,
             "defaults": self._print_defaults_list,

--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -385,7 +385,7 @@ class Hydra:
         cfg = self._get_cfg(
             config_name=config_name,
             overrides=overrides,
-            cfg_type="all",
+            cfg_type="hydra",
             with_log_configuration=False,
         )
 

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -649,6 +649,33 @@ def test_help(
 
 
 @mark.parametrize(
+    "script,overrides,expected",
+    [
+        param(
+            "examples/tutorials/basic/your_first_hydra_app/1_simple_cli/my_app.py",
+            ["hydra.searchpath=['pkg://fakeconf']"],
+            "hydra.searchpath in command-line | pkg://fakeconf",
+            id="searchpath config from command-line",
+        ),
+        param(
+            "examples/advanced/config_search_path/my_app.py",
+            [],
+            "hydra.searchpath in main | pkg://additonal_conf",
+            id="searchpath config from config file",
+        ),
+    ],
+)
+def test_searchpath_config(
+    tmpdir: Path, script: str, overrides: List[str], expected: Any
+) -> None:
+    cmd = [script, "--info", "searchpath"]
+    cmd.extend(overrides)
+    cmd.extend(["hydra.run.dir=" + str(tmpdir)])
+    result, _err = run_python_script(cmd)
+    assert expected in result
+
+
+@mark.parametrize(
     "calling_file, calling_module",
     [
         ("tests/test_apps/interpolating_dir_hydra_to_app/my_app.py", None),

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -654,25 +654,25 @@ def test_help(
         param(
             "examples/tutorials/basic/your_first_hydra_app/1_simple_cli/my_app.py",
             ["hydra.searchpath=['pkg://fakeconf']"],
-            "hydra.searchpath in command-line | pkg://fakeconf",
+            r".*hydra.searchpath in command-line\s+|\s+pkg://fakeconf.*",
             id="searchpath config from command-line",
         ),
         param(
             "examples/advanced/config_search_path/my_app.py",
             [],
-            "hydra.searchpath in main | pkg://additonal_conf",
+            r".*hydra.searchpath in main\s+|\s+pkg://additonal_conf.*",
             id="searchpath config from config file",
         ),
     ],
 )
 def test_searchpath_config(
-    tmpdir: Path, script: str, overrides: List[str], expected: Any
+    tmpdir: Path, script: str, overrides: List[str], expected: str
 ) -> None:
     cmd = [script, "--info", "searchpath"]
     cmd.extend(overrides)
     cmd.extend(["hydra.run.dir=" + str(tmpdir)])
     result, _err = run_python_script(cmd)
-    assert expected in result
+    assert re.match(expected, result, re.DOTALL)
 
 
 @mark.parametrize(


### PR DESCRIPTION
address part of #1469

### hydra.searchpath from primary config
```
$ python /Users/jieru/workspace/hydra-fork/hydra/examples/advanced/config_search_path/my_app.py --info searchpath

Config search path
******************
| Provider                 | Search path                                                                              |
-----------------------------------------------------------------------------------------------------------------------
| hydra                    | pkg://hydra.conf                                                                         |
| main                     | file:///Users/jieru/workspace/hydra-fork/hydra/examples/advanced/config_search_path/conf |
| hydra-colorlog           | pkg://hydra_plugins.hydra_colorlog.conf                                                  |
| hydra-submitit-launcher  | pkg://hydra_plugins.hydra_submitit_launcher.conf                                         |
| hydra.searchpath in main | pkg://additonal_conf                                                                     |
| schema                   | structured://                                                                            |
-----------------------------------------------------------------------------------------------------------------------
```

###  no hydra.searchpath configured
```
(pytest38) jieru-mbp:hydra jieru$ python /Users/jieru/workspace/hydra-fork/hydra/examples/tutorials/basic/running_your_hydra_app/3_working_directory/my_app.py --info searchpath

Config search path
******************
| Provider                | Search path                                                                                                        |
------------------------------------------------------------------------------------------------------------------------------------------------
| hydra                   | pkg://hydra.conf                                                                                                   |
| main                    | file:///Users/jieru/workspace/hydra-fork/hydra/examples/tutorials/basic/running_your_hydra_app/3_working_directory |
| hydra-colorlog          | pkg://hydra_plugins.hydra_colorlog.conf                                                                            |
| hydra-submitit-launcher | pkg://hydra_plugins.hydra_submitit_launcher.conf                                                                   |
| schema                  | structured://                                                                                                      |
------------------------------------------------------------------------------------------------------------------------------------------------
```

###  hydra.searchpath from command line
```
(pytest38) jieru-mbp:hydra jieru$ python /Users/jieru/workspace/hydra-fork/hydra/examples/tutorials/basic/running_your_hydra_app/3_working_directory/my_app.py hydra.searchpath=[file://fake_conf] --info searchpath

Config search path
******************
| Provider                         | Search path                                                                                                        |
---------------------------------------------------------------------------------------------------------------------------------------------------------
| hydra                            | pkg://hydra.conf                                                                                                   |
| main                             | file:///Users/jieru/workspace/hydra-fork/hydra/examples/tutorials/basic/running_your_hydra_app/3_working_directory |
| hydra-colorlog                   | pkg://hydra_plugins.hydra_colorlog.conf                                                                            |
| hydra-submitit-launcher          | pkg://hydra_plugins.hydra_submitit_launcher.conf                                                                   |
| hydra.searchpath in command-line | file://fake_conf                                                                                                   |
| schema                           | structured://                                                                                                      |
---------------------------------------------------------------------------------------------------------------
```