### PR TITLE
[configen] Add support for `*args` and `**kwargs`

### DIFF
--- a/tools/configen/configen/configen.py
+++ b/tools/configen/configen/configen.py
@@ -169,8 +169,14 @@ def generate_module(cfg: ConfigenConf, module: ModuleConf) -> str:
         params: List[Parameter] = []
         params = params + default_flags
 
-        for name, p in sig.parameters.items():
-            type_ = original_type = resolved_hints.get(name, sig.empty)
+        for i, (name, p) in enumerate(sig.parameters.items()):
+            if p.kind == p.VAR_KEYWORD:  # `**kwargs` parameter
+                continue
+            elif p.kind == p.VAR_POSITIONAL and i > 0:  # `*args` parameter
+                # hydra supports positional arguments only as the first arg
+                continue
+
+            type_or_empty = original_type = resolved_hints.get(name, sig.empty)
             default_ = p.default
 
             missing_value = default_ == sig.empty
@@ -178,17 +184,20 @@ def generate_module(cfg: ConfigenConf, module: ModuleConf) -> str:
                 type(default_)
             )
 
-            missing_annotation_type = type_ == sig.empty
+            missing_annotation_type = type_or_empty == sig.empty
             incompatible_annotation_type = (
-                not missing_annotation_type and is_incompatible(type_)
+                not missing_annotation_type and is_incompatible(type_or_empty)
             )
 
+            type_: type
             if missing_annotation_type or incompatible_annotation_type:
                 type_ = Any
                 collect_imports(imports, Any)
+            else:
+                type_ = type_or_empty
 
             if not missing_value:
-                if type_ == str or type(default_) == str:
+                if type_ is str or type(default_) == str:
                     default_ = f'"{default_}"'
                 elif isinstance(default_, list):
                     default_ = f"field(default_factory=lambda: {default_})"
@@ -213,6 +222,10 @@ def generate_module(cfg: ConfigenConf, module: ModuleConf) -> str:
                 else:
                     default_ = "MISSING"
                 string_imports.add("from omegaconf import MISSING")
+
+            if p.kind == p.VAR_POSITIONAL:  # `*args` parameter
+                name = "_args_"
+                type_ = List[type_]
 
             params.append(
                 Parameter(

--- a/tools/configen/tests/test_generate.py
+++ b/tools/configen/tests/test_generate.py
@@ -31,6 +31,10 @@ from tests.test_modules import (
     DictValues,
     PeskySentinelUsage,
     Tuples,
+    Args,
+    ArgsNotFirst,
+    ArgsNoType,
+    Kwargs,
 )
 
 from tests.test_modules.generated import PeskySentinelUsageConf
@@ -72,6 +76,10 @@ def test_generated_code() -> None:
         "ListValues",
         "DictValues",
         "Tuples",
+        "Args",
+        "ArgsNotFirst",
+        "ArgsNoType",
+        "Kwargs",
         "PeskySentinelUsage",
     ]
     expected_file = Path(MODULE_NAME.replace(".", "/")) / "generated.py"
@@ -271,6 +279,38 @@ def test_generated_code_with_default_flags(
             {"foo": 10.11},
             PeskySentinelUsage(foo=10.11),
             id="PeskySentinelUsage",
+        ),
+        param(
+            "Args",
+            {"_args_": [2.5, 3.6], "flag": True},
+            [],
+            {},
+            Args(2.5, 3.6, flag=True),
+            id="Args",
+        ),
+        param(
+            "ArgsNotFirst",
+            {"num": 3},
+            [],
+            {},
+            ArgsNotFirst(3),
+            id="ArgsNotFirst",
+        ),
+        param(
+            "ArgsNoType",
+            {"_args_": [3, 2, 4]},
+            [],
+            {},
+            ArgsNoType(3, 2, 4),
+            id="ArgsNoType",
+        ),
+        param(
+            "Kwargs",
+            {"num": 3},
+            [],
+            {"arg1": "foo", "arg2": "bar", "arg3": ""},
+            Kwargs(3, arg1="foo", arg2="bar", arg3=""),
+            id="Kwargs",
         ),
     ],
 )

--- a/tools/configen/tests/test_modules/__init__.py
+++ b/tools/configen/tests/test_modules/__init__.py
@@ -214,3 +214,50 @@ class Tuples:
             and self.t2 == other.t2
             and self.t3 == other.t3
         )
+
+
+class Args:
+    def __init__(self, *args: float, flag: bool = False):
+        self.arg_list = args
+        self.flag = flag
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, type(self))
+            and self.arg_list == other.arg_list
+            and self.flag == other.flag
+        )
+
+
+class ArgsNotFirst:
+    def __init__(self, num: int, *args: float):
+        self.num = num
+        self.arg_list = args
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, type(self))
+            and self.num == other.num
+            and self.arg_list == other.arg_list
+        )
+
+
+class ArgsNoType:
+    def __init__(self, *args):
+        self.arg_list = args
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, type(self)) and self.arg_list == other.arg_list
+
+
+class Kwargs:
+    def __init__(self, num: int, **kwargs: str):
+        self.num = num
+        self.arg_dict = kwargs
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, type(self))
+            and self.num == other.num
+            and self.arg_dict == other.arg_dict
+        )

--- a/tools/configen/tests/test_modules/generated.py
+++ b/tools/configen/tests/test_modules/generated.py
@@ -96,6 +96,31 @@ class TuplesConf:
 
 
 @dataclass
+class ArgsConf:
+    _target_: str = "tests.test_modules.Args"
+    _args_: List[float] = MISSING
+    flag: bool = False
+
+
+@dataclass
+class ArgsNotFirstConf:
+    _target_: str = "tests.test_modules.ArgsNotFirst"
+    num: int = MISSING
+
+
+@dataclass
+class ArgsNoTypeConf:
+    _target_: str = "tests.test_modules.ArgsNoType"
+    _args_: List[Any] = MISSING
+
+
+@dataclass
+class KwargsConf:
+    _target_: str = "tests.test_modules.Kwargs"
+    num: int = MISSING
+
+
+@dataclass
 class PeskySentinelUsageConf:
     _target_: str = "tests.test_modules.PeskySentinelUsage"
     foo: Any = MISSING  # PeskySentinel


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

It would be nice if configen could handle `__init__` functions with `*args` and `**kwargs`:

```python
class MyClass:
    def __init__(self, *args: int, foo: str = "bar", **kwargs: str):
        ...
```

`*args` can be translated to `_args_`, and for `**kwargs` there is really not anything that configen can do with it,
so we'll just skip it. So, the above will be turned into

```python
@dataclass
class MyClass Conf:
    _args_: List[int] = MISSING
    foo: str = "bar"
```

There is also the difficulty that hydra seems to only allow `*args` as the first argument. Thus, we'll skip that as well if it appears at any other position.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

I added tests to verify the new behavior.

## Related Issues and PRs

No related issues to my knowledge.
