### PR TITLE
Fixed searcpath plugin example MANIFEST to include the config yaml files

### DIFF
--- a/examples/plugins/example_searchpath_plugin/MANIFEST.in
+++ b/examples/plugins/example_searchpath_plugin/MANIFEST.in
@@ -1,3 +1,3 @@
 global-exclude *.pyc
 global-exclude __pycache__
-recursive-include *.yaml
+recursive-include arbitrary_package/* *.yaml


### PR DESCRIPTION
The example searchpath plugin did not correctly include the yaml files in the manifest, resulting in the config files not being found if the plugin was installed from a wheel (unless the user happened to be inside the plugin working directory).