### PR TITLE
Change hydra.job_logging and hydra.hydra_logging to be non-optional

### DIFF
--- a/hydra/conf/__init__.py
+++ b/hydra/conf/__init__.py
@@ -125,9 +125,9 @@ class HydraConf:
     # Multi-run output configuration
     sweep: SweepDir = SweepDir()
     # Logging configuration for Hydra
-    hydra_logging: Any = MISSING
+    hydra_logging: Dict[str, Any] = MISSING
     # Logging configuration for the job
-    job_logging: Any = MISSING
+    job_logging: Dict[str, Any] = MISSING
 
     # Sweeper configuration
     sweeper: Any = MISSING

--- a/news/1656.bugfix
+++ b/news/1656.bugfix
@@ -1,0 +1,1 @@
+Change hydra.job_logging and hydra.hydra_logging to be non-optional

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -615,3 +615,32 @@ def test_initialize_without_config_path(tmpdir: Path) -> None:
     with warns(expected_warning=UserWarning, match=re.escape(expected)):
         with initialize():
             pass
+
+
+@mark.usefixtures("initialize_hydra_no_path")
+@mark.parametrize(
+    ("overrides", "expected"),
+    [
+        param(
+            ["hydra.hydra_logging=null"],
+            raises(
+                ConfigCompositionException,
+                match="Error merging override hydra.hydra_logging=null",
+            ),
+            id="hydra.hydra_logging=null",
+        ),
+        param(
+            ["hydra.job_logging=null"],
+            raises(
+                ConfigCompositionException,
+                match="Error merging override hydra.job_logging=null",
+            ),
+            id="hydra.job_logging=null",
+        ),
+    ],
+)
+def test_error_assigning_null_to_logging_config(
+    hydra_restore_singletons: Any, overrides: List[str], expected: Any
+) -> None:
+    with expected:
+        compose(overrides=overrides)


### PR DESCRIPTION
None logging config objects were never supported but the config structure did not enforce it.

Closes #1656.

Manual testing with:
```
$ python examples/tutorials/basic/your_first_hydra_app/1_simple_cli/my_app.py hydra.job_logging=null
Error merging override hydra.job_logging=null
child 'hydra.job_logging' is not Optional
    full_key: hydra.job_logging
    object_type=HydraConf
```

I don't think this is justifying a unit test. The important thing is that the remaining logging tests are still passing.