### PR TITLE
Hydra >= 1.1: Add Redis SSL support ☀️

### DIFF
--- a/plugins/hydra_rq_launcher/example/config_redis_ssl.yaml
+++ b/plugins/hydra_rq_launcher/example/config_redis_ssl.yaml
@@ -1,9 +1,0 @@
-defaults:
-  - override hydra/launcher: rq
-
-task: 1
-
-hydra:
-  launcher:
-    redis:
-      ssl: true

--- a/plugins/hydra_rq_launcher/example/config_redis_ssl.yaml
+++ b/plugins/hydra_rq_launcher/example/config_redis_ssl.yaml
@@ -1,0 +1,9 @@
+defaults:
+  - override hydra/launcher: rq
+
+task: 1
+
+hydra:
+  launcher:
+    redis:
+      ssl: true

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
@@ -76,6 +76,8 @@ def launch(
             port=rq_cfg.redis.port,
             db=rq_cfg.redis.db,
             password=rq_cfg.redis.password,
+            ssl=rq_cfg.redis.ssl,
+            ssl_ca_certs=rq_cfg.redis.ssl_ca_certs,
         )
     else:
         log.info("Running in synchronous mode")

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
@@ -16,12 +16,12 @@ class RedisConf:
     db: Optional[str] = II("oc.env:REDIS_DB,'0'")
     # password via REDIS_PASSWORD environment variable, default: no password
     password: Optional[str] = II("oc.env:REDIS_PASSWORD,null")
-    # switch to run without redis server in single thread, for testing purposes only
-    mock: bool = II("oc.env:REDIS_MOCK,'False'")
     # enable/disable SSL, via REDIS_SSL environment variable, default False
     ssl: bool = II("oc.env:REDIS_SSL,'False'")
     # path to custom certs, via REDIS_SSL_CA_CERTS env veriable, default none
     ssl_ca_certs: Optional[str] = II("oc.env:REDIS_SSL_CA_CERTS,null")
+    # switch to run without redis server in single thread, for testing purposes only
+    mock: bool = II("oc.env:REDIS_MOCK,'False'")
 
 
 @dataclass

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
@@ -18,6 +18,10 @@ class RedisConf:
     password: Optional[str] = II("oc.env:REDIS_PASSWORD,null")
     # switch to run without redis server in single thread, for testing purposes only
     mock: bool = II("oc.env:REDIS_MOCK,'False'")
+    # enable/disable SSL, via REDIS_SSL environment variable, default False
+    ssl: bool = II("oc.env:REDIS_SSL,'False'")
+    # path to custom certs, via REDIS_SSL_CA_CERTS env veriable, default none
+    ssl_ca_certs: Optional[str] = II("oc.env:REDIS_SSL_CA_CERTS,null")
 
 
 @dataclass

--- a/plugins/hydra_rq_launcher/news/1586.plugin
+++ b/plugins/hydra_rq_launcher/news/1586.plugin
@@ -1,1 +1,1 @@
-Add support for SSL Redis connections in the RQ launcher plugin.
+Add support for SSL Redis connections in the RQ launcher plugin

--- a/plugins/hydra_rq_launcher/news/1586.plugin
+++ b/plugins/hydra_rq_launcher/news/1586.plugin
@@ -1,1 +1,1 @@
-Added support for SSL Redis connections in the RQ launcher plugin.
+Add support for SSL Redis connections in the RQ launcher plugin.

--- a/plugins/hydra_rq_launcher/news/1586.plugin
+++ b/plugins/hydra_rq_launcher/news/1586.plugin
@@ -1,0 +1,1 @@
+Added support for SSL Redis connections in the RQ launcher plugin.

--- a/plugins/hydra_rq_launcher/tests/test_rq_launcher.py
+++ b/plugins/hydra_rq_launcher/tests/test_rq_launcher.py
@@ -47,13 +47,14 @@ class TestRQLauncherIntegration(IntegrationTestSuite):
 
 # https://github.com/rq/rq/issues/1244
 @mark.filterwarnings("ignore::DeprecationWarning")
-def test_example_app(hydra_sweep_runner: TSweepRunner) -> None:
+@mark.parametrize("config_name", ["config", "config_redis_ssl"])
+def test_example_app(hydra_sweep_runner: TSweepRunner, config_name: str) -> None:
     with hydra_sweep_runner(
         calling_file="example/my_app.py",
         calling_module=None,
         task_function=None,
         config_path=".",
-        config_name="config",
+        config_name=config_name,
         overrides=["task=1,2,3,4"],
     ) as sweep:
         overrides = {("task=1",), ("task=2",), ("task=3",), ("task=4",)}

--- a/plugins/hydra_rq_launcher/tests/test_rq_launcher.py
+++ b/plugins/hydra_rq_launcher/tests/test_rq_launcher.py
@@ -1,4 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from typing import List
+
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
 from hydra.test_utils.launcher_common_tests import (
@@ -47,15 +49,17 @@ class TestRQLauncherIntegration(IntegrationTestSuite):
 
 # https://github.com/rq/rq/issues/1244
 @mark.filterwarnings("ignore::DeprecationWarning")
-@mark.parametrize("config_name", ["config", "config_redis_ssl"])
-def test_example_app(hydra_sweep_runner: TSweepRunner, config_name: str) -> None:
+@mark.parametrize("params_overrides", [[], ["hydra.launcher.redis.ssl=true"]])
+def test_example_app(
+    hydra_sweep_runner: TSweepRunner, params_overrides: List[str]
+) -> None:
     with hydra_sweep_runner(
         calling_file="example/my_app.py",
         calling_module=None,
         task_function=None,
         config_path=".",
-        config_name=config_name,
-        overrides=["task=1,2,3,4"],
+        config_name="config",
+        overrides=["task=1,2,3,4"] + params_overrides,
     ) as sweep:
         overrides = {("task=1",), ("task=2",), ("task=3",), ("task=4",)}
 

--- a/website/docs/plugins/rq_launcher.md
+++ b/website/docs/plugins/rq_launcher.md
@@ -40,25 +40,27 @@ The default configuration is as follows:
 # @package hydra.launcher
 _target_: hydra_plugins.hydra_rq_launcher.rq_launcher.RQLauncher
 enqueue:
-  job_timeout: null                  # maximum runtime of the job before it's killed (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
-  ttl: null                          # maximum queued time before the job before is discarded (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
-  result_ttl: null                   # how long successful jobs and their results are kept (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
-  failure_ttl: null                  # specifies how long failed jobs are kept (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
-  at_front: false                    # place job at the front of the queue, instead of the back
-  job_id: null                       # job id, will be overidden automatically by a uuid unless specified explicitly
-  description: null                  # description, will be overidden automatically unless specified explicitly
-queue: default                       # queue name
+  job_timeout: null                               # maximum runtime of the job before it's killed (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
+  ttl: null                                       # maximum queued time before the job before is discarded (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
+  result_ttl: null                                # how long successful jobs and their results are kept (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
+  failure_ttl: null                               # specifies how long failed jobs are kept (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
+  at_front: false                                 # place job at the front of the queue, instead of the back
+  job_id: null                                    # job id, will be overidden automatically by a uuid unless specified explicitly
+  description: null                               # description, will be overidden automatically unless specified explicitly
+queue: default                                    # queue name
 redis:
-  host: ${oc.env:REDIS_HOST,localhost}  # host address via REDIS_HOST environment variable, default: localhost
-  port: ${oc.env:REDIS_PORT,6379}       # port via REDIS_PORT environment variable, default: 6379
-  db: ${oc.env:REDIS_DB,0}              # database via REDIS_DB environment variable, default: 0
-  password: ${oc.env:REDIS_PASSWORD,}   # password via REDIS_PASSWORD environment variable, default: no password
-  mock: ${oc.env:REDIS_MOCK,False}      # switch to run without redis server in single thread, for testing purposes only
-stop_after_enqueue: false            # stop after enqueueing by raising custom exception
-wait_polling: 1.0                    # wait time in seconds when polling results
+  host: ${oc.env:REDIS_HOST,localhost}            # host address via REDIS_HOST environment variable, default: localhost
+  port: ${oc.env:REDIS_PORT,6379}                 # port via REDIS_PORT environment variable, default: 6379
+  db: ${oc.env:REDIS_DB,0}                        # database via REDIS_DB environment variable, default: 0
+  password: ${oc.env:REDIS_PASSWORD,}             # password via REDIS_PASSWORD environment variable, default: no password    
+  ssl: ${oc.env:REDIS_SSL,False}                  # enable/disable SSL, via REDIS_SSL environment variable, default False  
+  ssl_ca_certs: ${oc.env:REDIS_SSL_CA_CERTS,null} # path to custom certs, via REDIS_SSL_CA_CERTS env veriable, default none
+  mock: ${oc.env:REDIS_MOCK,False}                # switch to run without redis server in single thread, for testing purposes only
+stop_after_enqueue: false                         # stop after enqueueing by raising custom exception
+wait_polling: 1.0                                 # wait time in seconds when polling results
 ```
 
-The plugin is using environment variables to store Redis connection information. The environment variables `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, and `REDIS_PASSWORD`, are used for the host address, port, database, and password of the server, respectively.
+The plugin is using environment variables to store Redis connection information. The environment variables `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, and `REDIS_PASSWORD`, are used for the host address, port, database, and password of the server, respectively. Support for Redis SSL connections is controlled through `REDIS_SSL` and `REDIS_SSL_CA_CERTS`; see [redis-py](https://github.com/andymccurdy/redis-py#ssl-connections) documentation.
 
 For example, they might be set as follows when using `bash` or `zsh` as a shell:
 
@@ -67,6 +69,12 @@ export REDIS_HOST="localhost"
 export REDIS_PORT="6379"
 export REDIS_DB="0"
 export REDIS_PASSWORD=""
+```
+
+SSL can be enabled like so:
+```commandline
+export REDIS_SSL="True"
+export REDIS_SSL_CA_CERTS="/etc/ssl/certs/ca-certificates.crt"
 ```
 
 Assuming configured environment variables, workers connecting to the Redis server can be launched using:

--- a/website/docs/plugins/rq_launcher.md
+++ b/website/docs/plugins/rq_launcher.md
@@ -32,33 +32,33 @@ defaults:
   - override hydra/launcher: rq
 ```
 
-The configuration packaged with the plugin is defined <GithubLink to="plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py">here</GithubLink>.
-There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins) for more information.
 The default configuration is as follows:
 
 ```yaml title="$ python your_app.py hydra/launcher=rq --cfg hydra -p hydra.launcher"
 # @package hydra.launcher
 _target_: hydra_plugins.hydra_rq_launcher.rq_launcher.RQLauncher
 enqueue:
-  job_timeout: null                               # maximum runtime of the job before it's killed (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
-  ttl: null                                       # maximum queued time before the job before is discarded (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
-  result_ttl: null                                # how long successful jobs and their results are kept (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
-  failure_ttl: null                               # specifies how long failed jobs are kept (e.g. "1d" for 1 day, units: d/h/m/s), default: no limit
-  at_front: false                                 # place job at the front of the queue, instead of the back
-  job_id: null                                    # job id, will be overidden automatically by a uuid unless specified explicitly
-  description: null                               # description, will be overidden automatically unless specified explicitly
-queue: default                                    # queue name
+  job_timeout: null
+  ttl: null
+  result_ttl: null
+  failure_ttl: null
+  at_front: false
+  job_id: null
+  description: null
+queue: default 
 redis:
-  host: ${oc.env:REDIS_HOST,localhost}            # host address via REDIS_HOST environment variable, default: localhost
-  port: ${oc.env:REDIS_PORT,6379}                 # port via REDIS_PORT environment variable, default: 6379
-  db: ${oc.env:REDIS_DB,0}                        # database via REDIS_DB environment variable, default: 0
-  password: ${oc.env:REDIS_PASSWORD,}             # password via REDIS_PASSWORD environment variable, default: no password    
-  ssl: ${oc.env:REDIS_SSL,False}                  # enable/disable SSL, via REDIS_SSL environment variable, default False  
-  ssl_ca_certs: ${oc.env:REDIS_SSL_CA_CERTS,null} # path to custom certs, via REDIS_SSL_CA_CERTS env veriable, default none
-  mock: ${oc.env:REDIS_MOCK,False}                # switch to run without redis server in single thread, for testing purposes only
-stop_after_enqueue: false                         # stop after enqueueing by raising custom exception
-wait_polling: 1.0                                 # wait time in seconds when polling results
+  host: ${oc.env:REDIS_HOST,localhost}
+  port: ${oc.env:REDIS_PORT,6379}
+  db: ${oc.env:REDIS_DB,0}
+  password: ${oc.env:REDIS_PASSWORD,null}
+  ssl: ${oc.env:REDIS_SSL,False}
+  ssl_ca_certs: ${oc.env:REDIS_SSL_CA_CERTS,null
+  mock: ${oc.env:REDIS_MOCK,False}
+stop_after_enqueue: false
+wait_polling: 1.0
 ```
+
+Further descriptions on the variables can be found in the plugin config file, defined <GithubLink to="plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py">here</GithubLink>. There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins) for more information.
 
 The plugin is using environment variables to store Redis connection information. The environment variables `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, and `REDIS_PASSWORD`, are used for the host address, port, database, and password of the server, respectively. Support for Redis SSL connections is controlled through `REDIS_SSL` and `REDIS_SSL_CA_CERTS`; see [redis-py](https://github.com/andymccurdy/redis-py#ssl-connections) documentation.
 
@@ -71,10 +71,10 @@ export REDIS_DB="0"
 export REDIS_PASSWORD=""
 ```
 
-SSL can be enabled like so:
+Enable SSL by setting the relevant environment variables. e.g:
 ```commandline
-export REDIS_SSL="True"
-export REDIS_SSL_CA_CERTS="/etc/ssl/certs/ca-certificates.crt"
+export REDIS_SSL=true
+export REDIS_SSL_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 ```
 
 Assuming configured environment variables, workers connecting to the Redis server can be launched using:


### PR DESCRIPTION
## Motivation
> This is the Hydra >= 1.1 version of PR #1587.

RQ (Redis-Queue) has support for SSL connections. This PR adds Redis SSL support to the Hydra RQ launcher plugin. See #1586. This PR applies to Hydra >= 1.1.

### Have you read the [Contributing Guidelines on pull requests]
**Yes**

## Test Plan
The plugin has tests defined. This PR adds two extra config options to `RedisConf`.

## Related Issues and PRs
Closes #1586.