### PR TITLE
Fix escaping in quoted values

### DIFF
--- a/hydra/_internal/grammar/utils.py
+++ b/hydra/_internal/grammar/utils.py
@@ -11,6 +11,13 @@ _ESC = "\\()[]{}:=, \t"
 # Regular expression that matches any sequence of characters in `_ESC`.
 _ESC_REGEX = re.compile(f"[{re.escape(_ESC)}]+")
 
+# Regular expression that matches \ that must be escaped in a quoted string, i.e.,
+# any number of \ followed by a quote.
+_ESC_QUOTED_STR = {
+    "'": re.compile(r"(\\)+'"),  # single quote
+    '"': re.compile(r'(\\)+"'),  # double quote
+}
+
 
 def escape_special_characters(s: str) -> str:
     """Escape special characters in `s`"""

--- a/hydra/core/override_parser/overrides_visitor.py
+++ b/hydra/core/override_parser/overrides_visitor.py
@@ -309,13 +309,16 @@ class HydraOverrideVisitor(OverrideParserVisitor):  # type: ignore
         return ret
 
     def _unescape_quoted_string(self, text: str) -> str:
-        """
-        Unescape a quoted string, by looking at backslashes that either:
-            * precede a quote, or
-            * end the string content
+        r"""
+        Unescape a quoted string, by looking at \ that precede a quote.
 
         The input string should contain enclosing quotes, which are stripped away
         by this function.
+
+        Due to the grammar definition of quoted strings, it is assumed that:
+            * if there are \ preceding the closing quote, their number must be even
+            * if there are \ preceding a quote in the middle of the string, their
+              number must be odd
 
         Examples (with double quotes, but the same logic applies to single quotes):
             * "abc\"def"    -> abc"def
@@ -337,7 +340,7 @@ class HydraOverrideVisitor(OverrideParserVisitor):  # type: ignore
             # Add characters before the escaped sequence.
             tokens.append(text[0:start])
             # Un-escaping. Note that this works both for escaped quotes in the middle of
-            # a string, as well as trailing backslashes:
+            # a string, as well as trailing backslashes where the end quote is stripped:
             #   \"    -> "  (escaped quote in the middle)
             #   \\"   -> \  (escaped trailing backslash)
             #   \\\"  -> \" (escaped backslash followed by escaped quote in the middle)
@@ -348,9 +351,9 @@ class HydraOverrideVisitor(OverrideParserVisitor):  # type: ignore
             text = text[stop:]
             match = pattern.search(text)
 
-        if text:
+        if len(text) > 1:
             # Add characters after the last match, removing the end quote.
-            tokens.append(text[:-1])
+            tokens.append(text[0:-1])
 
         return "".join(tokens)
 

--- a/hydra/core/override_parser/overrides_visitor.py
+++ b/hydra/core/override_parser/overrides_visitor.py
@@ -240,6 +240,42 @@ class HydraOverrideVisitor(OverrideParserVisitor):  # type: ignore
                 f"{type(e).__name__} while evaluating '{ctx.getText()}': {e}"
             ) from e
 
+    def visitQuotedValue(self, ctx: OverrideParser.QuotedValueContext) -> QuotedString:
+        children = list(ctx.getChildren())
+        assert len(children) >= 2
+
+        # Identity quote type.
+        first_quote = children[0].getText()
+        if first_quote == "'":
+            quote = Quote.single
+        else:
+            assert first_quote == '"'
+            quote = Quote.double
+
+        # Inspect string content.
+        tokens = []
+        is_interpolation = False
+        for child in children[1:-1]:
+            assert isinstance(child, TerminalNode)
+            symbol = child.symbol
+            text = symbol.text
+            if symbol.type == OverrideLexer.ESC_QUOTE:
+                # Always un-escape quotes.
+                text = text[1]
+            elif symbol.type == OverrideLexer.INTERPOLATION:
+                is_interpolation = True
+            tokens.append(text)
+
+        # Contactenate string fragments.
+        ret = "".join(tokens)
+
+        # If it is an interpolation, then OmegaConf will take care of un-escaping
+        # the `\\`. But if it is not, then we need to do it here.
+        if not is_interpolation:
+            ret = ret.replace("\\\\", "\\")
+
+        return QuotedString(text=ret, quote=quote, esc_backslash=not is_interpolation)
+
     def _createPrimitive(
         self, ctx: ParserRuleContext
     ) -> Optional[Union[QuotedString, int, bool, float, str]]:
@@ -274,19 +310,8 @@ class HydraOverrideVisitor(OverrideParserVisitor):  # type: ignore
             ret = "".join(tokens)
         else:
             node = ctx.getChild(first_idx)
-            if node.symbol.type == OverrideLexer.QUOTED_VALUE:
-                text = node.getText()
-                qc = text[0]
-                text = text[1:-1]
-                if qc == "'":
-                    quote = Quote.single
-                    text = text.replace("\\'", "'")
-                elif qc == '"':
-                    quote = Quote.double
-                    text = text.replace('\\"', '"')
-                else:
-                    assert False
-                return QuotedString(text=text, quote=quote)
+            if isinstance(node, OverrideParser.QuotedValueContext):
+                return self.visitQuotedValue(node)
             elif node.symbol.type in (OverrideLexer.ID, OverrideLexer.INTERPOLATION):
                 ret = node.symbol.text
             elif node.symbol.type == OverrideLexer.INT:

--- a/hydra/core/override_parser/types.py
+++ b/hydra/core/override_parser/types.py
@@ -26,13 +26,12 @@ class Quote(Enum):
 @dataclass(frozen=True)
 class QuotedString:
     text: str
+
     quote: Quote
-    esc_backslash: bool = True
 
     def with_quotes(self) -> str:
-        text = self.text
-        if self.esc_backslash:
-            text = text.replace("\\", "\\\\")
+        # Both quotes and backslashes need to be escaped.
+        text = self.text.replace("\\", "\\\\")
         if self.quote == Quote.single:
             q = "'"
             text = text.replace("'", "\\'")

--- a/hydra/core/override_parser/types.py
+++ b/hydra/core/override_parser/types.py
@@ -26,16 +26,19 @@ class Quote(Enum):
 @dataclass(frozen=True)
 class QuotedString:
     text: str
-
     quote: Quote
+    esc_backslash: bool = True
 
     def with_quotes(self) -> str:
+        text = self.text
+        if self.esc_backslash:
+            text = text.replace("\\", "\\\\")
         if self.quote == Quote.single:
             q = "'"
-            text = self.text.replace("'", "\\'")
+            text = text.replace("'", "\\'")
         elif self.quote == Quote.double:
             q = '"'
-            text = self.text.replace('"', '\\"')
+            text = text.replace('"', '\\"')
         else:
             assert False
         return f"{q}{text}{q}"

--- a/hydra/core/override_parser/types.py
+++ b/hydra/core/override_parser/types.py
@@ -31,7 +31,7 @@ class QuotedString:
 
     def with_quotes(self) -> str:
         qc = "'" if self.quote == Quote.single else '"'
-        esc_qc = f"\\{qc}"
+        esc_qc = rf"\{qc}"
 
         match = None
         if "\\" in self.text:
@@ -62,7 +62,7 @@ class QuotedString:
             text = text[stop:]
             match = pattern.search(text)
 
-        if text:
+        if len(text) > 1:
             tokens.append(text[0:-1])  # remaining characters without the end quote
 
         # Concatenate all fragments and escape quotes.

--- a/hydra/core/override_parser/types.py
+++ b/hydra/core/override_parser/types.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Union, ca
 from omegaconf import OmegaConf
 from omegaconf._utils import is_structured_config
 
-from hydra._internal.grammar.utils import escape_special_characters
+from hydra._internal.grammar.utils import _ESC_QUOTED_STR, escape_special_characters
 from hydra.core.config_loader import ConfigLoader
 from hydra.core.object_type import ObjectType
 from hydra.errors import HydraException
@@ -30,17 +30,46 @@ class QuotedString:
     quote: Quote
 
     def with_quotes(self) -> str:
-        # Both quotes and backslashes need to be escaped.
-        text = self.text.replace("\\", "\\\\")
-        if self.quote == Quote.single:
-            q = "'"
-            text = text.replace("'", "\\'")
-        elif self.quote == Quote.double:
-            q = '"'
-            text = text.replace('"', '\\"')
-        else:
-            assert False
-        return f"{q}{text}{q}"
+        qc = "'" if self.quote == Quote.single else '"'
+        esc_qc = f"\\{qc}"
+
+        match = None
+        if "\\" in self.text:
+            text = self.text + qc  # add the closing quote
+            # Are there \ preceding a quote (including the closing one)?
+            pattern = _ESC_QUOTED_STR[qc]
+            match = pattern.search(text)
+
+        if match is None:
+            # Simple case: we only need to escape the quotes.
+            esc_text = self.text.replace(qc, esc_qc)
+            return f"{qc}{esc_text}{qc}"
+
+        # Escape the \ preceding a quote.
+        tokens = []
+        while match is not None:
+            start, stop = match.span()
+            # Add characters before the sequence to escape.
+            tokens.append(text[0:start])
+            # Escape the \ (we double the number of backslashes, which is equal to
+            # the length of the matched pattern, minus one for the quote).
+            new_n_backslashes = (stop - start - 1) * 2
+            tokens.append("\\" * new_n_backslashes)
+            if stop < len(text):
+                # We only append the matched quote if it is not the closing quote
+                # (because we will add back the closing quote in the final step).
+                tokens.append(qc)
+            text = text[stop:]
+            match = pattern.search(text)
+
+        if text:
+            tokens.append(text[0:-1])  # remaining characters without the end quote
+
+        # Concatenate all fragments and escape quotes.
+        esc_text = "".join(tokens).replace(qc, esc_qc)
+
+        # Finally add the enclosing quotes.
+        return f"{qc}{esc_text}{qc}"
 
 
 @dataclass

--- a/hydra/grammar/OverrideLexer.g4
+++ b/hydra/grammar/OverrideLexer.g4
@@ -71,14 +71,14 @@ WS: [ \t]+;
 // A quoted value is made of the enclosing quotes, and either:
 //   - nothing else
 //   - an even number of backslashes (meaning they are escaped)
-//   - a sequence of any character, followed by any non-backslash character, and optionally
-//     an even number of backslashes (i.e., also escaped)
+//   - an optional sequence of any character, followed by any non-backslash character,
+//     and optionally an even number of backslashes (i.e., also escaped)
 // Examples (right hand side: expected content of the resulting string, after un-escaping):
-//    ""                    -> <empty>
-//    '\\'                  -> \
-//    "\\\\"                -> \\
-//    'abc\\'               -> abc\
-//    "abc\"def\\\'ghi\\\\" -> abc"def\\\'ghi\\
+//    ""                      -> <empty>
+//    '\\'                    -> \
+//    "\\\\"                  -> \\
+//    'abc\\'                 -> abc\
+//    "abc\\\"def\\\'ghi\\\\" -> abc\"def\\\'ghi\\
 QUOTED_VALUE:
       '"' (('\\\\')* | (.)*? ~[\\] ('\\\\')*) '"'     // double quotes
     | '\'' (('\\\\')* | (.)*? ~[\\] ('\\\\')*) '\'';  // single quotes

--- a/hydra/grammar/OverrideLexer.g4
+++ b/hydra/grammar/OverrideLexer.g4
@@ -34,9 +34,6 @@ DOT_PATH: (KEY_SPECIAL | INT_UNSIGNED) ('.' (KEY_SPECIAL | INT_UNSIGNED))+;
 
 mode VALUE_MODE;
 
-QUOTE_OPEN_SINGLE: '\'' -> pushMode(QUOTED_SINGLE_MODE);
-QUOTE_OPEN_DOUBLE: '"' -> pushMode(QUOTED_DOUBLE_MODE);
-
 POPEN: WS? '(' WS?;  // whitespaces before to allow `func (x)`
 COMMA: WS? ',' WS?;
 PCLOSE: WS? ')';
@@ -69,39 +66,7 @@ ID: (CHAR|'_') (CHAR|DIGIT|'_')*;
 ESC: (ESC_BACKSLASH | '\\(' | '\\)' | '\\[' | '\\]' | '\\{' | '\\}' |
       '\\:' | '\\=' | '\\,' | '\\ ' | '\\\t')+;
 WS: [ \t]+;
-
+QUOTED_VALUE:
+      '"' (('\\\\')* | (.)*? ~[\\] ('\\\\')*) '"'     // double quotes
+    | '\'' (('\\\\')* | (.)*? ~[\\] ('\\\\')*) '\'';  // single quotes
 INTERPOLATION: '${' ~('}')+ '}';
-
-
-////////////////////////
-// QUOTED_SINGLE_MODE //
-////////////////////////
-
-mode QUOTED_SINGLE_MODE;
-
-MATCHING_QUOTE_CLOSE: '\'' -> popMode;
-
-ESC_QUOTE: '\\\'';
-QSINGLE_ESC_BACKSLASH: ESC_BACKSLASH -> type(ESC);
-
-QSINGLE_INTERPOLATION: INTERPOLATION -> type(INTERPOLATION);
-SPECIAL_CHAR: [\\$];
-ANY_STR: ~['\\$]+;
-
-
-////////////////////////
-// QUOTED_DOUBLE_MODE //
-////////////////////////
-
-mode QUOTED_DOUBLE_MODE;
-
-// Same as `QUOTED_SINGLE_MODE` but for double quotes.
-
-QDOUBLE_CLOSE: '"' -> type(MATCHING_QUOTE_CLOSE), popMode;
-
-QDOUBLE_ESC_QUOTE: '\\"' -> type(ESC_QUOTE);
-QDOUBLE_ESC_BACKSLASH: ESC_BACKSLASH -> type(ESC);
-
-QDOUBLE_INTERPOLATION: INTERPOLATION -> type(INTERPOLATION);
-QDOUBLE_SPECIAL_CHAR: SPECIAL_CHAR -> type(SPECIAL_CHAR);
-QDOUBLE_STR: ~["\\$]+ -> type(ANY_STR);

--- a/hydra/grammar/OverrideLexer.g4
+++ b/hydra/grammar/OverrideLexer.g4
@@ -66,7 +66,21 @@ ID: (CHAR|'_') (CHAR|DIGIT|'_')*;
 ESC: (ESC_BACKSLASH | '\\(' | '\\)' | '\\[' | '\\]' | '\\{' | '\\}' |
       '\\:' | '\\=' | '\\,' | '\\ ' | '\\\t')+;
 WS: [ \t]+;
+
+// Quoted values for both types of quotes.
+// A quoted value is made of the enclosing quotes, and either:
+//   - nothing else
+//   - an even number of backslashes (meaning they are escaped)
+//   - a sequence of any character, followed by any non-backslash character, and optionally
+//     an even number of backslashes (i.e., also escaped)
+// Examples (right hand side: expected content of the resulting string, after un-escaping):
+//    ""                    -> <empty>
+//    '\\'                  -> \
+//    "\\\\"                -> \\
+//    'abc\\'               -> abc\
+//    "abc\"def\\\'ghi\\\\" -> abc"def\\\'ghi\\
 QUOTED_VALUE:
       '"' (('\\\\')* | (.)*? ~[\\] ('\\\\')*) '"'     // double quotes
     | '\'' (('\\\\')* | (.)*? ~[\\] ('\\\\')*) '\'';  // single quotes
+
 INTERPOLATION: '${' ~('}')+ '}';

--- a/hydra/grammar/OverrideLexer.g4
+++ b/hydra/grammar/OverrideLexer.g4
@@ -34,6 +34,9 @@ DOT_PATH: (KEY_SPECIAL | INT_UNSIGNED) ('.' (KEY_SPECIAL | INT_UNSIGNED))+;
 
 mode VALUE_MODE;
 
+QUOTE_OPEN_SINGLE: '\'' -> pushMode(QUOTED_SINGLE_MODE);
+QUOTE_OPEN_DOUBLE: '"' -> pushMode(QUOTED_DOUBLE_MODE);
+
 POPEN: WS? '(' WS?;  // whitespaces before to allow `func (x)`
 COMMA: WS? ',' WS?;
 PCLOSE: WS? ')';
@@ -67,8 +70,38 @@ ESC: (ESC_BACKSLASH | '\\(' | '\\)' | '\\[' | '\\]' | '\\{' | '\\}' |
       '\\:' | '\\=' | '\\,' | '\\ ' | '\\\t')+;
 WS: [ \t]+;
 
-QUOTED_VALUE:
-      '\'' ('\\\''|.)*? '\'' // Single quotes, can contain escaped single quote : /'
-    | '"' ('\\"'|.)*? '"' ;  // Double quotes, can contain escaped double quote : /"
-
 INTERPOLATION: '${' ~('}')+ '}';
+
+
+////////////////////////
+// QUOTED_SINGLE_MODE //
+////////////////////////
+
+mode QUOTED_SINGLE_MODE;
+
+MATCHING_QUOTE_CLOSE: '\'' -> popMode;
+
+ESC_QUOTE: '\\\'';
+QSINGLE_ESC_BACKSLASH: ESC_BACKSLASH -> type(ESC);
+
+QSINGLE_INTERPOLATION: INTERPOLATION -> type(INTERPOLATION);
+SPECIAL_CHAR: [\\$];
+ANY_STR: ~['\\$]+;
+
+
+////////////////////////
+// QUOTED_DOUBLE_MODE //
+////////////////////////
+
+mode QUOTED_DOUBLE_MODE;
+
+// Same as `QUOTED_SINGLE_MODE` but for double quotes.
+
+QDOUBLE_CLOSE: '"' -> type(MATCHING_QUOTE_CLOSE), popMode;
+
+QDOUBLE_ESC_QUOTE: '\\"' -> type(ESC_QUOTE);
+QDOUBLE_ESC_BACKSLASH: ESC_BACKSLASH -> type(ESC);
+
+QDOUBLE_INTERPOLATION: INTERPOLATION -> type(INTERPOLATION);
+QDOUBLE_SPECIAL_CHAR: SPECIAL_CHAR -> type(SPECIAL_CHAR);
+QDOUBLE_STR: ~["\\$]+ -> type(ANY_STR);

--- a/hydra/grammar/OverrideParser.g4
+++ b/hydra/grammar/OverrideParser.g4
@@ -51,8 +51,14 @@ dictKeyValuePair: dictKey COLON element;
 
 // Primitive types.
 
+// Ex: "hello world", 'hello ${world}'
+quotedValue:
+    (QUOTE_OPEN_SINGLE | QUOTE_OPEN_DOUBLE)
+    (INTERPOLATION | ESC | ESC_QUOTE | SPECIAL_CHAR | ANY_STR)*
+    MATCHING_QUOTE_CLOSE;
+
 primitive:
-      QUOTED_VALUE                               // 'hello world', "hello world"
+      quotedValue                               // 'hello world', "hello world"
     | (   ID                                     // foo_10
         | NULL                                   // null, NULL
         | INT                                    // 0, 10, -20, 1_000_000

--- a/hydra/grammar/OverrideParser.g4
+++ b/hydra/grammar/OverrideParser.g4
@@ -51,14 +51,8 @@ dictKeyValuePair: dictKey COLON element;
 
 // Primitive types.
 
-// Ex: "hello world", 'hello ${world}'
-quotedValue:
-    (QUOTE_OPEN_SINGLE | QUOTE_OPEN_DOUBLE)
-    (INTERPOLATION | ESC | ESC_QUOTE | SPECIAL_CHAR | ANY_STR)*
-    MATCHING_QUOTE_CLOSE;
-
 primitive:
-      quotedValue                               // 'hello world', "hello world"
+      QUOTED_VALUE                               // 'hello world', "hello world"
     | (   ID                                     // foo_10
         | NULL                                   // null, NULL
         | INT                                    // 0, 10, -20, 1_000_000

--- a/news/1600.api_change
+++ b/news/1600.api_change
@@ -1,1 +1,1 @@
-The override grammar now requires that, in quoted strings, any sequence of \ preceding a (possibly escaped) quote must be escaped
+The override grammar now requires that, in quoted strings, any sequence of \ preceding a quote (either an escaped quote or the closing quote) must be escaped

--- a/news/1600.api_change
+++ b/news/1600.api_change
@@ -1,1 +1,1 @@
-The override grammar now un-escapes \\ into \ in quoted strings
+The override grammar now requires that, in quoted strings, any sequence of \ preceding a (possibly escaped) quote must be escaped

--- a/news/1600.api_change
+++ b/news/1600.api_change
@@ -1,0 +1,1 @@
+The override grammar now un-escapes \\ into \ in quoted strings

--- a/news/1600.bugfix
+++ b/news/1600.bugfix
@@ -1,0 +1,1 @@
+Fix edge cases where using the command line to set a key to a value containing a string ending with a backslash would crash

--- a/news/1600.bugfix
+++ b/news/1600.bugfix
@@ -1,1 +1,1 @@
-Fix edge cases where using the command line to set a key to a value containing a string ending with a backslash would crash
+Fix edge cases where using the command line to set a key to a value containing a string ending with a backslash could crash

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -772,7 +772,7 @@ def test_key(value: str, expected: Any) -> None:
         param(
             r"'a \\\'${b}\\\''",
             QuotedString(text=r"a \'${b}\'", quote=Quote.single),
-            id="value:backaslash_quotes_and_interpolation:quoted",
+            id="value:backslash_quotes_and_interpolation:quoted",
         ),
         param(
             r"'${foo:\'b,a,r\'}'",

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -464,15 +464,13 @@ def test_interval_sweep(value: str, expected: Any) -> None:
         param(
             "override",
             "key=[1,2,3]'",
-            raises(
-                HydraException, match=re.escape("extraneous input ''' expecting <EOF>")
-            ),
+            raises(HydraException, match=re.escape("token recognition error at: '''")),
             id="error:left_overs",
         ),
         param(
             "dictContainer",
             "{'0a': 0, \"1b\": 1}",
-            raises(HydraException, match=re.escape("mismatched input '''")),
+            raises(HydraException, match=re.escape("mismatched input ''0a''")),
             id="error:dict_quoted_key_dictContainer",
         ),
         param(
@@ -480,7 +478,7 @@ def test_interval_sweep(value: str, expected: Any) -> None:
             "key={' abc ': 0}",
             raises(
                 HydraException,
-                match=re.escape("no viable alternative at input '{''"),
+                match=re.escape("no viable alternative at input '{' abc ''"),
             ),
             id="error:dict_quoted_key_override_single",
         ),
@@ -489,7 +487,7 @@ def test_interval_sweep(value: str, expected: Any) -> None:
             'key={" abc ": 0}',
             raises(
                 HydraException,
-                match=re.escape("""no viable alternative at input '{"'"""),
+                match=re.escape("""no viable alternative at input '{" abc "'"""),
             ),
             id="error:dict_quoted_key_override_double",
         ),
@@ -728,37 +726,27 @@ def test_key(value: str, expected: Any) -> None:
         ),
         param(
             "'a ${b}'",
-            QuotedString(text="a ${b}", quote=Quote.single, esc_backslash=False),
+            QuotedString(text="a ${b}", quote=Quote.single),
             id="value:interpolation:quoted",
         ),
         param(
-            r"'a \${b}'",
-            QuotedString(text=r"a \${b}", quote=Quote.single, esc_backslash=False),
-            id="value:esc_interpolation:quoted",
-        ),
-        param(
             r"'a \\${b}'",
-            QuotedString(text=r"a \\${b}", quote=Quote.single, esc_backslash=False),
+            QuotedString(text=r"a \${b}", quote=Quote.single),
             id="value:backslash_and_interpolation:quoted",
         ),
         param(
             r"'a \'${b}\''",
-            QuotedString(text=r"a '${b}'", quote=Quote.single, esc_backslash=False),
+            QuotedString(text=r"a '${b}'", quote=Quote.single),
             id="value:quotes_and_interpolation:quoted",
         ),
         param(
-            r"'a \'\${b}\''",
-            QuotedString(text=r"a '\${b}'", quote=Quote.single, esc_backslash=False),
-            id="value:quotes_and_esc_interpolation:quoted",
-        ),
-        param(
             r"'a \'\\${b}\''",
-            QuotedString(text=r"a '\\${b}'", quote=Quote.single, esc_backslash=False),
+            QuotedString(text=r"a '\${b}'", quote=Quote.single),
             id="value:quotes_backslash_and_interpolation:quoted",
         ),
         param(
             r"'a \\\'${b}\\\''",
-            QuotedString(text=r"a \\'${b}\\'", quote=Quote.single, esc_backslash=False),
+            QuotedString(text=r"a \'${b}\'", quote=Quote.single),
             id="value:backaslash_quotes_and_interpolation:quoted",
         ),
         # interpolations:
@@ -791,6 +779,18 @@ def test_primitive(value: str, expected: Any) -> None:
             QuotedString(text=r"foo\bar", quote=Quote.double),
             r'"foo\\bar"',
             id="value:one_backslash_double",
+        ),
+        param(
+            r"'a \${b}'",
+            QuotedString(text=r"a \${b}", quote=Quote.single),
+            r"'a \\${b}'",
+            id="value:esc_interpolation:quoted",
+        ),
+        param(
+            r"'a \'\${b}\''",
+            QuotedString(text=r"a '\${b}'", quote=Quote.single),
+            r"'a \'\\${b}\''",
+            id="value:quotes_and_esc_interpolation:quoted",
         ),
     ],
 )

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -774,6 +774,23 @@ def test_key(value: str, expected: Any) -> None:
             QuotedString(text=r"a \'${b}\'", quote=Quote.single),
             id="value:backaslash_quotes_and_interpolation:quoted",
         ),
+        param(
+            r"'${foo:\'b,a,r\'}'",
+            QuotedString(text="${foo:'b,a,r'}", quote=Quote.single),
+            id="value:interpolation_with_quoted_string:quoted",
+        ),
+        param(
+            r"""'${foo:${a}, \'\${bar}\\\'\', {x: "${y}"}}'""",
+            QuotedString(
+                text=r"""${foo:${a}, '\${bar}\'', {x: "${y}"}}""", quote=Quote.single
+            ),
+            id="value:nested_interpolation:quoted",
+        ),
+        param(
+            r"""'${foo:"\' }"}'""",
+            QuotedString(text=r"""${foo:"' }"}""", quote=Quote.single),
+            id="value:interpolation_apparent_brace_mismatch:quoted",
+        ),
         # interpolations:
         param("${a}", "${a}", id="primitive:interpolation"),
         param("${a.b.c}", "${a.b.c}", id="primitive:interpolation"),

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -626,183 +626,6 @@ def test_key(value: str, expected: Any) -> None:
         # bool
         param("true", True, id="primitive:bool"),
         param("false", False, id="primitive:bool"),
-        # quoted string
-        param(
-            r"'foo \'bar'",
-            QuotedString(text="foo 'bar", quote=Quote.single),
-            id="value:escape_single_quote",
-        ),
-        param(
-            r'"foo \"bar"',
-            QuotedString(text='foo "bar', quote=Quote.double),
-            id="value:escape_double_quote",
-        ),
-        param(
-            r"'foo \\\'bar'",
-            QuotedString(text=r"foo \'bar", quote=Quote.single),
-            id="value:escape_single_quote_x3",
-        ),
-        param(
-            r'"foo \\\"bar"',
-            QuotedString(text=r"foo \"bar", quote=Quote.double),
-            id="value:escape_double_quote_x3",
-        ),
-        param(
-            r"'foo\bar'",
-            QuotedString(text=r"foo\bar", quote=Quote.single),
-            id="value:one_backslash_single",
-        ),
-        param(
-            r'"foo\bar"',
-            QuotedString(text=r"foo\bar", quote=Quote.double),
-            id="value:one_backslash_double",
-        ),
-        param(
-            r"'foo\\bar'",
-            QuotedString(text=r"foo\\bar", quote=Quote.single),
-            id="value:noesc_backslash",
-        ),
-        param(
-            r"'foo\\\\bar'",
-            QuotedString(text=r"foo\\\\bar", quote=Quote.single),
-            id="value:noesc_backslash_x4",
-        ),
-        param(
-            r"'foo bar\\'",
-            # Note: raw strings do not allow trailing \, adding a space and stripping it.
-            QuotedString(text=r" foo bar\ ".strip(), quote=Quote.single),
-            id="value:escape_backslash_trailing",
-        ),
-        param(
-            r"'foo \\\\\'bar\' \\\\\\'",
-            QuotedString(text=r" foo \\'bar' \\\ ".strip(), quote=Quote.single),
-            id="value:escape_mixed",
-        ),
-        param(
-            "'\t []{},=+~'",
-            QuotedString(text="\t []{},=+~", quote=Quote.single),
-            id="value:quoted_specials",
-        ),
-        param(
-            '"\t []{},=+~"',
-            QuotedString(text="\t []{},=+~", quote=Quote.double),
-            id="value:quoted_specials",
-        ),
-        param(
-            "'a b c'",
-            QuotedString(text="a b c", quote=Quote.single),
-            id="value:quoted_with_whitespace",
-        ),
-        param(
-            "'a,b'",
-            QuotedString(text="a,b", quote=Quote.single),
-            id="value:quoted_with_comma",
-        ),
-        param(
-            "'[1,2,3]'",
-            QuotedString(text="[1,2,3]", quote=Quote.single),
-            id="value:quoted_list",
-        ),
-        param(
-            '"[1,2,3]"',
-            QuotedString(text="[1,2,3]", quote=Quote.double),
-            id="value:quoted_list",
-        ),
-        param(
-            "\"[1,'2',3]\"",
-            QuotedString(text="[1,'2',3]", quote=Quote.double),
-            id="value:quoted_list_with_quoted_element",
-        ),
-        param(
-            "'null'",
-            QuotedString(text="null", quote=Quote.single),
-            id="value:null:quoted",
-        ),
-        param(
-            "'100'", QuotedString(text="100", quote=Quote.single), id="value:int:quoted"
-        ),
-        param(
-            "'3.14'",
-            QuotedString(text="3.14", quote=Quote.single),
-            id="value:float:quoted",
-        ),
-        param(
-            "'nan'",
-            QuotedString(text="nan", quote=Quote.single),
-            id="value:float:constant:quoted",
-        ),
-        param(
-            "'inf'",
-            QuotedString(text="inf", quote=Quote.single),
-            id="value:float:constant:quoted",
-        ),
-        param(
-            "'nan'",
-            QuotedString(text="nan", quote=Quote.single),
-            id="value:float:constant:quoted",
-        ),
-        param(
-            "'true'",
-            QuotedString(text="true", quote=Quote.single),
-            id="value:bool:quoted",
-        ),
-        param(
-            "'false'",
-            QuotedString(text="false", quote=Quote.single),
-            id="value:bool:quoted",
-        ),
-        param(
-            "'a ${b}'",
-            QuotedString(text="a ${b}", quote=Quote.single),
-            id="value:interpolation:quoted",
-        ),
-        param(
-            r"'a \${b}'",
-            QuotedString(text=r"a \${b}", quote=Quote.single),
-            id="value:esc_interpolation:quoted",
-        ),
-        param(
-            r"'a \'\${b}\''",
-            QuotedString(text=r"a '\${b}'", quote=Quote.single),
-            id="value:quotes_and_esc_interpolation:quoted",
-        ),
-        param(
-            r"'a \\${b}'",
-            QuotedString(text=r"a \\${b}", quote=Quote.single),
-            id="value:backslash_and_interpolation:quoted",
-        ),
-        param(
-            r"'a \'${b}\''",
-            QuotedString(text=r"a '${b}'", quote=Quote.single),
-            id="value:quotes_and_interpolation:quoted",
-        ),
-        param(
-            r"'a \'\\${b}\''",
-            QuotedString(text=r"a '\\${b}'", quote=Quote.single),
-            id="value:quotes_backslash_and_interpolation:quoted",
-        ),
-        param(
-            r"'a \\\'${b}\\\''",
-            QuotedString(text=r"a \'${b}\'", quote=Quote.single),
-            id="value:backslash_quotes_and_interpolation:quoted",
-        ),
-        param(
-            r"'${foo:\'b,a,r\'}'",
-            QuotedString(text="${foo:'b,a,r'}", quote=Quote.single),
-            id="value:interpolation_with_quoted_string:quoted",
-        ),
-        param(
-            r"""'${foo:${a}, \'\${bar}\\\'\', {x: "${y}"}}'""",
-            QuotedString(
-                text=r"""${foo:${a}, '\${bar}\'', {x: "${y}"}}""", quote=Quote.single
-            ),
-            id="value:nested_interpolation:quoted",
-        ),
-        param(
-            r"""'${foo:"\' }"}'""",
-            QuotedString(text=r"""${foo:"' }"}""", quote=Quote.single),
-            id="value:interpolation_apparent_brace_mismatch:quoted",
-        ),
         # interpolations:
         param("${a}", "${a}", id="primitive:interpolation"),
         param("${a.b.c}", "${a.b.c}", id="primitive:interpolation"),
@@ -813,10 +636,193 @@ def test_key(value: str, expected: Any) -> None:
 )
 def test_primitive(value: str, expected: Any) -> None:
     ret = parse_rule(value, "primitive")
-    if isinstance(ret, QuotedString):
-        assert value == ret.with_quotes()
-
     assert eq(ret, expected)
+
+
+@mark.parametrize(
+    ("value", "expected"),
+    [
+        param(
+            r"'foo \'bar'",
+            QuotedString(text="foo 'bar", quote=Quote.single),
+            id="escape_single_quote",
+        ),
+        param(
+            r'"foo \"bar"',
+            QuotedString(text='foo "bar', quote=Quote.double),
+            id="escape_double_quote",
+        ),
+        param(
+            r"'foo \\\'bar'",
+            QuotedString(text=r"foo \'bar", quote=Quote.single),
+            id="escape_single_quote_x3",
+        ),
+        param(
+            r'"foo \\\"bar"',
+            QuotedString(text=r"foo \"bar", quote=Quote.double),
+            id="escape_double_quote_x3",
+        ),
+        param(
+            r"'foo\bar'",
+            QuotedString(text=r"foo\bar", quote=Quote.single),
+            id="one_backslash_single",
+        ),
+        param(
+            r'"foo\bar"',
+            QuotedString(text=r"foo\bar", quote=Quote.double),
+            id="one_backslash_double",
+        ),
+        param(
+            r"'foo\\bar'",
+            QuotedString(text=r"foo\\bar", quote=Quote.single),
+            id="noesc_backslash",
+        ),
+        param(
+            r"'foo\\\\bar'",
+            QuotedString(text=r"foo\\\\bar", quote=Quote.single),
+            id="noesc_backslash_x4",
+        ),
+        param(
+            r"'foo bar\\'",
+            # Note: raw strings do not allow trailing \, adding a space and stripping it.
+            QuotedString(text=r" foo bar\ ".strip(), quote=Quote.single),
+            id="escape_backslash_trailing",
+        ),
+        param(
+            r"'foo \\\\\'bar\' \\\\\\'",
+            QuotedString(text=r" foo \\'bar' \\\ ".strip(), quote=Quote.single),
+            id="escape_mixed",
+        ),
+        param(
+            "'\t []{},=+~'",
+            QuotedString(text="\t []{},=+~", quote=Quote.single),
+            id="quoted_specials",
+        ),
+        param(
+            '"\t []{},=+~"',
+            QuotedString(text="\t []{},=+~", quote=Quote.double),
+            id="quoted_specials",
+        ),
+        param(
+            "'a b c'",
+            QuotedString(text="a b c", quote=Quote.single),
+            id="quoted_with_whitespace",
+        ),
+        param(
+            "'a,b'",
+            QuotedString(text="a,b", quote=Quote.single),
+            id="quoted_with_comma",
+        ),
+        param(
+            "'[1,2,3]'",
+            QuotedString(text="[1,2,3]", quote=Quote.single),
+            id="quoted_list",
+        ),
+        param(
+            '"[1,2,3]"',
+            QuotedString(text="[1,2,3]", quote=Quote.double),
+            id="quoted_list",
+        ),
+        param(
+            "\"[1,'2',3]\"",
+            QuotedString(text="[1,'2',3]", quote=Quote.double),
+            id="quoted_list_with_quoted_element",
+        ),
+        param(
+            "'null'",
+            QuotedString(text="null", quote=Quote.single),
+            id="null",
+        ),
+        param("'100'", QuotedString(text="100", quote=Quote.single), id="int"),
+        param(
+            "'3.14'",
+            QuotedString(text="3.14", quote=Quote.single),
+            id="float",
+        ),
+        param(
+            "'nan'",
+            QuotedString(text="nan", quote=Quote.single),
+            id="float:constant",
+        ),
+        param(
+            "'inf'",
+            QuotedString(text="inf", quote=Quote.single),
+            id="float:constant",
+        ),
+        param(
+            "'nan'",
+            QuotedString(text="nan", quote=Quote.single),
+            id="float:constant",
+        ),
+        param(
+            "'true'",
+            QuotedString(text="true", quote=Quote.single),
+            id="bool",
+        ),
+        param(
+            "'false'",
+            QuotedString(text="false", quote=Quote.single),
+            id="bool",
+        ),
+        param(
+            "'a ${b}'",
+            QuotedString(text="a ${b}", quote=Quote.single),
+            id="interpolation",
+        ),
+        param(
+            r"'a \${b}'",
+            QuotedString(text=r"a \${b}", quote=Quote.single),
+            id="esc_interpolation",
+        ),
+        param(
+            r"'a \'\${b}\''",
+            QuotedString(text=r"a '\${b}'", quote=Quote.single),
+            id="quotes_and_esc_interpolation",
+        ),
+        param(
+            r"'a \\${b}'",
+            QuotedString(text=r"a \\${b}", quote=Quote.single),
+            id="backslash_and_interpolation",
+        ),
+        param(
+            r"'a \'${b}\''",
+            QuotedString(text=r"a '${b}'", quote=Quote.single),
+            id="quotes_and_interpolation",
+        ),
+        param(
+            r"'a \'\\${b}\''",
+            QuotedString(text=r"a '\\${b}'", quote=Quote.single),
+            id="quotes_backslash_and_interpolation",
+        ),
+        param(
+            r"'a \\\'${b}\\\''",
+            QuotedString(text=r"a \'${b}\'", quote=Quote.single),
+            id="backslash_quotes_and_interpolation",
+        ),
+        param(
+            r"'${foo:\'b,a,r\'}'",
+            QuotedString(text="${foo:'b,a,r'}", quote=Quote.single),
+            id="interpolation_with_quoted_string",
+        ),
+        param(
+            r"""'${foo:${a}, \'\${bar}\\\'\', {x: "${y}"}}'""",
+            QuotedString(
+                text=r"""${foo:${a}, '\${bar}\'', {x: "${y}"}}""", quote=Quote.single
+            ),
+            id="nested_interpolation",
+        ),
+        param(
+            r"""'${foo:"\' }"}'""",
+            QuotedString(text=r"""${foo:"' }"}""", quote=Quote.single),
+            id="interpolation_apparent_brace_mismatch",
+        ),
+    ],
+)
+def test_primitive_quoted_string(value: str, expected: Any) -> None:
+    ret = parse_rule(value, "primitive")
+    assert isinstance(ret, QuotedString)
+    assert eq(ret, expected)
+    assert value == ret.with_quotes()  # round-trip
 
 
 @mark.parametrize(

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -462,6 +462,12 @@ def test_interval_sweep(value: str, expected: Any) -> None:
             id="error:left_overs",
         ),
         param(
+            "listContainer",
+            r"['a\', 'b']",
+            raises(HydraException, match=re.escape("token recognition error at: '']'")),
+            id="error:list_bad_escaping",
+        ),
+        param(
             "override",
             "key=[1,2,3]'",
             raises(HydraException, match=re.escape("token recognition error at: '''")),
@@ -472,6 +478,12 @@ def test_interval_sweep(value: str, expected: Any) -> None:
             "{'0a': 0, \"1b\": 1}",
             raises(HydraException, match=re.escape("mismatched input ''0a''")),
             id="error:dict_quoted_key_dictContainer",
+        ),
+        param(
+            "dictContainer",
+            r"{a: 'a\', b: 'b'}",
+            raises(HydraException, match=re.escape("token recognition error at: ''}'")),
+            id="error:dict_bad_escaping",
         ),
         param(
             "override",

--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -119,7 +119,8 @@ group@pkg1:pkg2   # A config group changing the package from pkg1 to pkg2
 Hydra supports both double quotes and single quoted values.
 Quoted strings can accept any value between the quotes, but some characters need escaping:
 * to include a single quote in a single quoted string, use `\'` (for double quotes in a double quoted string, use `\"`)
-* the `\` character may also be escaped with `\\`, which can be required e.g. for strings ending with `\`
+* any sequence of `\` characters preceding a quote (either an escaped quote as described in the previous point, or the closing quote)
+  must be escaped by doubling the number of `\`
 
 <div className="row">
 <div className="col col--6">
@@ -127,7 +128,7 @@ Quoted strings can accept any value between the quotes, but some characters need
 ```python title="Double quotes"
 "hello there"
 "escaped \"double quote\""
-"the Windows root is C:\\"
+"the path is C:\\\"some folder\"\\"
 "1,2,3"
 "{a:10} ${xyz}"
 "'single quoted string'"
@@ -140,7 +141,7 @@ Quoted strings can accept any value between the quotes, but some characters need
 ```python title="Single quotes"
 'hello there'
 'escaped \'single quote\''
-'the Windows root is C:\\'
+'the path is C:\\\'some folder\'\\'
 '1,2,3'
 '{a:10} ${xyz}'
 '"double quoted string"'

--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -191,7 +191,8 @@ Always single-quote interpolations in the shell, to prevent replacement with she
 ```shell
 $ python my_app.py 'dir=/root/${name}'
 ```
-In addition, more complex interpolations containing special characters may require being passed within a quoted value:
+In addition, more complex interpolations containing special characters may require being passed within a quoted value
+(note the extra double quotes surrounding the interpolation):
 ```shell
 $ python my_app.py 'dir="${get_dir: {root: /root, name: ${name}}}"'
 ```

--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -182,12 +182,19 @@ $ python my_app.py 'dir=job\{a\=1\,b\=2\,c\=3\}'
 - `float`: 3.14, -10e6, inf, -inf, nan.
 - `bool`: true, false
 - `dot_path`: foo.bar
-- `interpolation`: ${foo.bar}, ${co.env:USER,me}
+- `interpolation`: ${foo.bar}, ${oc.env:USER,me}
 
 Constants (null, true, false, inf, nan) are case-insensitive.
 
 :::important
-Always single-quote interpolations in the shell.
+Always single-quote interpolations in the shell, to prevent the shell from replacing them with environment variables:
+```shell
+$ python my_app.py 'dir=/root/${name}'
+```
+In addition, more complex interpolations containing special characters may require being passed as quoted values:
+```shell
+$ python my_app.py 'dir="${get_dir: {root: /root, name: ${name}}}"'
+```
 :::
 
 ## Dictionaries and Lists

--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -191,7 +191,7 @@ Always single-quote interpolations in the shell, to prevent the shell from repla
 ```shell
 $ python my_app.py 'dir=/root/${name}'
 ```
-In addition, more complex interpolations containing special characters may require being passed as quoted values:
+In addition, more complex interpolations containing special characters may require being passed within a quoted value:
 ```shell
 $ python my_app.py 'dir="${get_dir: {root: /root, name: ${name}}}"'
 ```

--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -187,7 +187,7 @@ $ python my_app.py 'dir=job\{a\=1\,b\=2\,c\=3\}'
 Constants (null, true, false, inf, nan) are case-insensitive.
 
 :::important
-Always single-quote interpolations in the shell, to prevent the shell from replacing them with environment variables:
+Always single-quote interpolations in the shell, to prevent replacement with shell variables:
 ```shell
 $ python my_app.py 'dir=/root/${name}'
 ```

--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -117,8 +117,9 @@ group@pkg1:pkg2   # A config group changing the package from pkg1 to pkg2
 
 ### Quoted values
 Hydra supports both double quotes and single quoted values.
-Quoted strings can accept any value between the quotes.
-To include a single quote in a single quoted string escape it : `\'`. Same for double quotes in a double quoted string.
+Quoted strings can accept any value between the quotes, but some characters need escaping:
+* to include a single quote in a single quoted string, use `\'` (for double quotes in a double quoted string, use `\"`)
+* the `\` character may also be escaped with `\\`, which can be required e.g. for strings ending with `\`
 
 <div className="row">
 <div className="col col--6">
@@ -126,6 +127,7 @@ To include a single quote in a single quoted string escape it : `\'`. Same for d
 ```python title="Double quotes"
 "hello there"
 "escaped \"double quote\""
+"the Windows root is C:\\"
 "1,2,3"
 "{a:10} ${xyz}"
 "'single quoted string'"
@@ -138,6 +140,7 @@ To include a single quote in a single quoted string escape it : `\'`. Same for d
 ```python title="Single quotes"
 'hello there'
 'escaped \'single quote\''
+'the Windows root is C:\\'
 '1,2,3'
 '{a:10} ${xyz}'
 '"double quoted string"'


### PR DESCRIPTION
Fixes #1600

@omry I realize you would prefer something simpler, but since I had it ready I thought it may still be useful to put it out so as to help ground discussions (we can keep the discussion in #1594 or move it here if you prefer)

Technically I should be able to replace the lexer mode approach from this PR with the simpler regex you mentioned in https://github.com/facebookresearch/hydra/issues/1600#issuecomment-831456040, but then I'll hit a problem later with something like `"key='abc ${foo:'def'}'"` when trying to support more interpolation types from OmegaConf (including quoted strings, dictionaries, nested interpolations...).