### PR TITLE
Add Redis SSL support ☀️ closes #1586

### DIFF
--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
@@ -74,6 +74,8 @@ def launch(
             port=rq_cfg.redis.port,
             db=rq_cfg.redis.db,
             password=rq_cfg.redis.password,
+            ssl=rq_cfg.redis.ssl,
+            ssl_ca_certs=rq_cfg.redis.ssl_ca_certs
         )
     else:
         log.info("Running in synchronous mode")

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
@@ -75,7 +75,7 @@ def launch(
             db=rq_cfg.redis.db,
             password=rq_cfg.redis.password,
             ssl=rq_cfg.redis.ssl,
-            ssl_ca_certs=rq_cfg.redis.ssl_ca_certs
+            ssl_ca_certs=rq_cfg.redis.ssl_ca_certs,
         )
     else:
         log.info("Running in synchronous mode")

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
@@ -18,7 +18,10 @@ class RedisConf:
     password: str = II("env:REDIS_PASSWORD,")
     # switch to run without redis server in single thread, for testing purposes only
     mock: bool = II("env:REDIS_MOCK,False")
-
+    # enable/disable SSL, via REDIS_SSL environment variable, default False
+    ssl: bool = II("oc.env:REDIS_SSL,False")
+    # path to custom certs, via REDIS_SSL_CA_CERTS env veriable, default none
+    ssl_ca_certs: Optional[str] = II("oc.env:REDIS_SSL_CA_CERTS,")
 
 @dataclass
 class EnqueueConf:

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
@@ -19,9 +19,9 @@ class RedisConf:
     # switch to run without redis server in single thread, for testing purposes only
     mock: bool = II("env:REDIS_MOCK,False")
     # enable/disable SSL, via REDIS_SSL environment variable, default False
-    ssl: bool = II("oc.env:REDIS_SSL,False")
+    ssl: bool = II("env:REDIS_SSL,False")
     # path to custom certs, via REDIS_SSL_CA_CERTS env veriable, default none
-    ssl_ca_certs: Optional[str] = II("oc.env:REDIS_SSL_CA_CERTS,")
+    ssl_ca_certs: Optional[str] = II("env:REDIS_SSL_CA_CERTS,")
 
 @dataclass
 class EnqueueConf:

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
@@ -23,6 +23,7 @@ class RedisConf:
     # path to custom certs, via REDIS_SSL_CA_CERTS env veriable, default none
     ssl_ca_certs: Optional[str] = II("env:REDIS_SSL_CA_CERTS,")
 
+
 @dataclass
 class EnqueueConf:
     # maximum runtime of the job before it's killed (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit


### PR DESCRIPTION
## Motivation
RQ (Redis-Queue) has support for SSL connections. This PR adds Redis SSL support to the Hydra RQ launcher plugin. See #1586.

### Have you read the [Contributing Guidelines on pull requests]
**Yes**

## Test Plan
The plugin has tests defined. This PR adds two extra [config options](https://github.com/facebookresearch/hydra/commit/cc06b7b6ed7fc81d80d7809effb255ae2ce39899#diff-76fe0d2245de177927fd8d97e8a97187958dad5d68b8a36229956312b7488604) to `RedisConf`.

## Related Issues and PRs
Closes #1586.