### PR TITLE
Allow range(stop) with default start for override grammar

### DIFF
--- a/hydra/_internal/grammar/grammar_functions.py
+++ b/hydra/_internal/grammar/grammar_functions.py
@@ -184,7 +184,9 @@ def choice(
 
 
 def range(
-    start: Union[int, float], stop: Union[int, float], step: Union[int, float] = 1
+    start: Union[int, float],
+    stop: Optional[Union[int, float]] = None,
+    step: Union[int, float] = 1,
 ) -> RangeSweep:
     """
     Range is defines a sweeep over a range of integer or floating-point values.
@@ -193,6 +195,9 @@ def range(
     For a negative step, the contents of the range are still determined by the formula
      r[i] = start + step*i, but the constraints are i >= 0 and r[i] > stop.
     """
+    if stop is None:
+        stop = start
+        start = 0
     return RangeSweep(start=start, stop=stop, step=step)
 
 

--- a/hydra/_internal/grammar/grammar_functions.py
+++ b/hydra/_internal/grammar/grammar_functions.py
@@ -189,7 +189,9 @@ def range(
     step: Union[int, float] = 1,
 ) -> RangeSweep:
     """
-    Range is defines a sweeep over a range of integer or floating-point values.
+    Range defines a sweep over a range of integer or floating-point values.
+    When only start is defined, it is set as the stop value, and start is set at
+    zero.
     For a positive step, the contents of a range r are determined by the formula
      r[i] = start + step*i where i >= 0 and r[i] < stop.
     For a negative step, the contents of the range are still determined by the formula

--- a/news/1664.feature
+++ b/news/1664.feature
@@ -1,0 +1,1 @@
+Allow range() in override grammar to have only one argument (the stop value), e.g. range(3)

--- a/tests/test_basic_sweeper.py
+++ b/tests/test_basic_sweeper.py
@@ -46,6 +46,7 @@ from hydra.test_utils.test_utils import assert_regex_match, run_process
             id="batches_of_2",
         ),
         param(["a=range(0,3)"], None, [[["a=0"], ["a=1"], ["a=2"]]], id="range"),
+        param(["a=range(3)"], None, [[["a=0"], ["a=1"], ["a=2"]]], id="range_no_start"),
     ],
 )
 def test_split(

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -402,6 +402,19 @@ def test_simple_choice_sweep(value: str, expected: Any) -> None:
             RangeSweep(start=1.0, stop=3.14, step=0.1),
             id="floats_with_step",
         ),
+        param("range(10)", RangeSweep(start=0, stop=10, step=1), id="no_start"),
+        param("range(-10)", RangeSweep(start=0, stop=-10, step=1), id="no_start_empty"),
+        param(
+            "range(-10, step=-1)",
+            RangeSweep(start=0, stop=-10, step=-1),
+            id="no_start_negative",
+        ),
+        param("range(5.5)", RangeSweep(start=0, stop=5.5, step=1), id="no_start_float"),
+        param(
+            "range(5.5, step=0.5)",
+            RangeSweep(start=0, stop=5.5, step=0.5),
+            id="no_start_step_float",
+        ),
     ],
 )
 def test_range_sweep(value: str, expected: Any) -> None:

--- a/website/docs/advanced/override_grammar/extended.md
+++ b/website/docs/advanced/override_grammar/extended.md
@@ -86,7 +86,7 @@ Unlike Python, Hydra's range can be used with both integer and floating-point nu
 In both cases, the range represents a discrete list of values.
 ```python title="Signature"
 def range(
-    start: Union[int, float], stop: Union[int, float], step: Union[int, float] = 1
+    start: Union[int, float], stop: Optional[Union[int, float]] = None, step: Union[int, float] = 1
 ) -> RangeSweep:
     """
     Range is defines a sweeep over a range of integer or floating-point values.
@@ -98,6 +98,7 @@ def range(
 ```
 
 ```python title="Examples"
+num=range(5)                          # 0,1,2,3,4
 num=range(0,5)                        # 0,1,2,3,4
 num=range(0,5,2)                      # 0,2,4
 num=range(0,10,3.3)                   # 0.0,3.3,6.6,9.9

--- a/website/docs/advanced/override_grammar/extended.md
+++ b/website/docs/advanced/override_grammar/extended.md
@@ -102,6 +102,7 @@ num=range(5)                          # 0,1,2,3,4
 num=range(0,5)                        # 0,1,2,3,4
 num=range(0,5,2)                      # 0,2,4
 num=range(0,10,3.3)                   # 0.0,3.3,6.6,9.9
+num=range(-5,step=-1)                 # 0,-1,-2,-3,-4
 ```
 
 ### Interval sweep


### PR DESCRIPTION
## Motivation

To make the range function more like the default python range(), and easier to type, I added a check if only start was added to set stop to start and start to zero.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

tested by adding a parametrize argument in `test_basic_sweeper.py`.

## Related Issues and PRs

N/A
