### PR TITLE
Fix master -> main references in jupyter_notebooks.md

### DIFF
--- a/website/docs/advanced/jupyter_notebooks.md
+++ b/website/docs/advanced/jupyter_notebooks.md
@@ -7,5 +7,5 @@ Hydra supports config composition inside Jupyter notebooks via the [Compose API]
 
 Run the Notebook in a the Binder to see a live demo, or open the Notebook source on GitHub.
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/facebookresearch/hydra/master?filepath=examples%2jupyter_notebooks)
-[![Notebook source](https://img.shields.io/badge/-Notebooks%20source-informational)](https://github.com/facebookresearch/hydra//tree/master/examples/jupyter_notebooks/)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/facebookresearch/hydra/main?filepath=examples%2jupyter_notebooks)
+[![Notebook source](https://img.shields.io/badge/-Notebooks%20source-informational)](https://github.com/facebookresearch/hydra//tree/main/examples/jupyter_notebooks/)

--- a/website/versioned_docs/version-1.0/advanced/jupyter_notebooks.md
+++ b/website/versioned_docs/version-1.0/advanced/jupyter_notebooks.md
@@ -7,5 +7,5 @@ Hydra supports config composition inside Jupyter notebooks via the [Compose API]
 
 Run the Notebook in a the Binder to see a live demo, or open the Notebook source on GitHub.
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/facebookresearch/hydra/master?filepath=examples%2jupyter_notebooks)
-[![Notebook source](https://img.shields.io/badge/-Notebooks%20source-informational)](https://github.com/facebookresearch/hydra//tree/master/examples/jupyter_notebooks/)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/facebookresearch/hydra/main?filepath=examples%2jupyter_notebooks)
+[![Notebook source](https://img.shields.io/badge/-Notebooks%20source-informational)](https://github.com/facebookresearch/hydra//tree/main/examples/jupyter_notebooks/)

--- a/website/versioned_docs/version-1.1/advanced/jupyter_notebooks.md
+++ b/website/versioned_docs/version-1.1/advanced/jupyter_notebooks.md
@@ -7,5 +7,5 @@ Hydra supports config composition inside Jupyter notebooks via the [Compose API]
 
 Run the Notebook in a the Binder to see a live demo, or open the Notebook source on GitHub.
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/facebookresearch/hydra/master?filepath=examples%2jupyter_notebooks)
-[![Notebook source](https://img.shields.io/badge/-Notebooks%20source-informational)](https://github.com/facebookresearch/hydra//tree/master/examples/jupyter_notebooks/)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/facebookresearch/hydra/main?filepath=examples%2jupyter_notebooks)
+[![Notebook source](https://img.shields.io/badge/-Notebooks%20source-informational)](https://github.com/facebookresearch/hydra//tree/main/examples/jupyter_notebooks/)


### PR DESCRIPTION
The master branch no longer exists on github, so these links have rotted.
I have updated them with the correct URL.
