### PR TITLE
docs: remove duplicate contents "Config Search Path" in the category "Reference manual" on the sidebar

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -106,7 +106,6 @@ module.exports = {
             },
             'advanced/defaults_list',
             'advanced/overriding_packages',
-            'advanced/search_path',
             {
                 type: 'category',
                 label: 'Instantiating Objects',
@@ -117,6 +116,7 @@ module.exports = {
                 ]
             },
             'advanced/compose_api',
+            'advanced/search_path',
             {
                 type: 'category',
                 label: 'Plugins',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -117,7 +117,6 @@ module.exports = {
                 ]
             },
             'advanced/compose_api',
-            'advanced/search_path',
             {
                 type: 'category',
                 label: 'Plugins',

--- a/website/versioned_sidebars/version-1.1-sidebars.json
+++ b/website/versioned_sidebars/version-1.1-sidebars.json
@@ -297,10 +297,6 @@
           "id": "version-1.1/advanced/compose_api"
         },
         {
-          "type": "doc",
-          "id": "version-1.1/advanced/search_path"
-        },
-        {
           "collapsed": true,
           "type": "category",
           "label": "Plugins",

--- a/website/versioned_sidebars/version-1.1-sidebars.json
+++ b/website/versioned_sidebars/version-1.1-sidebars.json
@@ -270,10 +270,6 @@
           "id": "version-1.1/advanced/overriding_packages"
         },
         {
-          "type": "doc",
-          "id": "version-1.1/advanced/search_path"
-        },
-        {
           "collapsed": true,
           "type": "category",
           "label": "Instantiating Objects",
@@ -295,6 +291,10 @@
         {
           "type": "doc",
           "id": "version-1.1/advanced/compose_api"
+        },
+        {
+          "type": "doc",
+          "id": "version-1.1/advanced/search_path"
         },
         {
           "collapsed": true,


### PR DESCRIPTION
## Motivation

To fix documentation.
I removed duplicate contents "Config Search Path" in the category "Reference manual" on the sidebar in docs.

- before removing
  - there are two "Config Search Path" on the sidebar.

<img width="500" alt="before" src="https://user-images.githubusercontent.com/42367320/122668382-ba21cc00-d1f2-11eb-9c7a-59287baee795.png">

- after removing
  - removed one

<img width="500" alt="after" src="https://user-images.githubusercontent.com/42367320/122668384-c017ad00-d1f2-11eb-8aa4-997d806d79cf.png">


### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

N/A

## Related Issues and PRs

N/A