### PR TITLE
fix NevergradDeprecationWarning

### DIFF
--- a/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/_impl.py
+++ b/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/_impl.py
@@ -132,7 +132,7 @@ class NevergradSweeperImpl(Sweeper):
             ] = create_nevergrad_parameter_from_override(override)
 
         parametrization = ng.p.Dict(**params)
-        parametrization.descriptors.deterministic_function = not self.opt_config.noisy
+        parametrization.function.deterministic = not self.opt_config.noisy
         parametrization.random_state.seed(self.opt_config.seed)
         # log and build the optimizer
         opt = self.opt_config.optimizer

--- a/plugins/hydra_nevergrad_sweeper/setup.py
+++ b/plugins/hydra_nevergrad_sweeper/setup.py
@@ -26,7 +26,7 @@ setup(
     ],
     install_requires=[
         "hydra-core>=1.0.0",
-        "nevergrad>=0.4.1.post4",
+        "nevergrad>=0.4.3.post2",
         "numpy<1.20.0",  # remove once nevergrad is upgraded to support numpy 1.20
     ],
     include_package_data=True,


### PR DESCRIPTION
test failure on master https://app.circleci.com/pipelines/github/facebookresearch/hydra/9032/workflows/0e1d2443-4f65-4600-9638-496df7f75692/jobs/78782

```
Subprocess error:
Traceback (most recent call last):
  File "/Users/distiller/project/.nox/test_plugins-3-9/lib/python3.9/site-packages/hydra/_internal/utils.py", line 212, in run_and_report
    return func()
  File "/Users/distiller/project/.nox/test_plugins-3-9/lib/python3.9/site-packages/hydra/_internal/utils.py", line 379, in <lambda>
    lambda: hydra.multirun(
  File "/Users/distiller/project/.nox/test_plugins-3-9/lib/python3.9/site-packages/hydra/_internal/hydra.py", line 132, in multirun
    ret = sweeper.sweep(arguments=task_overrides)
  File "/Users/distiller/project/.nox/test_plugins-3-9/lib/python3.9/site-packages/hydra_plugins/hydra_nevergrad_sweeper/nevergrad_sweeper.py", line 29, in sweep
    return self.sweeper.sweep(arguments)
  File "/Users/distiller/project/.nox/test_plugins-3-9/lib/python3.9/site-packages/hydra_plugins/hydra_nevergrad_sweeper/_impl.py", line 135, in sweep
    parametrization.descriptors.deterministic_function = not self.opt_config.noisy
  File "/Users/distiller/project/.nox/test_plugins-3-9/lib/python3.9/site-packages/nevergrad/parametrization/utils.py", line 146, in __setattr__
    warnings.warn(
nevergrad.common.errors.NevergradDeprecationWarning: parameter.descriptors is deprecated use 'parameter.function.deterministic' instead
=== Error executing:
/Users/distiller/project/.nox/test_plugins-3-9/bin/python -Werror example/my_app.py -m hydra.sweep.dir=/private/var/folders/6y/gy9gggt14379c_k39vwb50lc0000gn/T/pytest-of-distiller/pytest-1/test_nevergrad_example_False_0 hydra.sweeper.optim.budget=1 hydra.sweeper.optim.num_workers=1 hydra.sweeper.optim.seed=12

```