### PR TITLE
Follow-up 1726. Update optuna sweeper dependency and some cleanups.

### DIFF
--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -198,7 +198,7 @@ class OptunaSweeperImpl(Sweeper):
         while n_trials_to_go > 0:
             batch_size = min(n_trials_to_go, batch_size)
 
-            trials = [study._ask() for _ in range(batch_size)]
+            trials = [study.ask() for _ in range(batch_size)]
             overrides = []
             for trial in trials:
                 for param_name, distribution in search_space.items():
@@ -234,10 +234,10 @@ class OptunaSweeperImpl(Sweeper):
                                 "The number of the values and the number of the objectives are"
                                 f" mismatched. Expect {len(directions)}, but actually {len(values)}."
                             )
-                    study._tell(trial, state, values)
+                    study.tell(trial=trial, state=state, values=values)
                 except Exception as e:
                     state = optuna.trial.TrialState.FAIL
-                    study._tell(trial, state, values)
+                    study.tell(trial=trial, state=state, values=values)
                     raise e
 
             n_trials_to_go -= batch_size

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     install_requires=[
         "hydra-core>=1.1.0.dev7",
-        "optuna",
+        "optuna>=2.5.0",
     ],
     include_package_data=True,
 )

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -26,10 +26,8 @@ setup(
         "Development Status :: 4 - Beta",
     ],
     install_requires=[
-        # TODO(toshihikoyanase): Change version restriction to hydra-core>=1.1 after hydra-core=1.1.0 is released.
         "hydra-core>=1.1.0.dev7",
-        "optuna<2.5.0",
-        "numpy<1.20.0",  # remove once optuna is upgraded to support numpy 1.20
+        "optuna",
     ],
     include_package_data=True,
 )

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -126,7 +126,7 @@ def test_optuna_example(with_commandline: bool, tmpdir: Path) -> None:
         "example/sphere.py",
         "--multirun",
         "hydra.sweep.dir=" + str(tmpdir),
-        "hydra.sweeper.n_trials=40",
+        "hydra.sweeper.n_trials=20",
         "hydra.sweeper.n_jobs=1",
         f"hydra.sweeper.storage={storage}",
         f"hydra.sweeper.study_name={study_name}",
@@ -150,8 +150,11 @@ def test_optuna_example(with_commandline: bool, tmpdir: Path) -> None:
     else:
         assert returns["best_params"]["y"] == best_trial.params["y"]
     assert returns["best_value"] == best_trial.value
-    # 99th percentile with 1000 different seed values.
-    assert returns["best_value"] <= 0.25
+    # Check the search performance of the TPE sampler.
+    # The threshold is the 95th percentile calculated with 1000 different seed values
+    # to make the test robust against the detailed implementation of the sampler.
+    # See https://github.com/facebookresearch/hydra/pull/1746#discussion_r681549830.
+    assert returns["best_value"] <= 2.27
 
 
 @mark.parametrize("with_commandline", (True, False))

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -126,11 +126,11 @@ def test_optuna_example(with_commandline: bool, tmpdir: Path) -> None:
         "example/sphere.py",
         "--multirun",
         "hydra.sweep.dir=" + str(tmpdir),
-        "hydra.sweeper.n_trials=20",
+        "hydra.sweeper.n_trials=40",
         "hydra.sweeper.n_jobs=1",
         f"hydra.sweeper.storage={storage}",
         f"hydra.sweeper.study_name={study_name}",
-        "hydra/sweeper/sampler=random",
+        "hydra/sweeper/sampler=tpe",
         "hydra.sweeper.sampler.seed=123",
     ]
     if with_commandline:
@@ -150,8 +150,8 @@ def test_optuna_example(with_commandline: bool, tmpdir: Path) -> None:
     else:
         assert returns["best_params"]["y"] == best_trial.params["y"]
     assert returns["best_value"] == best_trial.value
-    # 95th percentile with 1000 different seed values.
-    assert returns["best_value"] <= 6.25
+    # 99th percentile with 1000 different seed values.
+    assert returns["best_value"] <= 0.25
 
 
 @mark.parametrize("with_commandline", (True, False))

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 from typing import Any, List
 
+import optuna
 from hydra.core.override_parser.overrides_parser import OverridesParser
 from hydra.core.plugins import Plugins
 from hydra.plugins.sweeper import Sweeper
@@ -12,7 +13,6 @@ from hydra.test_utils.test_utils import (
     run_python_script,
 )
 from omegaconf import DictConfig, OmegaConf
-import optuna
 from optuna.distributions import (
     BaseDistribution,
     CategoricalDistribution,

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -128,8 +128,8 @@ def test_optuna_example(with_commandline: bool, tmpdir: Path) -> None:
         "hydra.sweep.dir=" + str(tmpdir),
         "hydra.sweeper.n_trials=20",
         "hydra.sweeper.n_jobs=1",
-        "hydra.sweeper.storage=" + storage,
-        "hydra.sweeper.study_name=" + study_name,
+        f"hydra.sweeper.storage={storage}",
+        f"hydra.sweeper.study_name={study_name}",
         "hydra/sweeper/sampler=random",
         "hydra.sweeper.sampler.seed=123",
     ]

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -28,8 +28,6 @@ from hydra_plugins.hydra_optuna_sweeper.optuna_sweeper import OptunaSweeper
 chdir_plugin_root()
 
 
-# https://github.com/pyreadline/pyreadline/issues/65
-@mark.filterwarnings("ignore::DeprecationWarning")
 def test_discovery() -> None:
     assert OptunaSweeper.__name__ in [
         x.__name__ for x in Plugins.instance().discover(Sweeper)
@@ -46,8 +44,6 @@ def check_distribution(expected: BaseDistribution, actual: BaseDistribution) -> 
     assert set(expected.choices) == set(actual.choices)
 
 
-# https://github.com/pyreadline/pyreadline/issues/65
-@mark.filterwarnings("ignore::DeprecationWarning")
 @mark.parametrize(
     "input, expected",
     [
@@ -81,8 +77,6 @@ def test_create_optuna_distribution_from_config(input: Any, expected: Any) -> No
     check_distribution(expected, actual)
 
 
-# https://github.com/pyreadline/pyreadline/issues/65
-@mark.filterwarnings("ignore::DeprecationWarning")
 @mark.parametrize(
     "input, expected",
     [
@@ -104,8 +98,6 @@ def test_create_optuna_distribution_from_override(input: Any, expected: Any) -> 
     check_distribution(expected, actual)
 
 
-# https://github.com/pyreadline/pyreadline/issues/65
-@mark.filterwarnings("ignore::DeprecationWarning")
 def test_launch_jobs(hydra_sweep_runner: TSweepRunner) -> None:
     sweep = hydra_sweep_runner(
         calling_file=None,
@@ -124,15 +116,13 @@ def test_launch_jobs(hydra_sweep_runner: TSweepRunner) -> None:
         assert sweep.returns is None
 
 
-# https://github.com/pyreadline/pyreadline/issues/65
-@mark.filterwarnings("ignore::DeprecationWarning")
 @mark.parametrize("with_commandline", (True, False))
 def test_optuna_example(with_commandline: bool, tmpdir: Path) -> None:
     cmd = [
         "example/sphere.py",
         "--multirun",
         "hydra.sweep.dir=" + str(tmpdir),
-        "hydra.sweeper.n_trials=20",
+        "hydra.sweeper.n_trials=100",
         "hydra.sweeper.n_jobs=8",
         "hydra/sweeper/sampler=random",
         "hydra.sweeper.sampler.seed=123",
@@ -154,8 +144,6 @@ def test_optuna_example(with_commandline: bool, tmpdir: Path) -> None:
     assert returns["best_value"] == 0
 
 
-# https://github.com/pyreadline/pyreadline/issues/65
-@mark.filterwarnings("ignore::DeprecationWarning")
 @mark.parametrize("with_commandline", (True, False))
 def test_optuna_multi_objective_example(with_commandline: bool, tmpdir: Path) -> None:
     cmd = [

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -150,6 +150,8 @@ def test_optuna_example(with_commandline: bool, tmpdir: Path) -> None:
     else:
         assert returns["best_params"]["y"] == best_trial.params["y"]
     assert returns["best_value"] == best_trial.value
+    # 95th percentile with 1000 different seed values.
+    assert returns["best_value"] <= 6.25
 
 
 @mark.parametrize("with_commandline", (True, False))


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

This PR is a follow-up for #1726. Since #1726 has not merged yet, this PR includes the changes of the original PR.

*Changes*
- Set lower bound of Optuna version (>=2.5.0). Since the code in #1726 uses `study.ask` and `study.tell`, it does not work with `optuna<2.5.0`. See https://github.com/facebookresearch/hydra/pull/1726#discussion_r679915412.
- Update the scenario of `test_optuna_example` to save computation time. It also makes the test robust to Optuna's changes. See  "Test Plan" for more details.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

This PR changes the test scenario of `test_optuna_example`. The current test function tries to find the global optima by the random sampler, but it requires many trials (about 1000 trials) to make it robust to the change of seed values or the sampler
implementation.

The new test function compares the results in Optuna's storage and the results returned by the plugin. I think this is a straight forward way to verify the plugin behavior. Since it does not require the global optima, we can use the same number of trials as the current master.

(See also https://github.com/facebookresearch/hydra/pull/1726#discussion_r678299458)

## Related Issues and PRs

The original PR is #1726 .