### PR TITLE
enable --resolve flag usage with --help

### DIFF
--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -300,7 +300,11 @@ class Hydra:
         return s
 
     def get_help(
-        self, help_cfg: DictConfig, cfg: DictConfig, args_parser: ArgumentParser
+        self,
+        help_cfg: DictConfig,
+        cfg: DictConfig,
+        args_parser: ArgumentParser,
+        resolve: bool,
     ) -> str:
         s = string.Template(help_cfg.template)
 
@@ -314,7 +318,7 @@ class Hydra:
             FLAGS_HELP=self.format_args_help(args_parser),
             HYDRA_CONFIG_GROUPS=self.format_config_groups(is_hydra_group),
             APP_CONFIG_GROUPS=self.format_config_groups(is_not_hydra_group),
-            CONFIG=OmegaConf.to_yaml(cfg, resolve=False),
+            CONFIG=OmegaConf.to_yaml(cfg, resolve=resolve),
         )
         return help_text
 
@@ -329,7 +333,7 @@ class Hydra:
         )
         help_cfg = cfg.hydra.hydra_help
         cfg = self.get_sanitized_hydra_cfg(cfg)
-        help_text = self.get_help(help_cfg, cfg, args_parser)
+        help_text = self.get_help(help_cfg, cfg, args_parser, resolve=False)
         print(help_text)
 
     def app_help(
@@ -346,7 +350,9 @@ class Hydra:
 
         with flag_override(clean_cfg, ["struct", "readonly"], [False, False]):
             del clean_cfg["hydra"]
-        help_text = self.get_help(help_cfg, clean_cfg, args_parser)
+        help_text = self.get_help(
+            help_cfg, clean_cfg, args_parser, resolve=args.resolve
+        )
         print(help_text)
 
     @staticmethod

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -339,13 +339,17 @@ def _run_hydra(
         if args.help:
             hydra.app_help(config_name=config_name, args_parser=args_parser, args=args)
             sys.exit(0)
+        has_show_cfg = args.cfg is not None
+        if args.resolve and (not has_show_cfg and not args.help):
+            raise ValueError(
+                "The --resolve flag can only be used in conjunction with --cfg or --help"
+            )
         if args.hydra_help:
             hydra.hydra_help(
                 config_name=config_name, args_parser=args_parser, args=args
             )
             sys.exit(0)
 
-        has_show_cfg = args.cfg is not None
         num_commands = (
             args.run
             + has_show_cfg
@@ -359,10 +363,6 @@ def _run_hydra(
             )
         if num_commands == 0:
             args.run = True
-        if args.resolve and not has_show_cfg:
-            raise ValueError(
-                "The --resolve flag can only be used in conjunction with --cfg"
-            )
         if args.run:
             run_and_report(
                 lambda: hydra.run(

--- a/news/1482.feature
+++ b/news/1482.feature
@@ -1,1 +1,1 @@
-Add support resolving interpolations the config printed by `--help` via the `--resolve` flag.
+Add support for resolving interpolations in the config printed by `--help` via the `--resolve` flag.

--- a/news/1482.feature
+++ b/news/1482.feature
@@ -1,0 +1,1 @@
+Enable using the --resolve and --help flags together on the command line to resolve interpolations in app config before printing app help.

--- a/news/1482.feature
+++ b/news/1482.feature
@@ -1,1 +1,1 @@
-Enable using the --resolve and --help flags together on the command line to resolve interpolations in app config before printing app help.
+Add support resolving interpolations the config printed by `--help` via the `--resolve` flag.


### PR DESCRIPTION
This PR adds compatibility between the `--help` flag and `--resolve` flag.
In particular, if the app help displayed by running `python my_app.py --help` contains the `$CONFIG` key, it is now possible to have interpolations in the displayed config resolved by including the `--resolve` flag (`python my_app.py --help --resolve`).

Closes #1482.