### PR TITLE
ensure local hyperlinks end with ".md"

### DIFF
--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -251,7 +251,7 @@ key="a,b","c,d"               # Elements can be quoted strings, ChoiceSweep("a,b
 key=[a,b],[c,d]               # Elements can be real lists, ChoiceSweep([a,b], [c,d])
 key={a:10, b:20},{c:30,d:40}  # And dictionaries: ChoiceSweep({a:10, b:20}, {c:30,d:40})
 ```
-More sweeping options are described in the [Extended Grammar page](extended).
+More sweeping options are described in the [Extended Grammar page](extended.md).
 
 :::important
 You may need to quote your choice sweep in the shell.
@@ -260,7 +260,7 @@ You may need to quote your choice sweep in the shell.
 
 ### Functions
 Hydra supports several functions in the command line.
-See the [Extended Grammar page](extended) for more information.
+See the [Extended Grammar page](extended.md) for more information.
 
 ## Working with your shell
 All shells interprets command line inputs and may change what is passed to the process.

--- a/website/docs/advanced/search_path.md
+++ b/website/docs/advanced/search_path.md
@@ -145,7 +145,7 @@ python my_app.py 'hydra.searchpath=[pkg://additonal_conf]'
 
 #### Overriding `--config-dir` from the command line
 This is a less flexible alternative to `hydra.searchpath`. 
-See this [page](/docs/advanced/hydra-command-line-flags) for more info.
+See this [page](hydra-command-line-flags.md) for more info.
 
 
 #### Creating a `SearchPathPlugin`

--- a/website/docs/advanced/terminology.md
+++ b/website/docs/advanced/terminology.md
@@ -39,7 +39,7 @@ class User:
 **Output Config**: A config composed from the [Input Configs](#input-configs) and [Overrides](#overrides) by **@hydra.main()**, or the Compose API.
 
 ## Overrides
-[Overrides](override_grammar/basic) are strings that can be used to manipulate the config composition process.
+[Overrides](override_grammar/basic.md) are strings that can be used to manipulate the config composition process.
 This includes updating, adding and deleting config values and [Defaults List](#defaults-list) options.  
 
 Overrides can be used in the command line and in the [Compose API](compose_api.md).  

--- a/website/docs/patterns/configuring_experiments.md
+++ b/website/docs/patterns/configuring_experiments.md
@@ -177,7 +177,7 @@ server:
   port: 8080
 ```
 
-To run all the experiment, use the [glob](../../advanced/override_grammar/extended#glob-choice-sweep) syntax:
+To run all the experiments, use the [glob](../advanced/override_grammar/extended.md#glob-choice-sweep) syntax:
 ```text title="$ python my_app.py --multirun '+experiment=glob(*)'"
 [HYDRA]        #0 : +experiment=aplite
 ...

--- a/website/docs/plugins/ax_sweeper.md
+++ b/website/docs/plugins/ax_sweeper.md
@@ -115,4 +115,4 @@ ax_config:
   is_noisy: true
   params: {}
 ```
-There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins) for more information.
+There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins.md) for more information.

--- a/website/docs/plugins/colorlog.md
+++ b/website/docs/plugins/colorlog.md
@@ -28,7 +28,7 @@ defaults:
   - override hydra/hydra_logging: colorlog
 ```
 
-There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins) for more information.
+There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins.md) for more information.
 
 See included <GithubLink to="plugins/hydra_colorlog/example">example application</GithubLink>.
  

--- a/website/docs/plugins/joblib_launcher.md
+++ b/website/docs/plugins/joblib_launcher.md
@@ -45,7 +45,7 @@ temp_folder: null
 max_nbytes: null
 mmap_mode: r
 ```
-There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins) for more information.
+There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins.md) for more information.
 
 See [`Joblib.Parallel` documentation](https://joblib.readthedocs.io/en/latest/parallel.html) for full details about the parameters above.
 

--- a/website/docs/plugins/nevergrad_sweeper.md
+++ b/website/docs/plugins/nevergrad_sweeper.md
@@ -27,7 +27,7 @@ defaults:
 ```
 
 The default configuration is <GithubLink to="plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/config.py">here</GithubLink>.
-There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins) for more information.
+There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins.md) for more information.
 ## Example of training using Nevergrad hyperparameter search
 
 We include an example of how to use this plugin. The file <GithubLink to="plugins/hydra_nevergrad_sweeper/example/my_app.py">example/my_app.py</GithubLink> implements an example of minimizing a (dummy) function using a mixture of continuous and discrete parameters.

--- a/website/docs/plugins/optuna_sweeper.md
+++ b/website/docs/plugins/optuna_sweeper.md
@@ -28,7 +28,7 @@ You can install the plugin via pip:
 ```commandline
 pip install hydra-optuna-sweeper --upgrade
 ```
-There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins) for more information.
+There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins.md) for more information.
 
 ## Usage
 

--- a/website/docs/plugins/ray_launcher.md
+++ b/website/docs/plugins/ray_launcher.md
@@ -27,7 +27,7 @@ Once installed, add `hydra/launcher=ray_aws` or `hydra/launcher=ray` to your com
 defaults:
   - override hydra/launcher: ray_aws
 ```
-There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins) for more information.
+There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins.md) for more information.
 
 ### `ray_aws` launcher
 

--- a/website/docs/plugins/rq_launcher.md
+++ b/website/docs/plugins/rq_launcher.md
@@ -58,7 +58,7 @@ stop_after_enqueue: false
 wait_polling: 1.0
 ```
 
-Further descriptions on the variables can be found in the plugin config file, defined <GithubLink to="plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py">here</GithubLink>. There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins) for more information.
+Further descriptions on the variables can be found in the plugin config file, defined <GithubLink to="plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py">here</GithubLink>. There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins.md) for more information.
 
 The plugin is using environment variables to store Redis connection information. The environment variables `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, and `REDIS_PASSWORD`, are used for the host address, port, database, and password of the server, respectively. Support for Redis SSL connections is controlled through `REDIS_SSL` and `REDIS_SSL_CA_CERTS`; see [redis-py](https://github.com/andymccurdy/redis-py#ssl-connections) documentation.
 

--- a/website/docs/plugins/submitit_launcher.md
+++ b/website/docs/plugins/submitit_launcher.md
@@ -26,7 +26,7 @@ Once installed, add `hydra/launcher=submitit_slurm` to your command line. Altern
 defaults:
   - override hydra/launcher: submitit_slurm
 ```
-There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins) for more information.
+There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins.md) for more information.
 Note that this plugin expects a valid environment in the target host. Usually this means a shared file system between
 the launching host and the target host.
 

--- a/website/docs/tutorials/basic/your_first_app/5_defaults.md
+++ b/website/docs/tutorials/basic/your_first_app/5_defaults.md
@@ -79,5 +79,5 @@ Config files that are not part of a config group will always be loaded. They can
 Prefer using a config group.
 
 :::info
-For more information about the Defaults List see [Reference Manual/The Defaults List](../../../advanced/defaults_list).
+For more information about the Defaults List see [Reference Manual/The Defaults List](../../../advanced/defaults_list.md).
 :::


### PR DESCRIPTION
Local website hyperlinks now end with ".md", which closes #1640.

This bugfix is motivated by a comment [here](https://github.com/facebook/docusaurus/issues/3372#issuecomment-826759426) in a related Docusaurus issue.