### PR TITLE
Attempt to fix Windows CI build: pin pywin32==300

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ commands:
           name: Preparing environment - Hydra
           # Using virtualenv==20.0.33 higher versions of virtualenv are not compatible with conda on windows. Relevant issue: https://github.com/ContinuumIO/anaconda-issues/issues/12094
           command: |
-            conda create -n hydra python=<< parameters.py_version >> virtualenv==20.0.33 -qy
+            conda create -n hydra python=<< parameters.py_version >> pywin32==225 virtualenv==20.0.33 -qy
             conda activate hydra
             pip install nox dataclasses --progress-bar off
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ commands:
           name: Preparing environment - Hydra
           # Using virtualenv==20.0.33 higher versions of virtualenv are not compatible with conda on windows. Relevant issue: https://github.com/ContinuumIO/anaconda-issues/issues/12094
           command: |
-            conda create -n hydra python=<< parameters.py_version >> pywin32==300 virtualenv==20.0.33 -qy
+            conda create -n hydra python=<< parameters.py_version >> pywin32=300 virtualenv==20.0.33 -qy
             conda activate hydra
             pip install nox dataclasses --progress-bar off
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,9 +94,9 @@ commands:
           name: Preparing environment - Hydra
           # Using virtualenv==20.0.33 higher versions of virtualenv are not compatible with conda on windows. Relevant issue: https://github.com/ContinuumIO/anaconda-issues/issues/12094
           command: |
-            conda create -n hydra python=<< parameters.py_version >> pywin32==225 virtualenv==20.0.33 -qy
+            conda create -n hydra python=<< parameters.py_version >> virtualenv==20.0.33 -qy
             conda activate hydra
-            pip install nox dataclasses --progress-bar off
+            pip install nox dataclasses pywin32==225 --progress-bar off
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,9 +94,9 @@ commands:
           name: Preparing environment - Hydra
           # Using virtualenv==20.0.33 higher versions of virtualenv are not compatible with conda on windows. Relevant issue: https://github.com/ContinuumIO/anaconda-issues/issues/12094
           command: |
-            conda create -n hydra python=<< parameters.py_version >> pywin32=300 virtualenv==20.0.33 -qy
+            conda create -n hydra python=<< parameters.py_version >> virtualenv==20.0.33 -qy
             conda activate hydra
-            pip install nox dataclasses --progress-bar off
+            pip install nox dataclasses pywin32==300 --progress-bar off
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ commands:
             conda activate hydra
             pip install nox dataclasses pywin32==300 --progress-bar off
             curl.exe -o pywin32_postinstall.py https://raw.githubusercontent.com/mhammond/pywin32/master/pywin32_postinstall.py
-            python.exe pywin32_postinstall.py
+            python.exe pywin32_postinstall.py -install
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,8 @@ commands:
             conda create -n hydra python=<< parameters.py_version >> virtualenv==20.0.33 -qy
             conda activate hydra
             pip install nox dataclasses pywin32==300 --progress-bar off
+            curl.exe -o pywin32_postinstall.py https://raw.githubusercontent.com/mhammond/pywin32/master/pywin32_postinstall.py
+            python.exe pywin32_postinstall.py
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ commands:
           command: |
             conda create -n hydra python=<< parameters.py_version >> virtualenv==20.0.33 -qy
             conda activate hydra
-            pip install nox dataclasses pywin32==225 --progress-bar off
+            pip install nox dataclasses --progress-bar off
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,11 +94,11 @@ commands:
           name: Preparing environment - Hydra
           # Using virtualenv==20.0.33 higher versions of virtualenv are not compatible with conda on windows. Relevant issue: https://github.com/ContinuumIO/anaconda-issues/issues/12094
           command: |
-            conda create -n hydra python=<< parameters.py_version >> virtualenv==20.0.33 -qy
+            conda create -n hydra python=<< parameters.py_version >> pywin32 virtualenv==20.0.33 -qy
             conda activate hydra
-            pip install nox dataclasses pywin32==300 --progress-bar off
             curl.exe -o pywin32_postinstall.py https://raw.githubusercontent.com/mhammond/pywin32/master/pywin32_postinstall.py
             python.exe pywin32_postinstall.py -install
+            pip install nox dataclasses --progress-bar off
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ commands:
           name: Preparing environment - Hydra
           # Using virtualenv==20.0.33 higher versions of virtualenv are not compatible with conda on windows. Relevant issue: https://github.com/ContinuumIO/anaconda-issues/issues/12094
           command: |
-            conda create -n hydra python=<< parameters.py_version >> pywin32 virtualenv==20.0.33 -qy
+            conda create -n hydra python=<< parameters.py_version >> pywin32==300 virtualenv==20.0.33 -qy
             conda activate hydra
             pip install nox dataclasses --progress-bar off
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,10 +94,8 @@ commands:
           name: Preparing environment - Hydra
           # Using virtualenv==20.0.33 higher versions of virtualenv are not compatible with conda on windows. Relevant issue: https://github.com/ContinuumIO/anaconda-issues/issues/12094
           command: |
-            conda create -n hydra python=<< parameters.py_version >> pywin32 virtualenv==20.0.33 -qy
+            conda create -n hydra python=<< parameters.py_version >> pywin32=225 virtualenv==20.0.33 -qy
             conda activate hydra
-            curl.exe -o pywin32_postinstall.py https://raw.githubusercontent.com/mhammond/pywin32/master/pywin32_postinstall.py
-            python.exe pywin32_postinstall.py -install
             pip install nox dataclasses --progress-bar off
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-win-sys-{{ .Branch }}-<< parameters.py_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ commands:
           name: Preparing environment - Hydra
           # Using virtualenv==20.0.33 higher versions of virtualenv are not compatible with conda on windows. Relevant issue: https://github.com/ContinuumIO/anaconda-issues/issues/12094
           command: |
-            conda create -n hydra python=<< parameters.py_version >> pywin32=225 virtualenv==20.0.33 -qy
+            conda create -n hydra python=<< parameters.py_version >> virtualenv==20.0.33 -qy
             conda activate hydra
             pip install nox dataclasses --progress-bar off
       - save_cache:

--- a/noxfile.py
+++ b/noxfile.py
@@ -474,6 +474,8 @@ def test_jupyter_notebooks(session):
 
     session.install("jupyter", "nbval", "pyzmq")
     if platform.system() == "Windows":
+        # Newer versions of pywin32 are causing CI issues on Windows.
+        # see https://github.com/mhammond/pywin32/issues/1709
         session.install("pywin32==225")
 
     install_hydra(session, ["pip", "install", "-e"])

--- a/noxfile.py
+++ b/noxfile.py
@@ -474,7 +474,7 @@ def test_jupyter_notebooks(session):
 
     session.install("jupyter", "nbval", "pyzmq")
     if platform.system() == "Windows":
-        session.install("pywin32==300")
+        session.install("pywin32==225")
 
     install_hydra(session, ["pip", "install", "-e"])
     args = pytest_args(

--- a/noxfile.py
+++ b/noxfile.py
@@ -474,7 +474,7 @@ def test_jupyter_notebooks(session):
 
     session.install("jupyter", "nbval", "pyzmq")
     if platform.system() == "Windows":
-        session.install("pywin32=300")
+        session.install("pywin32==300")
 
     install_hydra(session, ["pip", "install", "-e"])
     args = pytest_args(

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import List
 
 import nox
+import system
 from nox.logger import logger
 
 BASE = os.path.abspath(os.path.dirname(__file__))
@@ -473,6 +474,9 @@ def test_jupyter_notebooks(session):
         )
 
     session.install("jupyter", "nbval", "pyzmq")
+    if sys.platform.system() == "Windows":
+        session.install("pywin32=300")
+
     install_hydra(session, ["pip", "install", "-e"])
     args = pytest_args(
         "--nbval", "examples/jupyter_notebooks/compose_configs_in_notebook.ipynb"

--- a/noxfile.py
+++ b/noxfile.py
@@ -473,8 +473,6 @@ def test_jupyter_notebooks(session):
         )
 
     session.install("jupyter", "nbval", "pyzmq")
-    if platform.system() == "Windows":
-        session.install("pywin32==225")
 
     install_hydra(session, ["pip", "install", "-e"])
     args = pytest_args(

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import List
 
 import nox
-import system
 from nox.logger import logger
 
 BASE = os.path.abspath(os.path.dirname(__file__))
@@ -474,7 +473,7 @@ def test_jupyter_notebooks(session):
         )
 
     session.install("jupyter", "nbval", "pyzmq")
-    if sys.platform.system() == "Windows":
+    if platform.system() == "Windows":
         session.install("pywin32=300")
 
     install_hydra(session, ["pip", "install", "-e"])

--- a/noxfile.py
+++ b/noxfile.py
@@ -473,6 +473,8 @@ def test_jupyter_notebooks(session):
         )
 
     session.install("jupyter", "nbval", "pyzmq")
+    if platform.system() == "Windows":
+        session.install("pywin32==225")
 
     install_hydra(session, ["pip", "install", "-e"])
     args = pytest_args(


### PR DESCRIPTION
This is an attempt to patch a failing CI build.
For an example of the failure, see the failed `ci/circleci: test_win-3.8` check from #1649.
This patch is based on a suggestion from [this issue](https://github.com/mhammond/pywin32/issues/1709) from the pywin32 repo.