### PR TITLE
ray remote resources as plain dict

### DIFF
--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_launcher_util.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_launcher_util.py
@@ -10,7 +10,7 @@ from hydra.core.hydra_config import HydraConfig
 from hydra.core.singleton import Singleton
 from hydra.core.utils import JobReturn, run_job, setup_globals
 from hydra.types import HydraContext, TaskFunction
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 # mypy complains about "unused type: ignore comment" on macos
 # workaround adapted from: https://github.com/twisted/twisted/pull/1416
@@ -64,7 +64,9 @@ def launch_job_on_ray(
     singleton_state: Any,
 ) -> Any:
     if ray_remote:
-        run_job_ray = ray.remote(**ray_remote)(_run_job)
+        run_job_ray = ray.remote(**OmegaConf.to_container(ray_remote, resolve=True))(
+            _run_job
+        )
     else:
         run_job_ray = ray.remote(_run_job)
 


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation
 Fix error with custom resources on ray launcher.
`TypeError: The 'resources' keyword argument must be a dictionary, but received type <class 'omegaconf.dictconfig.DictConfig'>.`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

No, sorry

## Test Plan

Tested locally. This is a very simple mod and shouldn't break anything else.

## Related Issues and PRs

Nope