### PR TITLE
Quoted values are not valid dictionary keys anymore

### DIFF
--- a/hydra/grammar/OverrideParser.g4
+++ b/hydra/grammar/OverrideParser.g4
@@ -67,13 +67,12 @@ primitive:
 
 // Same as `primitive` except that `COLON` and `INTERPOLATION` are not allowed.
 dictKey:
-      QUOTED_VALUE                               // 'hello world', "hello world"
-    | (   ID                                     // foo_10
-        | NULL                                   // null, NULL
-        | INT                                    // 0, 10, -20, 1_000_000
-        | FLOAT                                  // 3.14, -20.0, 1e-1, -10e3
-        | BOOL                                   // true, TrUe, false, False
-        | UNQUOTED_CHAR                          // /, -, \, +, ., $, %, *, @
-        | ESC                                    // \\, \(, \), \[, \], \{, \}, \:, \=, \ , \\t, \,
-        | WS                                     // whitespaces
+    (   ID                                     // foo_10
+      | NULL                                   // null, NULL
+      | INT                                    // 0, 10, -20, 1_000_000
+      | FLOAT                                  // 3.14, -20.0, 1e-1, -10e3
+      | BOOL                                   // true, TrUe, false, False
+      | UNQUOTED_CHAR                          // /, -, \, +, ., $, %, *, @
+      | ESC                                    // \\, \(, \), \[, \], \{, \}, \:, \=, \ , \\t, \,
+      | WS                                     // whitespaces
     )+;


### PR DESCRIPTION
This is to match OmegaConf's behavior as of https://github.com/omry/omegaconf/pull/695

There is no corresponding issue / news item for Hydra since quoted dictionary keys were not allowed in Hydra 1.0.