### PR TITLE
Updated release process to use python -m build

### DIFF
--- a/build_helpers/build_helpers.py
+++ b/build_helpers/build_helpers.py
@@ -106,7 +106,6 @@ class CleanCommand(Command):  # type: ignore
                 ".*/multirun$",
                 ".*/outputs$",
                 "^build$",
-                "^dist$",
             ],
             scan_exclude=["^.git$", "^.nox/.*$", "^website/.*$"],
             excludes=[".*\\.gitignore$"],

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 bandit
 black==20.8b1
+build
 coverage
 flake8
 flake8-copyright

--- a/website/docs/development/overview.md
+++ b/website/docs/development/overview.md
@@ -1,7 +1,6 @@
 ---
 id: overview
-title: Overview
-sidebar_label: Overview
+title: Developer Guide Overview
 ---
 
 This guide assumes you have checked-out the [repository](https://github.com/facebookresearch/hydra).
@@ -21,7 +20,10 @@ Activate the environment:
 ```
 conda activate hydra38
 ```
-From the source tree, install Hydra in development mode with the following command:
-```
-pip install -r requirements/dev.txt -e .
+From the source tree, install Hydra in development mode with the following commands:
+```bash
+# install development dependencies
+pip install -r requirements/dev.txt
+# install Hydra in development (editable) mode
+pip install -e .
 ```

--- a/website/docs/development/release.md
+++ b/website/docs/development/release.md
@@ -9,6 +9,6 @@ The release process may be automated in the future.
 - Checkout master
 - Update the Hydra version in `hydra/__init__.py`
 - Update NEWS.md with towncrier
-- Create a pip package for hydra-core: `python setup.py sdist bdist_wheel`
+- Create a wheel and source dist for hydra-core: `python -m build`
 - Upload pip package: `python -m twine upload dist/*`
  

--- a/website/docs/development/testing.md
+++ b/website/docs/development/testing.md
@@ -4,20 +4,35 @@ title: Testing
 sidebar_label: Testing
 ---
 
-Hydra uses a test automation tool called [nox](https://github.com/theacodes/nox) to manage tests, linting, code coverage, etc.
-`nox` will run all the configured sessions. You can see the full list of nox sessions with `nox -l` and run specific sessions
-with `nox -s NAME` (you may need to quote the session name in some cases)
+Hydra uses [nox](https://github.com/theacodes/nox) - a build automation tool - to manage tests, linting, code coverage, etc.
+The command `nox` will run all the configured sessions. List the sessions using `nox -l` and 
+run specific sessions with `nox -s NAME` (you may need to quote the session name in some cases)
 
-## With pytest
+## Testing with pytest
 Run `pytest` at the repository root to run all the Hydra core tests.
-To run the tests of individual plugins, use `pytest plugins/NAME`.
+To run the tests of individual plugins, use `pytest plugins/NAME` (The plugin must be installed).
 
 :::info NOTE
 Some plugins support fewer versions of Python than the Hydra core.
 :::
 
-## With nox
+## Testing with nox
 See `nox -l`. a few examples:
 * `nox -s test_core` will test Hydra core on all supported Python versions
-* `nox -s "test_core-3.6(pip install)"` : Test on Python 3.6 with `pip install` as installation method
-* `nox -s "test_plugins-3.8(pip install -e)"` : Test plugins on Python 3.8 with `pip install -e` as installation method
+* `nox -s "test_plugins-3.8"` will test plugins on Python 3.8.
+* `nox -s "test_plugins-3.8"` will test plugins on Python 3.8.
+
+The `noxfile.py` is checking some environment variables to decide what to run. For example,
+to test a single plugin:
+```shell {4}
+$ PLUGINS=hydra_colorlog nox -s test_plugins-3.8
+Operating system        :       Linux
+NOX_PYTHON_VERSIONS     :       ['3.6', '3.7', '3.8', '3.9']
+PLUGINS                 :       ['hydra_colorlog']
+SKIP_CORE_TESTS         :       False
+FIX                     :       False
+VERBOSE                 :       0
+INSTALL_EDITABLE_MODE   :       0
+nox > Running session test_plugins-3.8
+...
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -126,7 +126,7 @@ module.exports = {
             "experimental/intro",
         ],
 
-        'Development': [
+        'Developer Guide': [
             'development/overview',
             'development/testing',
             'development/style_guide',


### PR DESCRIPTION
Switching to build with `python -m build`.

1. clean no longer cleaning the dist directory. this is conflicting with python -m build.
2. include the `build` package in the development deps.
3. updated developer guild to reflect change + some other tweaks