### PR TITLE
Include config_sources in hydra.runtime

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -23,6 +23,7 @@ from hydra._internal.config_repository import (
     IConfigRepository,
 )
 from hydra._internal.defaults_list import DefaultsList, create_defaults_list
+from hydra.conf import ConfigSourceInfo
 from hydra.core.config_loader import ConfigLoader
 from hydra.core.config_search_path import ConfigSearchPath
 from hydra.core.default_element import ResultDefault
@@ -267,6 +268,11 @@ class ConfigLoaderImpl(ConfigLoader):
 
         cfg.hydra.runtime.version = __version__
         cfg.hydra.runtime.cwd = os.getcwd()
+
+        cfg.hydra.runtime.config_sources = [
+            ConfigSourceInfo(path=x.path, schema=x.scheme(), provider=x.provider)
+            for x in caching_repo.get_sources()
+        ]
 
         if "name" not in cfg.hydra.job:
             cfg.hydra.job.name = JobRuntime().get("name")

--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -262,7 +262,7 @@ class ConfigLoaderImpl(ConfigLoader):
                 app_overrides.append(override)
 
         with open_dict(cfg.hydra):
-            cfg.hydra.choices.update(defaults_list.overrides.known_choices)
+            cfg.hydra.runtime.choices.update(defaults_list.overrides.known_choices)
             for key in cfg.hydra.job.env_copy:
                 cfg.hydra.job.env_set[key] = os.environ[key]
 

--- a/hydra/_internal/config_repository.py
+++ b/hydra/_internal/config_repository.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import copy
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -314,7 +315,8 @@ class ConfigRepository(IConfigRepository):
 
 class CachingConfigRepository(IConfigRepository):
     def __init__(self, delegate: IConfigRepository):
-        self.delegate = delegate
+        # copy the underlying repository to avoid mutating it with initialize_sources()
+        self.delegate = copy.deepcopy(delegate)
         self.cache: Dict[str, Optional[ConfigResult]] = {}
 
     def get_schema_source(self) -> ConfigSource:

--- a/hydra/conf/__init__.py
+++ b/hydra/conf/__init__.py
@@ -94,6 +94,9 @@ class RuntimeConf:
     cwd: str = MISSING
     config_sources: List[ConfigSourceInfo] = MISSING
 
+    # Composition choices dictionary
+    choices: Dict[str, str] = field(default_factory=lambda: {})
+
 
 @dataclass
 class HydraConf:
@@ -160,10 +163,6 @@ class HydraConf:
     # hydra.verbose=[hydra,__main__]
     # TODO: good use case for Union support in OmegaConf
     verbose: Any = False
-
-    # TODO: move to hydra.runtime?
-    # Composition choices dictionary
-    choices: Dict[str, str] = field(default_factory=lambda: {})
 
 
 cs = ConfigStore.instance()

--- a/hydra/conf/__init__.py
+++ b/hydra/conf/__init__.py
@@ -82,9 +82,17 @@ class JobConf:
 
 
 @dataclass
+class ConfigSourceInfo:
+    path: str
+    schema: str
+    provider: str
+
+
+@dataclass
 class RuntimeConf:
     version: str = MISSING
     cwd: str = MISSING
+    config_sources: List[ConfigSourceInfo] = MISSING
 
 
 @dataclass
@@ -153,6 +161,7 @@ class HydraConf:
     # TODO: good use case for Union support in OmegaConf
     verbose: Any = False
 
+    # TODO: move to hydra.runtime?
     # Composition choices dictionary
     choices: Dict[str, str] = field(default_factory=lambda: {})
 

--- a/news/956.feature
+++ b/news/956.feature
@@ -1,1 +1,1 @@
-Final choices of defaults list are retained in the dictionary hydra.choices
+Final choices of defaults list are retained in the dictionary hydra.runtime.choices

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -799,4 +799,4 @@ def test_hydra_choices(config: str, overrides: Any, expected_choices: Any) -> No
     cfg = config_loader.load_configuration(
         config_name=config, overrides=overrides, run_mode=RunMode.RUN
     )
-    assert cfg.hydra.choices == expected_choices
+    assert cfg.hydra.runtime.choices == expected_choices

--- a/website/docs/configure_hydra/Intro.md
+++ b/website/docs/configure_hydra/Intro.md
@@ -74,19 +74,23 @@ def my_app(cfg: DictConfig) -> None:
 
 The following variables are populated at runtime.  
 
-#### hydra.job:
-- **hydra.job.name** : Job name, defaults to the Python file name without the suffix. can be overridden.
-- **hydra.job.override_dirname** : Pathname derived from the overrides for this job
-- **hydra.job.num** : job serial number in sweep
-- **hydra.job.id** : Job ID in the underlying jobs system (SLURM etc)
+### hydra.job:
+Fields under **hydra.job**:
+- **name** : Job name, defaults to the Python file name without the suffix. can be overridden.
+- **override_dirname** : Pathname derived from the overrides for this job
+- **id** : Job ID in the underlying jobs system (SLURM etc)
+- **num** : job serial number in sweep
+- **config_name** : The name of the config used by the job (Output only)
+- **env_set**: Environment variable to set for the launched job
+- **env_copy**: Environment variable to copy from the launching machine
+- **config**: fine-grained configuration for job
 
-#### hydra.runtime:
-- *hydra.runtime.version*: Hydra's version
-- *hydra.runtime.cwd*: Original working directory the app was executed from
-
-#### hydra.choices
-A dictionary containing the final choices of the Defaults List. Can be accessed 
-via the HydraConfig singleton or config interpolation e.g. `model : ${hydra:choices.model}`.
+### hydra.runtime:
+Fields under **hydra.runtime**:
+- **version**: Hydra's version
+- **cwd**: Original working directory the app was executed from
+- **choices**: A dictionary containing the final config group choices.
+- **config_sources**: The final list of config sources used to compose the config.
 
 ### Hydra resolvers
 Hydra supports several [OmegaConf resolvers](https://github.com/facebookresearch/hydra/blob/master/hydra/core/utils.py) by default.


### PR DESCRIPTION
1. caching repo is now deepcopying the underlying delegate to avoid mutations to it with initialize_sources().
2. Added config_sources to hydra.runtime to allow inspection of the effective config searchpath.
3. Moved hydra.choices to hydra.runtime.choices
4. Updated docs for hydra.job and hydra.runtime.