### PR TITLE
cannot add new config group from commandline if there's override in config file.

### DIFF
--- a/examples/patterns/configuring_experiments/conf/config_with_override.yaml
+++ b/examples/patterns/configuring_experiments/conf/config_with_override.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - db: mysql
+  - server: apache
+  - override hydra/env: custom

--- a/examples/patterns/configuring_experiments/conf/config_with_override.yaml
+++ b/examples/patterns/configuring_experiments/conf/config_with_override.yaml
@@ -1,4 +1,0 @@
-defaults:
-  - db: mysql
-  - server: apache
-  - override hydra/env: custom

--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -463,8 +463,24 @@ def _create_defaults_tree_impl(
     ):
         self_added = _validate_self(containing_node=parent, defaults=defaults_list)
 
-    if is_root_config:
-        defaults_list.extend(overrides.append_group_defaults)
+    if is_root_config and len(overrides.append_group_defaults) > 0:
+        # check to see if override exists
+        idx = -1
+        for i in range(len(defaults_list)):
+            if isinstance(defaults_list[i], GroupDefault) and defaults_list[i].override:  # type: ignore
+                idx = i
+                break
+        agd = overrides.append_group_defaults
+        if idx != -1:
+            # if override exists:
+            # 1. add the append group to default for override.
+            # 2. set group override to be True to indicate this is from commandline override
+            for a in agd:
+                aa = copy.deepcopy(a)
+                defaults_list.insert(idx, aa)
+                a.override = True
+
+        defaults_list.extend(agd)
 
     _update_overrides(defaults_list, overrides, parent, interpolated_subtree)
 

--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -463,24 +463,15 @@ def _create_defaults_tree_impl(
     ):
         self_added = _validate_self(containing_node=parent, defaults=defaults_list)
 
-    if is_root_config and len(overrides.append_group_defaults) > 0:
-        # check to see if override exists
-        idx = -1
-        for i in range(len(defaults_list)):
-            if isinstance(defaults_list[i], GroupDefault) and defaults_list[i].override:  # type: ignore
-                idx = i
+    if is_root_config:
+        # To ensure config overrides are last, insert the external overrides before the first config override.
+        insert_idx = len(defaults_list)
+        for idx, default in enumerate(defaults_list):
+            if default.is_override():
+                insert_idx = idx
                 break
-        agd = overrides.append_group_defaults
-        if idx != -1:
-            # if override exists:
-            # 1. add the append group to default for override.
-            # 2. set group override to be True to indicate this is from commandline override
-            for a in agd:
-                aa = copy.deepcopy(a)
-                defaults_list.insert(idx, aa)
-                a.override = True
 
-        defaults_list.extend(agd)
+        defaults_list[insert_idx:insert_idx] = overrides.append_group_defaults
 
     _update_overrides(defaults_list, overrides, parent, interpolated_subtree)
 

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -2161,6 +2161,28 @@ def test_none_config_with_hydra(
             ),
             id="defaults_with_override_only",
         ),
+        param(
+            "defaults_with_override_only",
+            ["+group1=file1"],
+            DefaultsTreeNode(
+                node=VirtualRoot(),
+                children=[
+                    DefaultsTreeNode(
+                        node=ConfigDefault(path="hydra/config"),
+                        children=[
+                            GroupDefault(group="help", value="custom1"),
+                            GroupDefault(group="output", value="default"),
+                            ConfigDefault(path="_self_"),
+                        ],
+                    ),
+                    DefaultsTreeNode(
+                        node=ConfigDefault(path="defaults_with_override_only"),
+                        children=[GroupDefault(group="group1", value="file1")],
+                    ),
+                ],
+            ),
+            id="defaults_with_override_only",
+        ),
     ],
 )
 def test_defaults_with_overrides_only(

--- a/tests/test_examples/test_patterns.py
+++ b/tests/test_examples/test_patterns.py
@@ -99,23 +99,13 @@ def test_extending_configs(
             {"db": {"name": "sqlite"}, "server": {"name": "apache", "port": 8080}},
             id="exp1+override",
         ),
-        param(
-            [
-                "--config-name=config_with_override",
-                "+experiment=nglite",
-                "server=apache",
-            ],
-            {"db": {"name": "sqlite"}, "server": {"name": "apache", "port": 8080}},
-            id="exp1+defaults_override",
-        ),
     ],
 )
 def test_configuring_experiments(
     monkeypatch: Any, tmpdir: Path, overrides: List[str], expected: Any
 ) -> None:
     monkeypatch.chdir("examples/patterns/configuring_experiments")
-    cmd = ["my_app.py"] + overrides
-    cmd.extend([f"hydra.run.dir={tmpdir}"])
+    cmd = ["my_app.py", "hydra.run.dir=" + str(tmpdir)] + overrides
     result, _err = run_python_script(cmd)
     assert OmegaConf.create(result) == expected
 

--- a/tests/test_examples/test_patterns.py
+++ b/tests/test_examples/test_patterns.py
@@ -115,7 +115,7 @@ def test_configuring_experiments(
 ) -> None:
     monkeypatch.chdir("examples/patterns/configuring_experiments")
     cmd = ["my_app.py"] + overrides
-    cmd.extend(["hydra.run.dir=" + str(tmpdir)])
+    cmd.extend([f"hydra.run.dir={tmpdir}"])
     result, _err = run_python_script(cmd)
     assert OmegaConf.create(result) == expected
 

--- a/tests/test_examples/test_patterns.py
+++ b/tests/test_examples/test_patterns.py
@@ -99,13 +99,23 @@ def test_extending_configs(
             {"db": {"name": "sqlite"}, "server": {"name": "apache", "port": 8080}},
             id="exp1+override",
         ),
+        param(
+            [
+                "--config-name=config_with_override",
+                "+experiment=nglite",
+                "server=apache",
+            ],
+            {"db": {"name": "sqlite"}, "server": {"name": "apache", "port": 8080}},
+            id="exp1+defaults_override",
+        ),
     ],
 )
 def test_configuring_experiments(
     monkeypatch: Any, tmpdir: Path, overrides: List[str], expected: Any
 ) -> None:
     monkeypatch.chdir("examples/patterns/configuring_experiments")
-    cmd = ["my_app.py", "hydra.run.dir=" + str(tmpdir)] + overrides
+    cmd = ["my_app.py"] + overrides
+    cmd.extend(["hydra.run.dir=" + str(tmpdir)])
     result, _err = run_python_script(cmd)
     assert OmegaConf.create(result) == expected
 


### PR DESCRIPTION
Closes #1548


### The bug

to repro with the examples from tutorial
```
$ git diff
diff --git a/examples/patterns/configuring_experiments/conf/config.yaml b/examples/patterns/configuring_experiments/conf/config.yaml
index 9554ce582..9077ff646 100644
--- a/examples/patterns/configuring_experiments/conf/config.yaml
+++ b/examples/patterns/configuring_experiments/conf/config.yaml
@@ -1,3 +1,4 @@
 defaults:
   - db: mysql
   - server: apache
+  - override hydra/hydra_logging: colorlog
```

Then run the application. 
```
$ python /Users/jieru/workspace/hydra-fork/hydra/examples/patterns/configuring_experiments/my_app.py +experiment=aglite
In config: Override 'hydra/hydra_logging : colorlog' is defined before 'experiment: aglite'.
Overrides must be at the end of the defaults list

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```

The exception comes from [here](https://github.com/facebookresearch/hydra/blob/4d902670cf661ef26cf14adc2da936f238e3ea2c/hydra/_internal/defaults_list.py#L362-L373).  The reason being `+experiment=aglite` is added to the end of  defaults list after the overrides (in this example, after `hydra/hydra_logging: colorlog`) but is not recognized as an override.

The fix is to update the defaults list by going through the defaults list first before calling [`_update_overrides `](https://github.com/facebookresearch/hydra/blob/master/hydra/_internal/defaults_list.py#L466-L469), if `overrides.append_group_defaults` is not empty, it means there is appending overrides from the commandline, in this case, we go through the defaults list to see if override exists, if override defaults exists, we append override right before the overrides default (so it can be overriden later), we also append the append commandline override to after the defaults override and make `override=True` which won't trigger the above exception.