### PR TITLE
Fix typo in doc

### DIFF
--- a/website/docs/patterns/configuring_experiments.md
+++ b/website/docs/patterns/configuring_experiments.md
@@ -41,7 +41,7 @@ defaults:
 <div className="col col--4">
 
 ```yaml title="db/mysql.yaml"
-name: sqlite
+name: mysql
 ```
 
 ```yaml title="server/apache.yaml"


### PR DESCRIPTION
title=`db/mysql.yaml` should have `mysql` instead of `sqlite`

<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
