### PR TITLE
Fixed +experinent=foo causing unexpected changes to defaults list

### DIFF
--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -98,6 +98,7 @@ class Overrides:
                         group=override.key_or_group,
                         package=override.package,
                         value=value,
+                        external_append=True,
                     )
                 )
             else:
@@ -364,7 +365,9 @@ def _update_overrides(
             assert d.group is not None
             legacy_hydra_override = not d.is_override() and d.group.startswith("hydra/")
 
-        if seen_override and not (d.is_override() or legacy_hydra_override):
+        if seen_override and not (
+            d.is_override() or d.is_external_append() or legacy_hydra_override
+        ):
             assert isinstance(last_override_seen, GroupDefault)
             pcp = parent.get_config_path()
             okey = last_override_seen.get_override_key()
@@ -467,14 +470,7 @@ def _create_defaults_tree_impl(
         self_added = _validate_self(containing_node=parent, defaults=defaults_list)
 
     if is_root_config:
-        # To ensure config overrides are last, insert the external overrides before the first config override.
-        insert_idx = len(defaults_list)
-        for idx, default in enumerate(defaults_list):
-            if default.is_override():
-                insert_idx = idx
-                break
-
-        defaults_list[insert_idx:insert_idx] = overrides.append_group_defaults
+        defaults_list.extend(overrides.append_group_defaults)
 
     _update_overrides(defaults_list, overrides, parent, interpolated_subtree)
 

--- a/hydra/core/default_element.py
+++ b/hydra/core/default_element.py
@@ -261,6 +261,9 @@ class InputDefault:
     def is_override(self) -> bool:
         raise NotImplementedError()
 
+    def is_external_append(self) -> bool:
+        raise NotImplementedError()
+
 
 @dataclass
 class VirtualRoot(InputDefault):
@@ -304,6 +307,9 @@ class VirtualRoot(InputDefault):
         raise NotImplementedError()
 
     def is_override(self) -> bool:
+        return False
+
+    def is_external_append(self) -> bool:
         return False
 
 
@@ -420,6 +426,9 @@ class ConfigDefault(InputDefault):
     def is_override(self) -> bool:
         return False
 
+    def is_external_append(self) -> bool:
+        return False
+
 
 _legacy_interpolation_pattern: Pattern[str] = re.compile(r"\${defaults\.\d\.")
 
@@ -436,6 +445,8 @@ class GroupDefault(InputDefault):
     deleted: Optional[bool] = None
 
     config_name_overridden: bool = field(default=False, compare=False, repr=False)
+    # True if this item was added using +foo=bar from the external overrides
+    external_append: bool = field(default=False, compare=False, repr=False)
 
     def __post_init__(self) -> None:
         assert self.group is not None and self.group != ""
@@ -552,6 +563,9 @@ See http://hydra.cc/docs/next/upgrades/1.0_to_1.1/defaults_list_interpolation fo
         if default_pkg != self.get_package() and self.package is not None:
             key = f"{key}@{self.package}"
         return key
+
+    def is_external_append(self) -> bool:
+        return self.external_append
 
 
 @dataclass

--- a/news/1706.bugfix
+++ b/news/1706.bugfix
@@ -1,0 +1,1 @@
+Fix unexpected changes to defaults list in some cases when appending an experiment (+experiment=test)

--- a/tests/defaults_list/data/override_hydra.yaml
+++ b/tests/defaults_list/data/override_hydra.yaml
@@ -1,0 +1,3 @@
+defaults:
+  - group1: file1
+  - override hydra/output: disabled

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -921,6 +921,52 @@ def test_group_default_with_appended_experiment(
     "config_name,overrides,expected",
     [
         param(
+            "override_hydra",
+            ["+experiment=override_config_group"],
+            DefaultsTreeNode(
+                node=VirtualRoot(),
+                children=[
+                    DefaultsTreeNode(
+                        node=ConfigDefault(path="hydra/config"),
+                        children=[
+                            GroupDefault(group="help", value="default"),
+                            GroupDefault(group="output", value="disabled"),
+                            ConfigDefault(path="_self_"),
+                        ],
+                    ),
+                    DefaultsTreeNode(
+                        node=ConfigDefault(path="override_hydra"),
+                        children=[
+                            GroupDefault(group="group1", value="file2"),
+                            ConfigDefault(path="_self_"),
+                            GroupDefault(
+                                group="experiment", value="override_config_group"
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            id="override_hydra_with_experiment",
+        ),
+    ],
+)
+def test_experiment_where_primary_config_has_override(
+    config_name: str,
+    overrides: List[str],
+    expected: DefaultsTreeNode,
+) -> None:
+    _test_defaults_tree_impl(
+        config_name=config_name,
+        input_overrides=overrides,
+        expected=expected,
+        prepend_hydra=True,
+    )
+
+
+@mark.parametrize(
+    "config_name,overrides,expected",
+    [
+        param(
             "group_default",
             ["+experiment=include_absolute_config"],
             DefaultsTreeNode(


### PR DESCRIPTION
This is undoing a previous bug fix for a related problem that attempted to insert the external overrides in the right place.
The idea behind forcing the order is just to communicate to the user that overrides are special and applies to what comes before. In practice the implementation should work correctly even if they are not.

The solution introduced here is to exempt external overrides from the order check.

Closes #1706 
