### PR TITLE
Parse overrides from config in basic sweeper

### DIFF
--- a/tests/test_apps/app_with_basic_sweeper_cfg/__init__.py
+++ b/tests/test_apps/app_with_basic_sweeper_cfg/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/tests/test_apps/app_with_basic_sweeper_cfg/config.yaml
+++ b/tests/test_apps/app_with_basic_sweeper_cfg/config.yaml
@@ -1,0 +1,8 @@
+hydra:
+  sweeper:
+    overrides:
+      letter: a,b,c
+      number: -1,5
+
+letter: z
+number: 0

--- a/tests/test_apps/app_with_basic_sweeper_cfg/my_app.py
+++ b/tests/test_apps/app_with_basic_sweeper_cfg/my_app.py
@@ -1,0 +1,13 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from omegaconf import DictConfig
+
+import hydra
+
+
+@hydra.main(config_path=".", config_name="config")
+def my_app(config: DictConfig) -> None:
+    print(f"letter={config.letter} number={config.number}")
+
+
+if __name__ == "__main__":
+    my_app()

--- a/tests/test_basic_sweeper.py
+++ b/tests/test_basic_sweeper.py
@@ -107,3 +107,22 @@ def test_partial_failure(
         from_name="Expected error",
         to_name="Actual error",
     )
+
+
+def test_configured_overrides(tmpdir: Any) -> None:
+    cmd = [
+        sys.executable,
+        "-Werror",
+        "tests/test_apps/app_with_basic_sweeper_cfg/my_app.py",
+        "--multirun",
+        "hydra.run.dir=" + str(tmpdir),
+        "hydra.hydra_logging.formatters.simple.format='[HYDRA] %(message)s'",
+    ]
+    out, err = run_process(cmd=cmd)
+
+    assert "letter=a number=-1" in out
+    assert "letter=b number=-1" in out
+    assert "letter=c number=-1" in out
+    assert "letter=a number=5" in out
+    assert "letter=b number=5" in out
+    assert "letter=c number=5" in out


### PR DESCRIPTION
## Motivation

This PR lets the user specify overrides for `BasicSweeper` in the configuration under `hydra.sweeper.overrides` similar to how it can be done for the "advanced" sweepers. This feature was requested in #1376 and is quite valuable in general, I believe. The basic sweeper sweeps the complete cartesian product of overrides which is important for me when I want to evaluate a set of options fully, for example to create a plot for a paper. Without this PR, I have to save the call to my program in a script (e.g. `python train.py -m param=range(1.0,5.0,1.0)`) to ensure that I can always recreate the same data without having to search my shell history for the exact ranges and choices I used. However, it would be much nicer to save these sweep parameters as part of the configuration.

The implementation allows the user to configure overrides in their configuration using the same syntax as on the command line.
```yaml
hydra:
  sweeper:
    overrides:
      letter: a,b,c
      number: range(10.0)
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Related Issues and PRs

Closes #1376
