### PR TITLE
remove dead code

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -5,7 +5,6 @@ import re
 import sys
 import warnings
 from collections import defaultdict
-from dataclasses import dataclass
 from textwrap import dedent
 from typing import Any, Dict, List, MutableSequence, Optional
 

--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -36,12 +36,6 @@ from hydra.plugins.config_source import ConfigLoadError, ConfigResult, ConfigSou
 from hydra.types import RunMode
 
 
-@dataclass
-class SplitOverrides:
-    config_group_overrides: List[Override]
-    config_overrides: List[Override]
-
-
 class ConfigLoaderImpl(ConfigLoader):
     """
     Configuration loader


### PR DESCRIPTION
I believe that the `SplitOverrides` class is dead code. This PR removes it.