### PR TITLE
process hydra.searchpath before printing defaults list

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -525,11 +525,13 @@ class ConfigLoaderImpl(ConfigLoader):
         run_mode: RunMode,
     ) -> DefaultsList:
         parser = OverridesParser.create()
+        parsed_overrides = parser.parse_overrides(overrides=overrides)
         repo = CachingConfigRepository(self.repository)
+        self._process_config_searchpath(config_name, parsed_overrides, repo)
         defaults_list = create_defaults_list(
             repo=repo,
             config_name=config_name,
-            overrides_list=parser.parse_overrides(overrides=overrides),
+            overrides_list=parsed_overrides,
             prepend_hydra=True,
             skip_missing=run_mode == RunMode.MULTIRUN,
         )

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -653,14 +653,20 @@ def test_help(
     [
         param(
             "examples/tutorials/basic/your_first_hydra_app/1_simple_cli/my_app.py",
-            ["hydra.searchpath=['pkg://fakeconf']"],
+            ["--info", "searchpath", "hydra.searchpath=['pkg://fakeconf']"],
             r".*hydra.searchpath in command-line\s+|\s+pkg://fakeconf.*",
             id="searchpath config from command-line",
         ),
         param(
             "examples/advanced/config_search_path/my_app.py",
-            [],
+            ["--info", "searchpath"],
             r".*hydra.searchpath in main\s+|\s+pkg://additonal_conf.*",
+            id="print info with searchpath config",
+        ),
+        param(
+            "examples/advanced/config_search_path/my_app.py",
+            ["--info", "all", "dataset=imagenet"],
+            r".*path:\s+/datasets/imagenet",
             id="searchpath config from config file",
         ),
     ],
@@ -668,7 +674,7 @@ def test_help(
 def test_searchpath_config(
     tmpdir: Path, script: str, overrides: List[str], expected: str
 ) -> None:
-    cmd = [script, "--info", "searchpath"]
+    cmd = [script]
     cmd.extend(overrides)
     cmd.extend(["hydra.run.dir=" + str(tmpdir)])
     result, _err = run_python_script(cmd)


### PR DESCRIPTION
Closes #1557 

Root cause:
--info calls  [compute_defaults_list](https://github.com/facebookresearch/hydra/blob/master/hydra/_internal/hydra.py#L473-L477) here
which does not update the defaults list with hydra.searchpath config.

Fix:
process hydra.searchpath config before getting defaulst list.

