### PR TITLE
Issue warning on outdated API usage

### DIFF
--- a/hydra/_internal/callbacks.py
+++ b/hydra/_internal/callbacks.py
@@ -1,20 +1,21 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 if TYPE_CHECKING:
     from hydra.core.utils import JobReturn
 
 
 class Callbacks:
-    def __init__(self, config: DictConfig) -> None:
+    def __init__(self, config: Optional[DictConfig] = None) -> None:
         self.callbacks = []
         from hydra.utils import instantiate
 
-        for params in config.hydra.callbacks.values():
-            self.callbacks.append(instantiate(params))
+        if config is not None and OmegaConf.select(config, "hydra.callbacks"):
+            for params in config.hydra.callbacks.values():
+                self.callbacks.append(instantiate(params))
 
     def _notify(self, function_name: str, reverse: bool = False, **kwargs: Any) -> None:
         callbacks = reversed(self.callbacks) if reverse else self.callbacks

--- a/hydra/_internal/core_plugins/basic_launcher.py
+++ b/hydra/_internal/core_plugins/basic_launcher.py
@@ -6,6 +6,8 @@ from typing import List, Optional, Sequence
 
 from omegaconf import DictConfig, open_dict
 
+from hydra._internal.callbacks import Callbacks
+from hydra.core.config_loader import ConfigLoader
 from hydra.core.config_store import ConfigStore
 from hydra.core.utils import (
     JobReturn,
@@ -36,23 +38,31 @@ class BasicLauncher(Launcher):
         self.config: Optional[DictConfig] = None
         self.task_function: Optional[TaskFunction] = None
         self.hydra_context: Optional[HydraContext] = None
+        # BasicLauncher supports Hydra 1.0 style setup for compatibility with 3rd party Sweeper
+        self.config_loader: Optional[ConfigLoader] = None
 
     def setup(
         self,
-        *,
-        hydra_context: HydraContext,
         task_function: TaskFunction,
         config: DictConfig,
+        hydra_context: Optional[HydraContext] = None,
+        config_loader: Optional[ConfigLoader] = None,
     ) -> None:
         self.config = config
         self.hydra_context = hydra_context
+        self.config_loader = config_loader
         self.task_function = task_function
 
     def launch(
         self, job_overrides: Sequence[Sequence[str]], initial_job_idx: int
     ) -> Sequence[JobReturn]:
         setup_globals()
-        assert self.hydra_context is not None
+        config_loader = (
+            self.hydra_context.config_loader
+            if self.hydra_context
+            else self.config_loader
+        )
+        assert config_loader is not None
         assert self.config is not None
         assert self.task_function is not None
 
@@ -61,16 +71,20 @@ class BasicLauncher(Launcher):
         Path(str(sweep_dir)).mkdir(parents=True, exist_ok=True)
         log.info(f"Launching {len(job_overrides)} jobs locally")
         runs: List[JobReturn] = []
+        if self.hydra_context is None:
+            self.hydra_context = HydraContext(
+                config_loader=config_loader, callbacks=Callbacks()
+            )
+
         for idx, overrides in enumerate(job_overrides):
             idx = initial_job_idx + idx
             lst = " ".join(filter_overrides(overrides))
             log.info(f"\t#{idx} : {lst}")
-            sweep_config = self.hydra_context.config_loader.load_sweep_config(
-                self.config, list(overrides)
-            )
+            sweep_config = config_loader.load_sweep_config(self.config, list(overrides))
             with open_dict(sweep_config):
                 sweep_config.hydra.job.id = idx
                 sweep_config.hydra.job.num = idx
+
             ret = run_job(
                 hydra_context=self.hydra_context,
                 task_function=self.task_function,

--- a/hydra/_internal/core_plugins/basic_launcher.py
+++ b/hydra/_internal/core_plugins/basic_launcher.py
@@ -6,8 +6,6 @@ from typing import List, Optional, Sequence
 
 from omegaconf import DictConfig, open_dict
 
-from hydra._internal.callbacks import Callbacks
-from hydra.core.config_loader import ConfigLoader
 from hydra.core.config_store import ConfigStore
 from hydra.core.utils import (
     JobReturn,
@@ -38,31 +36,23 @@ class BasicLauncher(Launcher):
         self.config: Optional[DictConfig] = None
         self.task_function: Optional[TaskFunction] = None
         self.hydra_context: Optional[HydraContext] = None
-        # BasicLauncher supports Hydra 1.0 style setup for compatibility with 3rd party Sweeper
-        self.config_loader: Optional[ConfigLoader] = None
 
     def setup(
         self,
+        *,
+        hydra_context: HydraContext,
         task_function: TaskFunction,
         config: DictConfig,
-        hydra_context: Optional[HydraContext] = None,
-        config_loader: Optional[ConfigLoader] = None,
     ) -> None:
         self.config = config
         self.hydra_context = hydra_context
-        self.config_loader = config_loader
         self.task_function = task_function
 
     def launch(
         self, job_overrides: Sequence[Sequence[str]], initial_job_idx: int
     ) -> Sequence[JobReturn]:
         setup_globals()
-        config_loader = (
-            self.hydra_context.config_loader
-            if self.hydra_context
-            else self.config_loader
-        )
-        assert config_loader is not None
+        assert self.hydra_context is not None
         assert self.config is not None
         assert self.task_function is not None
 
@@ -71,20 +61,16 @@ class BasicLauncher(Launcher):
         Path(str(sweep_dir)).mkdir(parents=True, exist_ok=True)
         log.info(f"Launching {len(job_overrides)} jobs locally")
         runs: List[JobReturn] = []
-        if self.hydra_context is None:
-            self.hydra_context = HydraContext(
-                config_loader=config_loader, callbacks=Callbacks()
-            )
-
         for idx, overrides in enumerate(job_overrides):
             idx = initial_job_idx + idx
             lst = " ".join(filter_overrides(overrides))
             log.info(f"\t#{idx} : {lst}")
-            sweep_config = config_loader.load_sweep_config(self.config, list(overrides))
+            sweep_config = self.hydra_context.config_loader.load_sweep_config(
+                self.config, list(overrides)
+            )
             with open_dict(sweep_config):
                 sweep_config.hydra.job.id = idx
                 sweep_config.hydra.job.num = idx
-
             ret = run_job(
                 hydra_context=self.hydra_context,
                 task_function=self.task_function,

--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -141,6 +141,7 @@ class Plugins(metaclass=Singleton):
                     "\n"
                     "\tPlugin's setup() signature has changed in Hydra 1.1.\n"
                     "\tSupport for the old style will be removed in Hydra 1.2.\n"
+                    "\tFor more info, check https://github.com/facebookresearch/hydra/pull/1581.\n"
                 ),
                 category=UserWarning,
             )

--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -135,8 +135,7 @@ class Plugins(metaclass=Singleton):
                     """
                     Plugin's setup() signature has changed in Hydra 1.1.
                     Support for the old style will be removed in Hydra 1.2.
-                    For more info, check https://github.com/facebookresearch/hydra/pull/1581.
-                    """
+                    For more info, check https://github.com/facebookresearch/hydra/pull/1581."""
                 ),
                 category=UserWarning,
             )

--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -128,6 +128,8 @@ class Plugins(metaclass=Singleton):
         param_keys = signature(plugin.setup).parameters.keys()
 
         if "hydra_context" not in param_keys:
+            # DEPRECATED: remove in 1.2
+            # hydra_context will be required in 1.2
             warnings.warn(
                 message=dedent(
                     """

--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -126,7 +126,7 @@ class Plugins(metaclass=Singleton):
 
         param_keys = signature(plugin.setup).parameters.keys()
 
-        if "config_loader" in param_keys:
+        if "hydra_context" not in param_keys:
             warnings.warn(
                 message=(
                     "\n"

--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -152,7 +152,7 @@ class Plugins(metaclass=Singleton):
             )
         else:
             if hydra_context is None:
-                # hydra_context could be None when an incompatible Sweeper tried to compatible Launcher
+                # hydra_context could be None when an incompatible Sweeper instantiates a compatible Launcher
                 assert config_loader is not None
                 hydra_context = HydraContext(
                     config_loader=config_loader, callbacks=Callbacks()

--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -7,6 +7,7 @@ import warnings
 from collections import defaultdict
 from dataclasses import dataclass, field
 from inspect import signature
+from textwrap import dedent
 from timeit import default_timer as timer
 from typing import Any, Dict, List, Optional, Tuple, Type
 
@@ -128,11 +129,12 @@ class Plugins(metaclass=Singleton):
 
         if "hydra_context" not in param_keys:
             warnings.warn(
-                message=(
-                    "\n"
-                    "\tPlugin's setup() signature has changed in Hydra 1.1.\n"
-                    "\tSupport for the old style will be removed in Hydra 1.2.\n"
-                    "\tFor more info, check https://github.com/facebookresearch/hydra/pull/1581.\n"
+                message=dedent(
+                    """
+                    Plugin's setup() signature has changed in Hydra 1.1.
+                    Support for the old style will be removed in Hydra 1.2.
+                    For more info, check https://github.com/facebookresearch/hydra/pull/1581.
+                    """
                 ),
                 category=UserWarning,
             )
@@ -148,6 +150,7 @@ class Plugins(metaclass=Singleton):
             )
         else:
             if hydra_context is None:
+                # hydra_context could be None when an incompatible Sweeper tried to compatible Launcher
                 assert config_loader is not None
                 hydra_context = HydraContext(
                     config_loader=config_loader, callbacks=Callbacks()

--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -89,10 +89,12 @@ def filter_overrides(overrides: Sequence[str]) -> Sequence[str]:
 
 def _get_callbacks_for_run_job(hydra_context: Optional[HydraContext]) -> "Callbacks":
     if hydra_context is None:
+        # DEPRECATED: remove in 1.2
+        # hydra_context will be required in 1.2
         warnings.warn(
             message=dedent(
                 """
-            run_job's signature has changed in Hydra 1.1.
+            run_job's signature has changed in Hydra 1.1. Please pass in hydra_context.
             Support for the old style will be removed in Hydra 1.2.
             For more info, check https://github.com/facebookresearch/hydra/pull/1581.
             """

--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -94,10 +94,9 @@ def _get_callbacks_for_run_job(hydra_context: Optional[HydraContext]) -> "Callba
         warnings.warn(
             message=dedent(
                 """
-            run_job's signature has changed in Hydra 1.1. Please pass in hydra_context.
-            Support for the old style will be removed in Hydra 1.2.
-            For more info, check https://github.com/facebookresearch/hydra/pull/1581.
-            """
+                run_job's signature has changed in Hydra 1.1. Please pass in hydra_context.
+                Support for the old style will be removed in Hydra 1.2.
+                For more info, check https://github.com/facebookresearch/hydra/pull/1581."""
             ),
         )
         from hydra._internal.callbacks import Callbacks

--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -90,10 +90,13 @@ def filter_overrides(overrides: Sequence[str]) -> Sequence[str]:
 def _get_callbacks_for_run_job(hydra_context: Optional[HydraContext]) -> "Callbacks":
     if hydra_context is None:
         warnings.warn(
-            message="\n"
-            "\trun_job's signature has changed in Hydra 1.1.\n"
-            "\tSupport for the old style will be removed in Hydra 1.2.\n"
-            "\tFor more info, check https://github.com/facebookresearch/hydra/pull/1581.\n"
+            message=dedent(
+                """
+            run_job's signature has changed in Hydra 1.1.
+            Support for the old style will be removed in Hydra 1.2.
+            For more info, check https://github.com/facebookresearch/hydra/pull/1581.
+            """
+            ),
         )
         from hydra._internal.callbacks import Callbacks
 

--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -93,6 +93,7 @@ def _get_callbacks_for_run_job(hydra_context: Optional[HydraContext]) -> "Callba
             message="\n"
             "\trun_job's signature has changed in Hydra 1.1.\n"
             "\tSupport for the old style will be removed in Hydra 1.2.\n"
+            "\tFor more info, check https://github.com/facebookresearch/hydra/pull/1581.\n"
         )
         from hydra._internal.callbacks import Callbacks
 

--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import sys
+import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
@@ -11,13 +12,17 @@ from enum import Enum
 from os.path import splitext
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Dict, Optional, Sequence, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Union, cast
 
 from omegaconf import DictConfig, OmegaConf, open_dict, read_write
 
 from hydra.core.hydra_config import HydraConfig
 from hydra.core.singleton import Singleton
 from hydra.errors import HydraJobException
+
+if TYPE_CHECKING:
+    from hydra._internal.callbacks import Callbacks
+
 from hydra.types import HydraContext, TaskFunction
 
 log = logging.getLogger(__name__)
@@ -82,17 +87,31 @@ def filter_overrides(overrides: Sequence[str]) -> Sequence[str]:
     return [x for x in overrides if not x.startswith("hydra.")]
 
 
+def _get_callbacks_for_run_job(hydra_context: Optional[HydraContext]) -> "Callbacks":
+    if hydra_context is None:
+        warnings.warn(
+            message="\n"
+            "\trun_job's signature has changed in Hydra 1.1.\n"
+            "\tSupport for the old style will be removed in Hydra 1.2.\n"
+        )
+        from hydra._internal.callbacks import Callbacks
+
+        callbacks = Callbacks()
+    else:
+        callbacks = hydra_context.callbacks
+
+    return callbacks
+
+
 def run_job(
-    *,
-    hydra_context: HydraContext,
     task_function: TaskFunction,
     config: DictConfig,
     job_dir_key: str,
     job_subdir_key: Optional[str],
     configure_logging: bool = True,
+    hydra_context: Optional[HydraContext] = None,
 ) -> "JobReturn":
-
-    callbacks = hydra_context.callbacks
+    callbacks = _get_callbacks_for_run_job(hydra_context)
 
     old_cwd = os.getcwd()
     orig_hydra_cfg = HydraConfig.instance().cfg

--- a/hydra/plugins/sweeper.py
+++ b/hydra/plugins/sweeper.py
@@ -51,9 +51,15 @@ class Sweeper(Plugin):
         This repeat work the launcher will do, but as the launcher may be performing this in a different
         process/machine it's important to do it here as well to detect failures early.
         """
-        assert self.hydra_context is not None
+        config_loader = (
+            self.hydra_context.config_loader
+            if hasattr(self, "hydra_context") and self.hydra_context is not None
+            else self.config_loader  # type: ignore
+        )
+        assert config_loader is not None
+
         assert self.config is not None
         for overrides in batch:
-            self.hydra_context.config_loader.load_sweep_config(
+            config_loader.load_sweep_config(
                 master_config=self.config, sweep_overrides=list(overrides)
             )

--- a/tests/test_hydra_context_warnings.py
+++ b/tests/test_hydra_context_warnings.py
@@ -100,7 +100,7 @@ def test_run_job() -> None:
     hydra_context = None
     msg = dedent(
         """
-            run_job's signature has changed in Hydra 1.1.
+            run_job's signature has changed in Hydra 1.1. Please pass in hydra_context.
             Support for the old style will be removed in Hydra 1.2.
             For more info, check https://github.com/facebookresearch/hydra/pull/1581.
             """

--- a/tests/test_hydra_context_warnings.py
+++ b/tests/test_hydra_context_warnings.py
@@ -1,71 +1,96 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import re
-from typing import Any, Optional
+from typing import Any, List, Sequence, Union
 from unittest.mock import Mock
 
-from omegaconf import DictConfig
-from pytest import mark, raises, warns
+from omegaconf import DictConfig, OmegaConf
+from pytest import mark, warns
 
 from hydra import TaskFunction
+from hydra._internal.callbacks import Callbacks
+from hydra._internal.config_loader_impl import ConfigLoaderImpl
+from hydra._internal.utils import create_config_search_path
 from hydra.core.config_loader import ConfigLoader
 from hydra.core.plugins import Plugins
-from hydra.core.utils import _get_callbacks_for_run_job
+from hydra.core.utils import JobReturn, _get_callbacks_for_run_job
+from hydra.plugins.launcher import Launcher
 from hydra.plugins.sweeper import Sweeper
 from hydra.test_utils.test_utils import chdir_hydra_root
 from hydra.types import HydraContext
 
 chdir_hydra_root()
 
-plugins = Plugins.instance()
+
+class IncompatibleSweeper(Sweeper):
+    def __init__(self) -> None:
+        pass
+
+    def setup(  # type: ignore
+        self,
+        config: DictConfig,
+        config_loader: ConfigLoader,
+        task_function: TaskFunction,
+    ) -> None:
+        pass
+
+    def sweep(self, arguments: List[str]) -> Any:
+        pass
+
+
+class IncompatibleLauncher(Launcher):
+    def __init__(self) -> None:
+        pass
+
+    def setup(  # type: ignore
+        self,
+        config: DictConfig,
+        config_loader: ConfigLoader,
+        task_function: TaskFunction,
+    ) -> None:
+        pass
+
+    def launch(
+        self, job_overrides: Sequence[Sequence[str]], initial_job_idx: int
+    ) -> Sequence[JobReturn]:
+        pass
 
 
 @mark.parametrize(
-    "config_loader, hydra_context, setup_method, expected",
+    "plugin, config",
     [
-        (None, None, lambda foo, bar: None, AssertionError),
-        (
-            Mock(ConfigLoader),
-            None,
-            lambda config_loader, config, task_function: None,
-            UserWarning(),
-        ),
-        (
-            Mock(spec=ConfigLoader),
-            Mock(spec=HydraContext),
-            lambda hydra_context, config, task_function: None,
-            None,
-        ),
+        (IncompatibleLauncher(), OmegaConf.create({"hydra": {"launcher": {}}})),
+        (IncompatibleSweeper(), OmegaConf.create({"hydra": {"sweeper": {}}})),
     ],
 )
-def test_setup_plugin(
-    config_loader: Optional[ConfigLoader],
-    hydra_context: Optional[HydraContext],
-    setup_method: Any,
-    expected: Any,
+def test_setup_plugins(
+    monkeypatch: Any, plugin: Union[Launcher, Sweeper], config: DictConfig
 ) -> None:
-    plugin = Mock(spec=Sweeper)
-    plugin.setup = setup_method
-    config = Mock(spec=DictConfig)
     task_function = Mock(spec=TaskFunction)
+    config_loader = ConfigLoaderImpl(config_search_path=create_config_search_path(None))
+    hydra_context = HydraContext(config_loader=config_loader, callbacks=Callbacks())
+    plugin_instance = Plugins.instance()
+    monkeypatch.setattr(Plugins, "check_usage", lambda _: None)
+    monkeypatch.setattr(plugin_instance, "_instantiate", lambda _: plugin)
+
     msg = (
         "\n"
         "\tPlugin's setup() signature has changed in Hydra 1.1.\n"
         "\tSupport for the old style will be removed in Hydra 1.2.\n"
         "\tFor more info, check https://github.com/facebookresearch/hydra/pull/1581.\n"
     )
-    if expected is None:
-        plugins._setup_plugin(
-            plugin, config, task_function, config_loader, hydra_context
-        )
-    elif isinstance(expected, UserWarning):
-        with warns(expected_warning=UserWarning, match=re.escape(msg)):
-            plugins._setup_plugin(
-                plugin, task_function, config, config_loader, hydra_context
+    with warns(expected_warning=UserWarning, match=re.escape(msg)):
+        if isinstance(plugin, Launcher):
+            Plugins.instance().instantiate_launcher(
+                task_function=task_function,
+                config=config,
+                config_loader=config_loader,
+                hydra_context=hydra_context,
             )
-    else:
-        with raises(expected):
-            plugins._setup_plugin(
-                plugin, config, task_function, config_loader, hydra_context
+        else:
+            Plugins.instance().instantiate_sweeper(
+                hydra_context=hydra_context,
+                task_function=task_function,
+                config=config,
             )
 
 

--- a/tests/test_hydra_context_warnings.py
+++ b/tests/test_hydra_context_warnings.py
@@ -75,10 +75,9 @@ def test_setup_plugins(
 
     msg = dedent(
         """
-                    Plugin's setup() signature has changed in Hydra 1.1.
-                    Support for the old style will be removed in Hydra 1.2.
-                    For more info, check https://github.com/facebookresearch/hydra/pull/1581.
-                    """
+        Plugin's setup() signature has changed in Hydra 1.1.
+        Support for the old style will be removed in Hydra 1.2.
+        For more info, check https://github.com/facebookresearch/hydra/pull/1581."""
     )
     with warns(expected_warning=UserWarning, match=re.escape(msg)):
         if isinstance(plugin, Launcher):
@@ -100,10 +99,9 @@ def test_run_job() -> None:
     hydra_context = None
     msg = dedent(
         """
-            run_job's signature has changed in Hydra 1.1. Please pass in hydra_context.
-            Support for the old style will be removed in Hydra 1.2.
-            For more info, check https://github.com/facebookresearch/hydra/pull/1581.
-            """
+        run_job's signature has changed in Hydra 1.1. Please pass in hydra_context.
+        Support for the old style will be removed in Hydra 1.2.
+        For more info, check https://github.com/facebookresearch/hydra/pull/1581."""
     )
     with warns(expected_warning=UserWarning, match=msg):
         _get_callbacks_for_run_job(hydra_context)

--- a/tests/test_hydra_context_warnings.py
+++ b/tests/test_hydra_context_warnings.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import re
+from textwrap import dedent
 from typing import Any, List, Sequence, Union
 from unittest.mock import Mock
 
@@ -72,11 +73,12 @@ def test_setup_plugins(
     monkeypatch.setattr(Plugins, "check_usage", lambda _: None)
     monkeypatch.setattr(plugin_instance, "_instantiate", lambda _: plugin)
 
-    msg = (
-        "\n"
-        "\tPlugin's setup() signature has changed in Hydra 1.1.\n"
-        "\tSupport for the old style will be removed in Hydra 1.2.\n"
-        "\tFor more info, check https://github.com/facebookresearch/hydra/pull/1581.\n"
+    msg = dedent(
+        """
+                    Plugin's setup() signature has changed in Hydra 1.1.
+                    Support for the old style will be removed in Hydra 1.2.
+                    For more info, check https://github.com/facebookresearch/hydra/pull/1581.
+                    """
     )
     with warns(expected_warning=UserWarning, match=re.escape(msg)):
         if isinstance(plugin, Launcher):
@@ -96,11 +98,12 @@ def test_setup_plugins(
 
 def test_run_job() -> None:
     hydra_context = None
-    msg = (
-        "\n"
-        "\trun_job's signature has changed in Hydra 1.1.\n"
-        "\tSupport for the old style will be removed in Hydra 1.2.\n"
-        "\tFor more info, check https://github.com/facebookresearch/hydra/pull/1581.\n"
+    msg = dedent(
+        """
+            run_job's signature has changed in Hydra 1.1.
+            Support for the old style will be removed in Hydra 1.2.
+            For more info, check https://github.com/facebookresearch/hydra/pull/1581.
+            """
     )
     with warns(expected_warning=UserWarning, match=msg):
         _get_callbacks_for_run_job(hydra_context)

--- a/tests/test_hydra_context_warnings.py
+++ b/tests/test_hydra_context_warnings.py
@@ -1,0 +1,79 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import re
+from typing import Any, Optional
+from unittest.mock import Mock
+
+from omegaconf import DictConfig
+from pytest import mark, raises, warns
+
+from hydra import TaskFunction
+from hydra.core.config_loader import ConfigLoader
+from hydra.core.plugins import Plugins
+from hydra.core.utils import _get_callbacks_for_run_job
+from hydra.plugins.sweeper import Sweeper
+from hydra.test_utils.test_utils import chdir_hydra_root
+from hydra.types import HydraContext
+
+chdir_hydra_root()
+
+plugins = Plugins.instance()
+
+
+@mark.parametrize(
+    "config_loader, hydra_context, setup_method, expected",
+    [
+        (None, None, lambda foo, bar: None, AssertionError),
+        (
+            Mock(ConfigLoader),
+            None,
+            lambda config_loader, config, task_function: None,
+            UserWarning(),
+        ),
+        (
+            Mock(spec=ConfigLoader),
+            Mock(spec=HydraContext),
+            lambda hydra_context, config, task_function: None,
+            None,
+        ),
+    ],
+)
+def test_setup_plugin(
+    config_loader: Optional[ConfigLoader],
+    hydra_context: Optional[HydraContext],
+    setup_method: Any,
+    expected: Any,
+) -> None:
+    plugin = Mock(spec=Sweeper)
+    plugin.setup = setup_method
+    config = Mock(spec=DictConfig)
+    task_function = Mock(spec=TaskFunction)
+    msg = (
+        "\n"
+        "\tPlugin's setup() signature has changed in Hydra 1.1.\n"
+        "\tSupport for the old style will be removed in Hydra 1.2.\n"
+    )
+    if expected is None:
+        plugins._setup_plugin(
+            plugin, config, task_function, config_loader, hydra_context
+        )
+    elif isinstance(expected, UserWarning):
+        with warns(expected_warning=UserWarning, match=re.escape(msg)):
+            plugins._setup_plugin(
+                plugin, task_function, config, config_loader, hydra_context
+            )
+    else:
+        with raises(expected):
+            plugins._setup_plugin(
+                plugin, config, task_function, config_loader, hydra_context
+            )
+
+
+def test_run_job() -> None:
+    hydra_context = None
+    msg = (
+        "\n"
+        "\trun_job's signature has changed in Hydra 1.1.\n"
+        "\tSupport for the old style will be removed in Hydra 1.2.\n"
+    )
+    with warns(expected_warning=UserWarning, match=msg):
+        _get_callbacks_for_run_job(hydra_context)

--- a/tests/test_hydra_context_warnings.py
+++ b/tests/test_hydra_context_warnings.py
@@ -51,6 +51,7 @@ def test_setup_plugin(
         "\n"
         "\tPlugin's setup() signature has changed in Hydra 1.1.\n"
         "\tSupport for the old style will be removed in Hydra 1.2.\n"
+        "\tFor more info, check https://github.com/facebookresearch/hydra/pull/1581.\n"
     )
     if expected is None:
         plugins._setup_plugin(
@@ -74,6 +75,7 @@ def test_run_job() -> None:
         "\n"
         "\trun_job's signature has changed in Hydra 1.1.\n"
         "\tSupport for the old style will be removed in Hydra 1.2.\n"
+        "\tFor more info, check https://github.com/facebookresearch/hydra/pull/1581.\n"
     )
     with warns(expected_warning=UserWarning, match=msg):
         _get_callbacks_for_run_job(hydra_context)


### PR DESCRIPTION
Closes #1589, #1604

### running with an outdated sweeper
```
$ python /Users/jieru/workspace/hydra-fork/hydra/plugins/hydra_ax_sweeper/example/banana.py -m
/Users/jieru/workspace/hydra-fork/hydra/hydra/core/plugins.py:127: UserWarning:


        Plugin's setup() signature has changed in Hydra 1.1.
        Support for the old style will be removed in Hydra 1.2.


[2021-05-03 18:05:09,476][HYDRA] AxSweeper is optimizing the following parameters: 
banana.x: range=[-5, 5]
banana.y: range=[-5.0, 10.1]
[INFO 05-03 18:05:09] ax.service.utils.instantiation: Inferred value type of ParameterType.INT for parameter banana.x. If that is not the expected value type, you can explicity specify 'value_type' ('int', 'float', 'bool' or 'str') in parameter dict.
[INFO 05-03 18:05:09] ax.service.utils.instantiation: Inferred value type of ParameterType.FLOAT for parameter banana.y. If that is not the expected value type, you can explicity specify 'value_type' ('int', 'float', 'bool' or 'str') in parameter dict.
[INFO 05-03 18:05:09] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.
[2021-05-03 18:05:09,575][HYDRA] AxSweeper is launching 5 jobs
[2021-05-03 18:05:10,054][HYDRA] Launching 5 jobs locally
[2021-05-03 18:05:10,054][HYDRA]        #0 : banana.x=-2 banana.y=-1.4334993640892209
[2021-05-03 18:05:10,190][__main__][INFO] - Banana_Function(x=-2, y=-1.4334993640892209)=2961.2915339557962
[2021-05-03 18:05:10,191][HYDRA]        #1 : banana.x=3 banana.y=0.25573451602831465
[2021-05-03 18:05:10,320][__main__][INFO] - Banana_Function(x=3, y=0.25573451602831465)=7650.217885417856
[2021-05-03 18:05:10,321][HYDRA]        #2 : banana.x=-3 banana.y=6.488616014365107
[2021-05-03 18:05:10,433][__main__][INFO] - Banana_Function(x=-3, y=6.488616014365107)=646.7049523303401
[2021-05-03 18:05:10,434][HYDRA]        #3 : banana.x=-4 banana.y=-1.6604875128716232
[2021-05-03 18:05:10,567][__main__][INFO] - Banana_Function(x=-4, y=-1.6604875128716232)=31214.28191922945
[2021-05-03 18:05:10,568][HYDRA]        #4 : banana.x=-5 banana.y=8.075565069634466
[2021-05-03 18:05:10,690][__main__][INFO] - Banana_Function(x=-5, y=8.075565069634466)=28679.649771217708
[2021-05-03 18:05:10,754][HYDRA] New best value: 646.7049523303401, best parameters: {'banana.x': -3, 'banana.y': 6.488616014365107}
[2021-05-03 18:05:12,843][HYDRA] AxSweeper is launching 3 jobs
```

### Running with outdated Launcher
```
$ python /Users/jieru/workspace/hydra-fork/hydra/plugins/hydra_joblib_launcher/example/my_app.py -m 
/Users/jieru/workspace/hydra-fork/hydra/plugins/hydra_joblib_launcher/example/my_app.py:12: UserWarning: 
config_path is not specified in @hydra.main().
See https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_hydra_main_config_path for more information.
  @hydra.main(config_name="config")
/Users/jieru/workspace/hydra-fork/hydra/hydra/core/plugins.py:127: UserWarning: 
        Plugin's setup() signature has changed in Hydra 1.1.
        Support for the old style will be removed in Hydra 1.2.

  warnings.warn(
[2021-05-03 18:06:37,759][HYDRA] Joblib.Parallel(n_jobs=10,backend=loky,prefer=processes,require=None,verbose=0,timeout=None,pre_dispatch=2*n_jobs,batch_size=auto,temp_folder=None,max_nbytes=None,mmap_mode=r) is launching 1 jobs
[2021-05-03 18:06:37,759][HYDRA] Launching jobs, sweep output dir : multirun/2021-05-03/18-06-37
[2021-05-03 18:06:37,759][HYDRA]        #0 : 
/Users/jieru/workspace/hydra-fork/hydra/hydra/core/utils.py:92: UserWarning: 
        run_job's signature has changed in Hydra 1.1.
        Support for the old style will be removed in Hydra 1.2.

  warnings.warn(
[2021-05-03 18:06:38,504][__main__][INFO] - Process ID 3429 executing task 1 ...

```