### PR TITLE
Fix recent invalid processing of structured configs

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -527,9 +527,9 @@ class ConfigLoaderImpl(ConfigLoader):
                 if cfg._is_missing() or cfg._is_none():
                     return
                 with flag_override(cfg, ["readonly", "struct"], False):
-                    if getattr(cfg, "__HYDRA_REMOVE_TOP_LEVEL_DEFAULTS__", False):
+                    if cfg._get_flag("HYDRA_REMOVE_TOP_LEVEL_DEFAULTS"):
+                        cfg._set_flag("HYDRA_REMOVE_TOP_LEVEL_DEFAULTS", None)
                         cfg.pop("defaults", None)
-                        cfg.pop("__HYDRA_REMOVE_TOP_LEVEL_DEFAULTS__")
 
                 for _key, value in cfg.items_ex(resolve=False):
                     strip_defaults(value)

--- a/hydra/_internal/config_repository.py
+++ b/hydra/_internal/config_repository.py
@@ -285,7 +285,7 @@ class ConfigRepository(IConfigRepository):
                     # It will be removed later.
                     # This is addressing an edge case where the defaults list re-appears once the dataclass is used
                     # as a prototype during OmegaConf merge.
-                    cfg["__HYDRA_REMOVE_TOP_LEVEL_DEFAULTS__"] = True
+                    cfg._set_flag("HYDRA_REMOVE_TOP_LEVEL_DEFAULTS", True)
                     defaults = cfg.get("defaults", empty)
         if not isinstance(defaults, ListConfig):
             if isinstance(defaults, DictConfig):

--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -435,10 +435,7 @@ def _has_config_content(cfg: DictConfig) -> bool:
         return False
 
     for key in cfg.keys():
-        if not OmegaConf.is_missing(cfg, key) and key not in (
-            "defaults",
-            "__HYDRA_REMOVE_TOP_LEVEL_DEFAULTS__",
-        ):
+        if not OmegaConf.is_missing(cfg, key) and key != "defaults":
             return True
     return False
 

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Dict, List, Optional
@@ -703,3 +704,23 @@ def test_missing_node_with_defaults_list(hydra_restore_singletons: Any) -> None:
 
     cfg = compose("trainer/base_trainer")
     assert cfg == {"trainer": {"reducer": {}}}
+
+
+@mark.usefixtures("initialize_hydra_no_path")
+def test_enum_with_removed_defaults_list(hydra_restore_singletons: Any) -> None:
+    class Category(Enum):
+        X = 0
+        Y = 1
+        Z = 2
+
+    @dataclass
+    class Conf:
+        enum_dict: Dict[Category, str] = field(default_factory=dict)
+        int_dict: Dict[int, str] = field(default_factory=dict)
+        str_dict: Dict[str, str] = field(default_factory=dict)
+
+    cs = ConfigStore.instance()
+    cs.store(name="conf", node=Conf)
+
+    cfg = compose("conf")
+    assert cfg == {"enum_dict": {}, "int_dict": {}, "str_dict": {}}


### PR DESCRIPTION
Fixes issue #1834

We can't insert an aribtrary "__REMOVE_TOP_LEVEL_DEFAULTS__" key
in the config, as that will fail various base OmegaConf checks,
due to not being a valid enum etc, giving errors like:
  Key '__HYDRA_REMOVE_TOP_LEVEL_DEFAULTS__' is incompatible with the enum type ...

Instead we set that flag using _set_flag on the cfg object.

This was tested with:

  pytest tests/test_compose.py -k test_missing_node_with_defaults_list