### PR TITLE
[ray test ]only assert minor version

### DIFF
--- a/plugins/hydra_ray_launcher/integration_test_tools/create_integration_test_ami.py
+++ b/plugins/hydra_ray_launcher/integration_test_tools/create_integration_test_ami.py
@@ -34,6 +34,8 @@ def set_up_machine(cfg: DictConfig) -> None:
     security_group_id = cfg.security_group_id
     assert security_group_id != "", "Security group cannot be empty!"
 
+    python_versions = cfg.python_versions
+
     # set up security group rules to allow pip install
     _run_command(
         f"aws ec2 authorize-security-group-egress --group-id {security_group_id} "
@@ -49,19 +51,8 @@ def set_up_machine(cfg: DictConfig) -> None:
         _run_command(
             f"ray rsync_up {yaml} './setup_integration_test_ami.py' '/home/ubuntu/' "
         )
-        _run_command("conda update --all -y")
-        output = _run_command("conda search python").split("\n")
 
-        # gather all the python versions and install conda envs
-        versions = set()
-        for o in output:
-            o = o.split()
-            if len(o) > 2 and o[0] == "python" and float(o[1][:3]) >= 3.6:
-
-                versions.add(o[1])
-        print(f"Found python versions {sorted( versions )}")
-
-        for v in versions:
+        for v in python_versions:
             print(f"Setting up conda env for py version {v}")
             _run_command(
                 f"ray exec {yaml} 'python ./setup_integration_test_ami.py {v}' "

--- a/plugins/hydra_ray_launcher/integration_test_tools/create_integration_test_ami_config.yaml
+++ b/plugins/hydra_ray_launcher/integration_test_tools/create_integration_test_ami_config.yaml
@@ -1,4 +1,7 @@
 security_group_id: sg-095ac7c26aa0d33bb
+python_versions:
+  - 3.7
+  - 3.8
 ray_yaml:
   cluster_name: ray_test_base_AMI
   min_workers: 0

--- a/plugins/hydra_ray_launcher/integration_test_tools/setup_integration_test_ami.py
+++ b/plugins/hydra_ray_launcher/integration_test_tools/setup_integration_test_ami.py
@@ -5,8 +5,8 @@ from datetime import datetime
 
 dependencies = [
     "boto3==1.17.17",
-    "hydra-core>=1.0.0",
-    "ray==1.2.0",
+    "hydra-core>=1.1.0.dev7",
+    "ray==1.3.0",
     "cloudpickle==1.6.0",
     "pickle5==0.0.11",
 ]

--- a/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
@@ -44,7 +44,7 @@ cluster_name = "IntegrationTest-" + "".join(
 )
 win_msg = "Ray doesn't support Windows."
 cur_py_version = (
-    f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    f"{sys.version_info.major}.{sys.version_info.minor}"
 )
 
 aws_not_configured_msg = "AWS credentials not configured correctly. Skipping AWS tests."
@@ -56,7 +56,7 @@ except (NoCredentialsError, NoRegionError):
     aws_not_configured = True
 
 
-ami = os.environ.get("AWS_RAY_AMI", "ami-0e96acce4111ef8bb")
+ami = os.environ.get("AWS_RAY_AMI", "ami-01a4c55662261264a")
 security_group_id = os.environ.get("AWS_RAY_SECURITY_GROUP", "sg-0a12b09a5ff961aee")
 subnet_id = os.environ.get("AWS_RAY_SUBNET", "subnet-acd2cfe7")
 instance_role = os.environ.get(

--- a/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
@@ -43,9 +43,7 @@ cluster_name = "IntegrationTest-" + "".join(
     [random.choice(string.ascii_letters + string.digits) for n in range(5)]
 )
 win_msg = "Ray doesn't support Windows."
-cur_py_version = (
-    f"{sys.version_info.major}.{sys.version_info.minor}"
-)
+cur_py_version = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 aws_not_configured_msg = "AWS credentials not configured correctly. Skipping AWS tests."
 try:
@@ -196,10 +194,9 @@ def validate_lib_version(connect_config: Dict[Any, Any]) -> None:
     ).decode()
     remote_python = out.split()[1]
 
-    assert (
-        parse_python_minor_version(local_python) == parse_python_minor_version(remote_python)
+    assert parse_python_minor_version(local_python) == parse_python_minor_version(
+        remote_python
     ), f"Python version mismatch, local={local_python}, remote={remote_python}"
-
 
 
 @mark.skipif(sys.platform.startswith("win"), reason=win_msg)

--- a/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
@@ -173,6 +173,11 @@ def upload_and_install_wheels(
     )
 
 
+def parse_python_minor_version(version: str) -> str:
+    micro_start = version.rfind(".")
+    return version[:micro_start]
+
+
 def validate_lib_version(connect_config: Dict[Any, Any]) -> None:
     # a few lib versions that we care about
     libs = ["ray", "cloudpickle", "pickle5"]
@@ -190,9 +195,11 @@ def validate_lib_version(connect_config: Dict[Any, Any]) -> None:
         connect_config, cmd="python --version", with_output=True
     ).decode()
     remote_python = out.split()[1]
+
     assert (
-        local_python == remote_python
+        parse_python_minor_version(local_python) == parse_python_minor_version(remote_python)
     ), f"Python version mismatch, local={local_python}, remote={remote_python}"
+
 
 
 @mark.skipif(sys.platform.startswith("win"), reason=win_msg)


### PR DESCRIPTION
We've been trying to make sure the micro versions of python matches for the circleCI instance and the AWS instance launched by the ray launcher (due to cloudpickle), however this breaks whenever Python releases a new micro version.
It seems like only making sure the minor version matches works, so changing the check to minor version only.