### PR TITLE
Relax restriction on defaults list interpolation

### DIFF
--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -543,13 +543,6 @@ def _create_defaults_tree_impl(
 
     for idx, dd in enumerate(children):
         if isinstance(dd, InputDefault) and dd.is_interpolation():
-            if not parent.primary:
-                # Interpolations from nested configs would require much more work
-                # If you have a compelling use case please file an feature request.
-                path = parent.get_config_path()
-                raise ConfigCompositionException(
-                    f"In '{path}': Defaults List interpolation is only supported in the primary config"
-                )
             dd.resolve_interpolation(known_choices)
             new_root = DefaultsTreeNode(node=dd, parent=root)
             dd.update_parent(parent.get_group_path(), parent.get_final_package())

--- a/news/1668.bugfix
+++ b/news/1668.bugfix
@@ -1,0 +1,1 @@
+Allow Defaults List interpolation in nested configs and document that the interpolation keys must be absolute

--- a/tests/defaults_list/data/group1/interpolation.yaml
+++ b/tests/defaults_list/data/group1/interpolation.yaml
@@ -1,3 +1,2 @@
 defaults:
-  - group2: file1
-  - group3: ${group2}
+  - group2: ${group1}_ext

--- a/tests/defaults_list/data/group1/resolver.yaml
+++ b/tests/defaults_list/data/group1/resolver.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - group2: ${oc.decode:file1}

--- a/tests/defaults_list/data/interpolation_resolver_in_nested.yaml
+++ b/tests/defaults_list/data/interpolation_resolver_in_nested.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - group1: resolver

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -1493,13 +1493,38 @@ def test_placeholder(
         param(
             "interpolation_in_nested",
             [],
-            raises(
-                ConfigCompositionException,
-                match=re.escape(
-                    "In 'group1/interpolation': Defaults List interpolation is only supported in the primary config"
-                ),
+            DefaultsTreeNode(
+                node=ConfigDefault(path="interpolation_in_nested"),
+                children=[
+                    DefaultsTreeNode(
+                        node=GroupDefault(group="group1", value="interpolation"),
+                        children=[
+                            GroupDefault(group="group2", value="interpolation_ext"),
+                            ConfigDefault(path="_self_"),
+                        ],
+                    ),
+                    ConfigDefault(path="_self_"),
+                ],
             ),
             id="interpolation_in_nested",
+        ),
+        param(
+            "interpolation_resolver_in_nested",
+            [],
+            DefaultsTreeNode(
+                node=ConfigDefault(path="interpolation_resolver_in_nested"),
+                children=[
+                    DefaultsTreeNode(
+                        node=GroupDefault(group="group1", value="resolver"),
+                        children=[
+                            GroupDefault(group="group2", value="file1"),
+                            ConfigDefault(path="_self_"),
+                        ],
+                    ),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="interpolation_resolver_in_nested",
         ),
         param(
             "interpolation_config_default",

--- a/website/docs/advanced/defaults_list.md
+++ b/website/docs/advanced/defaults_list.md
@@ -212,13 +212,13 @@ Interpolation keys can be config groups with any @package overrides.
 For example: `${db/engine}`, `${db@backup}`
 
 The selected option for *combination_specific_config* depends on the final selected options for *db* and *server*.  
-e.g. If *db* is overridden to *sqlite*, *combination_specific_config* will become *apache_sqlite*.
+e.g., If *db* is overridden to *sqlite*, *combination_specific_config* will become *apache_sqlite*.
 
 #### Restrictions:
 
- - Defaults List interpolation is only supported in the primary config.
- - The subtree expanded by an Interpolated Config may not contain overrides.
- - Interpolation Keys in the Defaults List cannot reference values in the Final Config Object (it does not yet).
+ - Interpolation keys in the Defaults List cannot reference values in the Final Config Object (it does not yet exist).
+ - Defaults List interpolation keys are absolute (even in nested configs).
+ - The subtree expanded by an Interpolated Config may not contain Default List overrides.
 
 See [Patterns/Specializing Configs](/patterns/specializing_config.md) for more information.
 


### PR DESCRIPTION
Defaults List interpolation in nested configs is now allowed.
The keys must be absolute even in nested configs (unlike other config keys in the nested defaults list).

This also resolves the issues custom resolvers in nested configs.

Closes #1668.

NOTE:
By allowing nested interpolations in the Defaults List, we are making a decision that interpolation keys (db.foo, db.foo@pkg1.pkg2) in the defaults list are absolute config groups (like in the primary config).
Enabling relative interpolation keys is very tricky, and It's also not clear to me that it's the correct design.

Once this is in, a change making them relative in the future will be a hard breaking change for people using it.
However, only a small fraction of the users are using Defaults List interpolations to begin with so I think it's an acceptable risk.