### PR TITLE
handle frame in stack trace that doesn't have a module

### DIFF
--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -7,7 +7,7 @@ import sys
 from dataclasses import dataclass
 from os.path import dirname, join, normpath, realpath
 from traceback import print_exc, print_exception
-from types import FrameType
+from types import FrameType, TracebackType
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 
 from omegaconf.errors import OmegaConfBaseException
@@ -223,7 +223,7 @@ def run_and_report(func: Any) -> Any:
                 # It is possible to add additional libraries to sanitize from the bottom later,
                 # maybe even make it configurable.
 
-                tb: Any = ex.__traceback__
+                tb = ex.__traceback__
                 search_max = 10
                 # strip Hydra frames from start of stack
                 # will strip until it hits run_job()
@@ -243,7 +243,7 @@ def run_and_report(func: Any) -> Any:
                     sys.exit(1)
 
                 # strip OmegaConf frames from bottom of stack
-                end = tb
+                end: Optional[TracebackType] = tb
                 num_frames = 0
                 while end is not None:
                     frame = end.tb_frame
@@ -276,6 +276,7 @@ def run_and_report(func: Any) -> Any:
                     added = added + 1
                     cur.tb_next = FakeTracebackType()
                     cur = cur.tb_next
+                    assert iter_tb.tb_next is not None
                     iter_tb = iter_tb.tb_next
 
                 print_exception(etype=None, value=ex, tb=final_tb)  # type: ignore

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -284,8 +284,18 @@ def run_and_report(func: Any) -> Any:
                 sys.stderr.write(
                     "\nSet the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.\n"
                 )
-            except Exception:
-                print_exception(etype=None, value=ex, tb=ex.__traceback__)
+            except Exception as ex2:
+                sys.stderr.write(
+                    "An error occurred during Hydra's exception formatting:"
+                    + os.linesep
+                )
+                if ex2.__traceback__ is not None:
+                    fname = ex2.__traceback__.tb_frame.f_code.co_filename
+                    lineno = ex2.__traceback__.tb_lineno
+                    sys.stderr.write(repr(ex2) + f", {fname}:{lineno}" + os.linesep)
+                else:  # pragma: no cover
+                    sys.stderr.write(repr(ex2))
+                raise ex
         sys.exit(1)
 
 

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -248,8 +248,7 @@ def run_and_report(func: Any) -> Any:
                 while end is not None:
                     frame = end.tb_frame
                     mdl = inspect.getmodule(frame)
-                    if mdl is None:
-                        break
+                    assert mdl is not None
                     name = mdl.__name__
                     if name.startswith("omegaconf."):
                         break

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -213,76 +213,79 @@ def run_and_report(func: Any) -> Any:
         if _is_env_set("HYDRA_FULL_ERROR") or is_under_debugger():
             raise ex
         else:
-            if isinstance(ex, CompactHydraException):
-                sys.stderr.write(str(ex) + os.linesep)
-                if isinstance(ex.__cause__, OmegaConfBaseException):
-                    sys.stderr.write(str(ex.__cause__) + os.linesep)
-            else:
-                # Custom printing that strips the Hydra related stack frames from the top
-                # And any omegaconf frames from the bottom.
-                # It is possible to add additional libraries to sanitize from the bottom later,
-                # maybe even make it configurable.
+            try:
+                if isinstance(ex, CompactHydraException):
+                    sys.stderr.write(str(ex) + os.linesep)
+                    if isinstance(ex.__cause__, OmegaConfBaseException):
+                        sys.stderr.write(str(ex.__cause__) + os.linesep)
+                else:
+                    # Custom printing that strips the Hydra related stack frames from the top
+                    # And any omegaconf frames from the bottom.
+                    # It is possible to add additional libraries to sanitize from the bottom later,
+                    # maybe even make it configurable.
 
-                tb = ex.__traceback__
-                search_max = 10
-                # strip Hydra frames from start of stack
-                # will strip until it hits run_job()
-                while search_max > 0:
-                    if tb is None:
-                        break
-                    frame = tb.tb_frame
-                    tb = tb.tb_next
-                    search_max = search_max - 1
-                    if inspect.getframeinfo(frame).function == "run_job":
-                        break
+                    tb = ex.__traceback__
+                    search_max = 10
+                    # strip Hydra frames from start of stack
+                    # will strip until it hits run_job()
+                    while search_max > 0:
+                        if tb is None:
+                            break
+                        frame = tb.tb_frame
+                        tb = tb.tb_next
+                        search_max = search_max - 1
+                        if inspect.getframeinfo(frame).function == "run_job":
+                            break
 
-                if search_max == 0 or tb is None:
-                    # could not detect run_job, probably a runtime exception before we got there.
-                    # do not sanitize the stack trace.
-                    print_exc()
-                    sys.exit(1)
+                    if search_max == 0 or tb is None:
+                        # could not detect run_job, probably a runtime exception before we got there.
+                        # do not sanitize the stack trace.
+                        print_exc()
+                        sys.exit(1)
 
-                # strip OmegaConf frames from bottom of stack
-                end: Optional[TracebackType] = tb
-                num_frames = 0
-                while end is not None:
-                    frame = end.tb_frame
-                    mdl = inspect.getmodule(frame)
-                    assert mdl is not None
-                    name = mdl.__name__
-                    if name.startswith("omegaconf."):
-                        break
-                    end = end.tb_next
-                    num_frames = num_frames + 1
+                    # strip OmegaConf frames from bottom of stack
+                    end: Optional[TracebackType] = tb
+                    num_frames = 0
+                    while end is not None:
+                        frame = end.tb_frame
+                        mdl = inspect.getmodule(frame)
+                        assert mdl is not None
+                        name = mdl.__name__
+                        if name.startswith("omegaconf."):
+                            break
+                        end = end.tb_next
+                        num_frames = num_frames + 1
 
-                @dataclass
-                class FakeTracebackType:
-                    tb_next: Any = None  # Optional["FakeTracebackType"]
-                    tb_frame: Optional[FrameType] = None
-                    tb_lasti: Optional[int] = None
-                    tb_lineno: Optional[int] = None
+                    @dataclass
+                    class FakeTracebackType:
+                        tb_next: Any = None  # Optional["FakeTracebackType"]
+                        tb_frame: Optional[FrameType] = None
+                        tb_lasti: Optional[int] = None
+                        tb_lineno: Optional[int] = None
 
-                iter_tb = tb
-                final_tb = FakeTracebackType()
-                cur = final_tb
-                added = 0
-                while True:
-                    cur.tb_lasti = iter_tb.tb_lasti
-                    cur.tb_lineno = iter_tb.tb_lineno
-                    cur.tb_frame = iter_tb.tb_frame
+                    iter_tb = tb
+                    final_tb = FakeTracebackType()
+                    cur = final_tb
+                    added = 0
+                    while True:
+                        cur.tb_lasti = iter_tb.tb_lasti
+                        cur.tb_lineno = iter_tb.tb_lineno
+                        cur.tb_frame = iter_tb.tb_frame
 
-                    if added == num_frames - 1:
-                        break
-                    added = added + 1
-                    cur.tb_next = FakeTracebackType()
-                    cur = cur.tb_next
-                    assert iter_tb.tb_next is not None
-                    iter_tb = iter_tb.tb_next
+                        if added == num_frames - 1:
+                            break
+                        added = added + 1
+                        cur.tb_next = FakeTracebackType()
+                        cur = cur.tb_next
+                        assert iter_tb.tb_next is not None
+                        iter_tb = iter_tb.tb_next
 
-                print_exception(etype=None, value=ex, tb=final_tb)  # type: ignore
-            sys.stderr.write(
-                "\nSet the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.\n"
-            )
+                    print_exception(etype=None, value=ex, tb=final_tb)  # type: ignore
+                sys.stderr.write(
+                    "\nSet the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.\n"
+                )
+            except Exception:
+                print_exception(etype=None, value=ex, tb=ex.__traceback__)
         sys.exit(1)
 
 

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -248,7 +248,8 @@ def run_and_report(func: Any) -> Any:
                 while end is not None:
                     frame = end.tb_frame
                     mdl = inspect.getmodule(frame)
-                    assert mdl is not None
+                    if mdl is None:
+                        break
                     name = mdl.__name__
                     if name.startswith("omegaconf."):
                         break

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -288,13 +288,9 @@ def run_and_report(func: Any) -> Any:
                 sys.stderr.write(
                     "An error occurred during Hydra's exception formatting:"
                     + os.linesep
+                    + repr(ex2)
+                    + os.linesep
                 )
-                if ex2.__traceback__ is not None:
-                    fname = ex2.__traceback__.tb_frame.f_code.co_filename
-                    lineno = ex2.__traceback__.tb_lineno
-                    sys.stderr.write(repr(ex2) + f", {fname}:{lineno}" + os.linesep)
-                else:  # pragma: no cover
-                    sys.stderr.write(repr(ex2) + os.linesep)
                 raise ex
         sys.exit(1)
 

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -294,7 +294,7 @@ def run_and_report(func: Any) -> Any:
                     lineno = ex2.__traceback__.tb_lineno
                     sys.stderr.write(repr(ex2) + f", {fname}:{lineno}" + os.linesep)
                 else:  # pragma: no cover
-                    sys.stderr.write(repr(ex2))
+                    sys.stderr.write(repr(ex2) + os.linesep)
                 raise ex
         sys.exit(1)
 

--- a/news/1739.bugfix
+++ b/news/1739.bugfix
@@ -1,0 +1,1 @@
+Fix failure when sanitizing stack traces resulting from job exceptions

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -168,7 +168,7 @@ class TestRunAndReport:
         expected_traceback_regex = dedent(
             r"""
             An error occurred during Hydra's exception formatting:$
-            AssertionError\(.*\), [^\s\d]+\.py:\d+$
+            AssertionError\(.*\), \S+\.py:\d+$
             """
         )
         mock_stderr = io.StringIO()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ from typing import Any
 from unittest.mock import patch
 
 from omegaconf import DictConfig, OmegaConf
-from pytest import mark, raises, param
+from pytest import mark, param, raises
 
 from hydra import utils
 from hydra._internal.utils import run_and_report

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,14 +1,19 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import io
 import os
 from pathlib import Path
+from textwrap import dedent
 from typing import Any
+from unittest.mock import patch
 
 from omegaconf import DictConfig, OmegaConf
 from pytest import mark, raises
 
 from hydra import utils
+from hydra._internal.utils import run_and_report
 from hydra.conf import HydraConf, RuntimeConf
 from hydra.core.hydra_config import HydraConfig
+from hydra.test_utils.test_utils import assert_regex_match
 
 
 def test_get_original_cwd(hydra_restore_singletons: Any) -> None:
@@ -60,3 +65,104 @@ def test_to_absolute_path_without_hydra(
     path = str(Path(path))
     expected = str(Path(expected).absolute())
     assert utils.to_absolute_path(path) == expected
+
+
+class TestRunAndReport:
+    def test_success(self) -> None:
+        def func() -> Any:
+            return 123
+
+        assert run_and_report(func) == 123
+
+    def test_simple_failure(self) -> None:
+        """Full traceback is printed for simple `run_and_report` failure."""
+
+        def simple_error() -> None:
+            assert False, "simple_err_msg"
+
+        mock_stderr = io.StringIO()
+        with raises(SystemExit, match="1"), patch("sys.stderr", new=mock_stderr):
+            run_and_report(simple_error)
+        mock_stderr.seek(0)
+        stderr_output = mock_stderr.read()
+        assert_regex_match(
+            dedent(
+                r"""
+                Traceback \(most recent call last\):$
+                  File "[^"]+", line \d+, in run_and_report$
+                    return func\(\)$
+                  File "[^"]+", line \d+, in simple_error$
+                    assert False, "simple_err_msg"$
+                AssertionError: simple_err_msg$
+                assert False$
+                """
+            ),
+            stderr_output,
+        )
+
+    def test_run_job_failure(self) -> None:
+        """
+        If a function named `run_job` appears in the traceback, the top of the
+        stack is stripped away until after the `run_job` frame.
+        """
+
+        def run_job_wrapper() -> None:
+            def run_job() -> None:
+                def nested_error() -> None:
+                    assert False, "nested_err"
+
+                nested_error()
+
+            run_job()
+
+        mock_stderr = io.StringIO()
+        with raises(SystemExit, match="1"), patch("sys.stderr", new=mock_stderr):
+            run_and_report(run_job_wrapper)
+        mock_stderr.seek(0)
+        stderr_output = mock_stderr.read()
+        assert_regex_match(
+            dedent(
+                r"""
+                Traceback \(most recent call last\):$
+                  File "[^"]+", line \d+, in nested_error$
+                    assert False, "nested_err"$
+                AssertionError: nested_err$
+                assert False$
+                Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.$
+                """
+            ),
+            stderr_output,
+        )
+
+    def test_run_job_omegaconf_failure(self) -> None:
+        """
+        If a function named `run_job` appears in the traceback, the bottom of the
+        stack is stripped away until an `omegaconf` frame is found.
+        """
+
+        def run_job() -> None:
+            def job_calling_omconf() -> None:
+                from omegaconf import OmegaConf
+
+                OmegaConf.resolve(123)  # type: ignore
+
+            job_calling_omconf()
+
+        mock_stderr = io.StringIO()
+        with raises(SystemExit, match="1"), patch("sys.stderr", new=mock_stderr):
+            run_and_report(run_job)
+        mock_stderr.seek(0)
+        stderr_output = mock_stderr.read()
+        print(f"stderr_output:\n{stderr_output}\n--------")
+        assert_regex_match(
+            dedent(
+                r"""
+                Traceback \(most recent call last\):$
+                  File "[^"]+", line \d+, in job_calling_omconf$
+                    OmegaConf.resolve\(123\)  # type: ignore$
+                ValueError: Invalid config type \(int\), expected an OmegaConf Container$
+                Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.$
+                """
+            ),
+            stderr_output,
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,3 +158,23 @@ class TestRunAndReport:
         mock_stderr.seek(0)
         stderr_output = mock_stderr.read()
         assert_regex_match(expected_traceback_regex, stderr_output)
+
+    def test_getmodule_returns_none(self) -> None:
+        demo_func = self.DemoFunctions.omegaconf_job_wrapper
+        expected_traceback_regex = dedent(
+            r"""
+            .*
+            .*
+            .*
+            .*
+            .*
+            """
+        )
+        mock_stderr = io.StringIO()
+        with raises(SystemExit, match="1"), patch("sys.stderr", new=mock_stderr), patch(
+            "inspect.getmodule", new=lambda *args: None
+        ):
+            run_and_report(demo_func)
+        mock_stderr.seek(0)
+        stderr_output = mock_stderr.read()
+        assert_regex_match(expected_traceback_regex, stderr_output)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,8 +68,27 @@ def test_to_absolute_path_without_hydra(
 
 
 class TestRunAndReport:
+    """
+    Test the `hydra._internal.utils.run_and_report` function.
+
+    def run_and_report(func: Any) -> Any: ...
+
+    This class defines several test methods:
+      test_success:
+          a simple test case where `run_and_report(func)` succeeds.
+      test_failure:
+          test when `func` raises an exception, and `run_and_report(func)`
+          prints a nicely-formatted error message
+      test_simplified_traceback_failure:
+          test when printing a nicely-formatted error message fails, so
+          `run_and_report` falls back to re-raising the exception from `func`.
+    """
+
     class DemoFunctions:
-        """Demo inputs for `run_and_report`"""
+        """
+        The methods of this `DemoFunctions` class are passed to
+        `run_and_report` as the func argument.
+        """
 
         @staticmethod
         def success_func() -> Any:
@@ -81,6 +100,12 @@ class TestRunAndReport:
 
         @staticmethod
         def run_job_wrapper() -> None:
+            """
+            Trigger special logic in `run_and_report` that looks for a function
+            called "run_job" in the stack and strips away the leading stack
+            frames.
+            """
+
             def run_job() -> None:
                 def nested_error() -> None:
                     assert False, "nested_err"
@@ -91,10 +116,17 @@ class TestRunAndReport:
 
         @staticmethod
         def omegaconf_job_wrapper() -> None:
+            """
+            Trigger special logic in `run_and_report` that looks for the
+            `omegaconf` module in the stack and strips away the bottom stack
+            frames.
+            """
+
             def run_job() -> None:
                 def job_calling_omconf() -> None:
                     from omegaconf import OmegaConf
 
+                    # The below causes an exception:
                     OmegaConf.resolve(123)  # type: ignore
 
                 job_calling_omconf()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -120,7 +120,7 @@ class TestRunAndReport:
                     assert False$
                     """
                 ),
-                id="simple_failure"
+                id="simple_failure_full_traceback",
             ),
             param(
                 DemoFunctions.run_job_wrapper,
@@ -134,7 +134,7 @@ class TestRunAndReport:
                     Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.$
                     """
                 ),
-                id="run_job_failure"
+                id="strip_run_job_from_top_of_stack",
             ),
             param(
                 DemoFunctions.omegaconf_job_wrapper,
@@ -147,7 +147,7 @@ class TestRunAndReport:
                     Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.$
                     """
                 ),
-                id="run_job_failure_with_omegaconf"
+                id="strip_omegaconf_from_bottom_of_stack",
             ),
         ],
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -154,8 +154,6 @@ class TestRunAndReport:
     def test_failure(
         self, demo_func: Any, expected_traceback_regex: str
     ) -> None:
-        """Full traceback is printed for simple `run_and_report` failure."""
-
         mock_stderr = io.StringIO()
         with raises(SystemExit, match="1"), patch("sys.stderr", new=mock_stderr):
             run_and_report(demo_func)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -151,9 +151,7 @@ class TestRunAndReport:
             ),
         ],
     )
-    def test_failure(
-        self, demo_func: Any, expected_traceback_regex: str
-    ) -> None:
+    def test_failure(self, demo_func: Any, expected_traceback_regex: str) -> None:
         mock_stderr = io.StringIO()
         with raises(SystemExit, match="1"), patch("sys.stderr", new=mock_stderr):
             run_and_report(demo_func)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -175,9 +175,9 @@ class TestRunAndReport:
               File "[^"]+", line \d+, in run_job$
                 job_calling_omconf\(\)$
               File "[^"]+", line \d+, in job_calling_omconf$
-                OmegaConf.resolve(123)  # type: ignore
+                OmegaConf.resolve\(123\)  # type: ignore
               File "[^"]+", line \d+, in resolve$
-                raise ValueError(
+                raise ValueError\(
             ValueError: Invalid config type \(int\), expected an OmegaConf Container$
             """
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -168,7 +168,7 @@ class TestRunAndReport:
         expected_traceback_regex = dedent(
             r"""
             An error occurred during Hydra's exception formatting:$
-            AssertionError\(.*\), \S+\.py:\d+$
+            AssertionError\(.*\)$
             """
         )
         mock_stderr = io.StringIO()


### PR DESCRIPTION
Closes #1739

Not sure how to test this.
Currently there are not any unit tests of the `run_and_report` function.
