### PR TITLE
warning if legacy hydra override comes before group default

### DIFF
--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -385,15 +385,7 @@ def _update_overrides(
                     )
                 )
             elif seen_legacy_override:
-                warnings.warn(
-                    dedent(
-                        f"""\
-                        In {pcp}: Legacy override '{okey} : {oval}' is defined before '{dkey} : {dval}'.
-                        Overrides should be at the end of the defaults list.
-                        """
-                    ),
-                    UserWarning,
-                )
+                pass  # for now, we allow legacy overrides anywhere in the defaults list
 
         if isinstance(d, GroupDefault):
             if legacy_hydra_override:
@@ -404,6 +396,7 @@ def _update_overrides(
                     f"""\
                     In {parent.get_config_path()}: Invalid overriding of {d.group}:
                     Default list overrides requires 'override' keyword.
+                    Note: in Hydra 1.2, overrides will only be allowed to appear at the end of the defaults list.
                     See {url} for more information.
                     """
                 )

--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -390,7 +390,6 @@ def _update_overrides(
                     f"""\
                     In {parent.get_config_path()}: Invalid overriding of {d.group}:
                     Default list overrides requires 'override' keyword.
-                    Note: in Hydra 1.2, overrides will only be allowed to appear at the end of the defaults list.
                     See {url} for more information.
                     """
                 )

--- a/news/1748.api_change
+++ b/news/1748.api_change
@@ -1,0 +1,1 @@
+Relax handling of legacy hydra overrides in the defaults list to make migration from Hydra 1.0 to 1.1 easier

--- a/tests/defaults_list/data/legacy_override_hydra_wrong_order.yaml
+++ b/tests/defaults_list/data/legacy_override_hydra_wrong_order.yaml
@@ -1,0 +1,3 @@
+defaults:
+  - hydra/help: custom1
+  - group1: file1

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -799,7 +799,6 @@ def test_legacy_hydra_overrides_from_primary_config(
         """\
         Invalid overriding of hydra/help:
         Default list overrides requires 'override' keyword.
-        Note: in Hydra 1.2, overrides will only be allowed to appear at the end of the defaults list.
         See https://hydra.cc/docs/next/upgrades/1.0_to_1.1/defaults_list_override for more information."""
     )
     with warns(expected_warning=UserWarning, match=re.escape(msg)):

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -835,6 +835,63 @@ def test_legacy_hydra_overrides_from_primary_config_2(
     "config_name,overrides,expected",
     [
         param(
+            "legacy_override_hydra_wrong_order",
+            [],
+            DefaultsTreeNode(
+                node=VirtualRoot(),
+                children=[
+                    DefaultsTreeNode(
+                        node=ConfigDefault(path="hydra/config"),
+                        children=[
+                            GroupDefault(group="help", value="custom1"),
+                            GroupDefault(group="output", value="default"),
+                            ConfigDefault(path="_self_"),
+                        ],
+                    ),
+                    DefaultsTreeNode(
+                        node=ConfigDefault(path="legacy_override_hydra_wrong_order"),
+                        children=[
+                            GroupDefault(group="group1", value="file1"),
+                            ConfigDefault(path="_self_"),
+                        ],
+                    ),
+                ],
+            ),
+            id="legacy_override_hydra_wrong_order",
+        ),
+    ],
+)
+def test_legacy_hydra_overrides_from_primary_config_3(
+    config_name: str, overrides: List[str], expected: DefaultsTreeNode, recwarn: Any
+) -> None:
+    """
+    Override two Hydra config groups using legacy notation
+    """
+
+    _test_defaults_tree_impl(
+        config_name=config_name,
+        input_overrides=overrides,
+        expected=expected,
+        prepend_hydra=True,
+    )
+
+    assert len(recwarn) == 2
+    assert "Invalid overriding of hydra/help:" in recwarn.list[0].message.args[0]
+    assert (
+        dedent(
+            """\
+            Legacy override 'hydra/help : custom1' is defined before 'group1 : file1'.
+            Overrides should be at the end of the defaults list.
+            """
+        )
+        in recwarn.list[1].message.args[0]
+    )
+
+
+@mark.parametrize(
+    "config_name,overrides,expected",
+    [
+        param(
             "group_default_with_explicit_experiment",
             [],
             DefaultsTreeNode(


### PR DESCRIPTION
Closes #1748.

- Keep track of legacy overrides separately from non-legacy overrides.
- Issue a warning for out-of-order legacy overrides. As before, raise an Exception for out-of-order non-legacy overrides.
