### PR TITLE
mention `_self_` in basic & structured conf tutorial

### DIFF
--- a/website/docs/tutorials/basic/your_first_app/5_defaults.md
+++ b/website/docs/tutorials/basic/your_first_app/5_defaults.md
@@ -49,6 +49,11 @@ The defaults are ordered:
  * If multiple configs define the same value, the last one wins. 
  * If multiple configs contribute to the same dictionary, the result is the combined dictionary.
 
+If your `config.yaml` file defines additional keys and values (outside of the
+defaults list), you may wish to control the way that these keys/values are
+combined with the configs from the defaults list.
+This can be controlled by inserting the `_self_` keyword into the defaults list.
+See [Compositon Order](advanced/defaults_list.md#composition-order) for more information.
 
 #### Overriding a config group default
 

--- a/website/docs/tutorials/structured_config/4_defaults.md
+++ b/website/docs/tutorials/structured_config/4_defaults.md
@@ -95,6 +95,14 @@ Available options:
         postgresql
 ```
 
+</div>
+</div>
 
-</div>
-</div>
+#### Merge order for combining a defaults list with other structured config fields
+
+Just like with defaults lists in `yaml` files, the `_self_` keyword can be used
+in a defaults list that is part of a structured config.
+Using `_self_` in a structured config's defaults list gives explicit control
+over the order in which the structured config's fields are merged with the
+configs from the defaults list
+(see [Compositon Order](advanced/defaults_list.md#composition-order)).


### PR DESCRIPTION
Some updates to the docs r.e. use of `_self_` in defaults lists.