### PR TITLE
disambiguate get_override_key treatment of global

### DIFF
--- a/hydra/core/default_element.py
+++ b/hydra/core/default_element.py
@@ -250,7 +250,9 @@ class InputDefault:
         default_pkg = self.get_default_package()
         final_pkg = self.get_final_package(default_to_package_header=False)
         key = self.get_group_path()
-        if default_pkg != final_pkg and final_pkg != "":
+        if default_pkg != final_pkg:
+            if final_pkg == "":
+                final_pkg = "_global_"
             key = f"{key}@{final_pkg}"
         return key
 

--- a/news/1784.bugfix
+++ b/news/1784.bugfix
@@ -1,0 +1,1 @@
+Fix an internal key collision to prevent an exception when `- group@_global_: choice` is used in the same defaults list as `- group: choice`.

--- a/tests/defaults_list/data/experiment/override_with_global_default.yaml
+++ b/tests/defaults_list/data/experiment/override_with_global_default.yaml
@@ -1,2 +1,4 @@
+# @package _global_
+
 defaults:
-  - override /group1@_global_.group1: file2
+  - override /group1: file2

--- a/tests/defaults_list/data/experiment/override_with_global_default.yaml
+++ b/tests/defaults_list/data/experiment/override_with_global_default.yaml
@@ -1,2 +1,2 @@
 defaults:
-  - override /group1@_global_: file2
+  - override /group1@_global_.group1: file2

--- a/tests/defaults_list/data/experiment/override_with_global_default2.yaml
+++ b/tests/defaults_list/data/experiment/override_with_global_default2.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - override /group1@_global_: file2

--- a/tests/defaults_list/data/group_default_at_global.yaml
+++ b/tests/defaults_list/data/group_default_at_global.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - group1@_global_: file1

--- a/tests/defaults_list/data/two_group_defaults_different_pkgs_global.yaml
+++ b/tests/defaults_list/data/two_group_defaults_different_pkgs_global.yaml
@@ -1,0 +1,3 @@
+defaults:
+  - group1: file1
+  - group1@_global_: file2

--- a/tests/defaults_list/data/with_missing_at_global.yaml
+++ b/tests/defaults_list/data/with_missing_at_global.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - db@_global_: ???

--- a/tests/defaults_list/test_defaults_list.py
+++ b/tests/defaults_list/test_defaults_list.py
@@ -674,6 +674,79 @@ def test_include_nested_group_global(
     "config_name, overrides, expected",
     [
         param(
+            "group_default_at_global",
+            [],
+            [
+                ResultDefault(
+                    config_path="group1/file1",
+                    package="",
+                    parent="group_default_at_global",
+                ),
+                ResultDefault(
+                    config_path="group_default_at_global",
+                    package="",
+                    is_self=True,
+                ),
+            ],
+            id="group_default_at_global",
+        ),
+        param(
+            "group_default_at_global",
+            ["+experiment=override_with_global_default2"],
+            [
+                ResultDefault(
+                    config_path="group1/file2",
+                    package="",
+                    parent="group_default_at_global",
+                ),
+                ResultDefault(
+                    config_path="group_default_at_global",
+                    package="",
+                    is_self=True,
+                ),
+                ResultDefault(
+                    config_path="experiment/override_with_global_default2",
+                    package="experiment",
+                    parent="group_default_at_global",
+                ),
+            ],
+            id="include_absolute_config:override_with_global_default2",
+        ),
+        param(
+            "two_group_defaults_different_pkgs_global",
+            [],
+            [
+                ResultDefault(
+                    config_path="group1/file1",
+                    parent="two_group_defaults_different_pkgs_global",
+                    package="group1",
+                ),
+                ResultDefault(
+                    config_path="group1/file2",
+                    parent="two_group_defaults_different_pkgs_global",
+                    package="",
+                ),
+                ResultDefault(
+                    config_path="two_group_defaults_different_pkgs_global",
+                    package="",
+                    is_self=True,
+                ),
+            ],
+        ),
+    ],
+)
+def test_group_global(
+    config_name: str, overrides: List[str], expected: List[ResultDefault]
+) -> None:
+    _test_defaults_list_impl(
+        config_name=config_name, overrides=overrides, expected=expected
+    )
+
+
+@mark.parametrize(
+    "config_name, overrides, expected",
+    [
+        param(
             "include_nested_group_global_foo",
             [],
             [

--- a/tests/defaults_list/test_defaults_list.py
+++ b/tests/defaults_list/test_defaults_list.py
@@ -639,7 +639,7 @@ def test_group_default_pkg1(
         ),
         param(
             "include_nested_group_global_",
-            ["group1/group2=file2"],
+            ["group1/group2@_global_=file2"],
             [
                 ResultDefault(
                     config_path="group1/group2/file2",

--- a/tests/defaults_list/test_defaults_list.py
+++ b/tests/defaults_list/test_defaults_list.py
@@ -710,7 +710,7 @@ def test_include_nested_group_global(
                     parent="group_default_at_global",
                 ),
             ],
-            id="include_absolute_config:override_with_global_default2",
+            id="group_default_at_global:include_experiment_to_override_toplevel_package",
         ),
         param(
             "two_group_defaults_different_pkgs_global",
@@ -732,6 +732,7 @@ def test_include_nested_group_global(
                     is_self=True,
                 ),
             ],
+            id="two_group_defaults_different_pkgs_global"
         ),
     ],
 )

--- a/tests/defaults_list/test_defaults_list.py
+++ b/tests/defaults_list/test_defaults_list.py
@@ -732,7 +732,7 @@ def test_include_nested_group_global(
                     is_self=True,
                 ),
             ],
-            id="two_group_defaults_different_pkgs_global"
+            id="two_group_defaults_different_pkgs_global",
         ),
     ],
 )

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -682,6 +682,19 @@ def test_override_option_from_defaults_list(
             ),
             id="two_group_defaults_different_pkgs:override_second",
         ),
+        param(
+            "two_group_defaults_different_pkgs_global",
+            [],
+            DefaultsTreeNode(
+                node=ConfigDefault(path="two_group_defaults_different_pkgs_global"),
+                children=[
+                    GroupDefault(group="group1", value="file1"),
+                    GroupDefault(group="group1", value="file2", package="_global_"),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="two_group_defaults_different_pkgs_global",
+        ),
     ],
 )
 def test_two_group_defaults_different_pkgs(
@@ -1132,6 +1145,21 @@ def test_experiment_overriding_hydra_group(
                 ],
             ),
             id="include_absolute_config:override_with_global_default",
+        ),
+        param(
+            "group_default_at_global",
+            ["+experiment=override_with_global_default2"],
+            DefaultsTreeNode(
+                node=ConfigDefault(path="group_default_at_global"),
+                children=[
+                    GroupDefault(group="group1", value="file2", package="_global_"),
+                    ConfigDefault(path="_self_"),
+                    GroupDefault(
+                        group="experiment", value="override_with_global_default2"
+                    ),
+                ],
+            ),
+            id="include_absolute_config:override_with_global_default2",
         ),
     ],
 )

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -1319,6 +1319,19 @@ def test_extension_use_cases(
             id="with_missing",
         ),
         param(
+            "with_missing_at_global",
+            [],
+            raises(
+                ConfigCompositionException,
+                match=dedent(
+                    """\
+                You must specify 'db@_global_', e.g, db@_global_=<OPTION>
+                Available options:"""
+                ),
+            ),
+            id="with_missing_at_global",
+        ),
+        param(
             "with_missing",
             ["db=base_db"],
             DefaultsTreeNode(


### PR DESCRIPTION
This PR closes #1784 by modifying the `InputDefaults.get_override_key` method.

#### Changes Introduced
Previously, `get_override_key` had this behavior:
- Group `"foo"` and package `"foo"` -> `override key == "foo"`
- Group `"foo"` and package `"bar"` -> `override key == "foo@bar"`
- Group `"foo"` and package `""` -> `override key == "foo"`
With this PR, `get_override_key` has this behavior:
- Group `"foo"` and package `"foo"` -> `override key == "foo"`
- Group `"foo"` and package `"bar"` -> `override key == "foo@bar"`
- Group `"foo"` and package `""` -> `override key == "foo@_global_"`

#### Updates to Pre-Existing Tests
This PR introduces some new tests, and it also updates two old tests that were relying on the old key-collision behavior.
These two tests had to be updated:
```
test_defaults_list.py::test_include_nested_group_global[option_override:include_nested_config_item_global]
test_defaults_tree.py::test_experiment_overriding_global_group[include_absolute_config:override_with_global_default]
```
In the first updated tests, the command-line override `"group1/group2=file2"` was being used, while `"group1/group2@_global_=file2"` should have been used instead.
In the second updated test, the default element `override /group1@_global_: file2` was being used to override group `"group1"` at package `"group1"`, while the element `override /group1@_global_.group1: file2` should have been used instead.