### PR TITLE
Implement shell completion for +group and ~group

### DIFF
--- a/hydra/plugins/completion_plugin.py
+++ b/hydra/plugins/completion_plugin.py
@@ -158,6 +158,10 @@ class CompletionPlugin(Plugin):
         return matches
 
     def _query_config_groups(self, word: str) -> Tuple[List[str], bool]:
+        if word.startswith("+") or word.startswith("~"):
+            prefix, word = word[0], word[1:]
+        else:
+            prefix = ""
         last_eq_index = word.rfind("=")
         last_slash_index = word.rfind("/")
         exact_match: bool = False
@@ -197,6 +201,7 @@ class CompletionPlugin(Plugin):
                         name = name + "/"
                     matched_groups.append(name)
 
+        matched_groups = [f"{prefix}{group}" for group in matched_groups]
         return matched_groups, exact_match
 
     def _query(self, config_name: Optional[str], line: str) -> List[str]:

--- a/hydra/plugins/completion_plugin.py
+++ b/hydra/plugins/completion_plugin.py
@@ -158,7 +158,9 @@ class CompletionPlugin(Plugin):
         return matches
 
     def _query_config_groups(self, word: str) -> Tuple[List[str], bool]:
-        if word.startswith("+") or word.startswith("~"):
+        is_addition = word.startswith("+")
+        is_deletion = word.startswith("~")
+        if is_addition or is_deletion:
             prefix, word = word[0], word[1:]
         else:
             prefix = ""
@@ -195,7 +197,7 @@ class CompletionPlugin(Plugin):
                     dirs = self.config_loader.get_group_options(
                         group_name=name, results_filter=ObjectType.GROUP
                     )
-                    if len(dirs) == 0 and len(files) > 0:
+                    if len(dirs) == 0 and len(files) > 0 and not is_deletion:
                         name = name + "="
                     elif len(dirs) > 0 and len(files) == 0:
                         name = name + "/"

--- a/news/1841.feature
+++ b/news/1841.feature
@@ -1,0 +1,1 @@
+Implement tab completions for appending to the defaults list (+group=option) and deleting from the defaults list (~group).

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -237,8 +237,8 @@ class TestRunCompletion:
             skip("fish is not installed or the version is too old")
         if shell == "zsh" and not is_zsh_supported():
             skip("zsh is not installed or the version is too old")
-        if shell == "zsh" and "~" in line:
-            xfail("zsh treats unquoted tilde symbols specially")
+        if shell in ("zsh", "fish") and "~" in line:
+            xfail(f"{shell} treats words prefixed by the tilde symbol specially")
 
         # verify expect will be running the correct Python.
         # This preemptively detect a much harder to understand error from expect.

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -171,6 +171,32 @@ base_completion_list: List[str] = [
             "group=dict ~group=", 2, ["~group=dict", "~group=list"], id="group_delete2"
         ),
         param("~", 2, ["~group", "~hydra", "~test_hydra/"], id="bare_tilde"),
+        param("+test_hydra/lau", 2, ["+test_hydra/launcher="], id="nested_plus"),
+        param(
+            "+test_hydra/launcher=",
+            2,
+            ["+test_hydra/launcher=fairtask"],
+            id="nested_plus_equal",
+        ),
+        param(
+            "+test_hydra/launcher=fa",
+            2,
+            ["+test_hydra/launcher=fairtask"],
+            id="nested_plus_equal_partial",
+        ),
+        param("~test_hydra/lau", 2, ["~test_hydra/launcher"], id="nested_tilde"),
+        param(
+            "~test_hydra/launcher=",
+            2,
+            ["~test_hydra/launcher=fairtask"],
+            id="nested_tilde_equal",
+        ),
+        param(
+            "~test_hydra/launcher=fa",
+            2,
+            ["~test_hydra/launcher=fairtask"],
+            id="nested_tilde_equal_partial",
+        ),
     ],
 )
 class TestRunCompletion:

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List
 
 from packaging import version
-from pytest import mark, param, skip
+from pytest import mark, param, skip, xfail
 
 from hydra._internal.config_loader_impl import ConfigLoaderImpl
 from hydra._internal.core_plugins.bash_completion import BashCompletion
@@ -237,6 +237,8 @@ class TestRunCompletion:
             skip("fish is not installed or the version is too old")
         if shell == "zsh" and not is_zsh_supported():
             skip("zsh is not installed or the version is too old")
+        if shell == "zsh" and "~" in line:
+            xfail("zsh treats unquoted tilde symbols specially")
 
         # verify expect will be running the correct Python.
         # This preemptively detect a much harder to understand error from expect.

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -237,7 +237,9 @@ class TestRunCompletion:
             skip("fish is not installed or the version is too old")
         if shell == "zsh" and not is_zsh_supported():
             skip("zsh is not installed or the version is too old")
-        if shell in ("zsh", "fish") and "~" in line:
+        if shell in ("zsh", "fish") and any(
+            word.startswith("~") for word in line.split(" ")
+        ):
             xfail(f"{shell} treats words prefixed by the tilde symbol specially")
 
         # verify expect will be running the correct Python.

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -157,18 +157,20 @@ base_completion_list: List[str] = [
         param("group=dict group.dict=", 2, ["group.dict=true"], id="group"),
         param("group=dict group=", 2, ["group=dict", "group=list"], id="group"),
         param("group=dict group=", 2, ["group=dict", "group=list"], id="group"),
+        param("+", 2, ["+group=", "+hydra", "+test_hydra/"], id="bare_plus"),
         param("+gro", 2, ["+group="], id="append_group_partial"),
         param("+group=di", 2, ["+group=dict"], id="append_group_partial_option"),
         param("+group=", 2, ["+group=dict", "+group=list"], id="group_append"),
         param(
             "group=dict +group=", 2, ["+group=dict", "+group=list"], id="group_append2"
         ),
-        param("~gro", 2, ["~group="], id="delete_group_partial"),
+        param("~gro", 2, ["~group"], id="delete_group_partial"),
         param("~group=di", 2, ["~group=dict"], id="delete_group_partial_option"),
         param("~group=", 2, ["~group=dict", "~group=list"], id="group_delete"),
         param(
             "group=dict ~group=", 2, ["~group=dict", "~group=list"], id="group_delete2"
         ),
+        param("~", 2, ["~group", "~hydra", "~test_hydra/"], id="bare_tilde"),
     ],
 )
 class TestRunCompletion:

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -157,6 +157,18 @@ base_completion_list: List[str] = [
         param("group=dict group.dict=", 2, ["group.dict=true"], id="group"),
         param("group=dict group=", 2, ["group=dict", "group=list"], id="group"),
         param("group=dict group=", 2, ["group=dict", "group=list"], id="group"),
+        param("+gro", 2, ["+group="], id="append_group_partial"),
+        param("+group=di", 2, ["+group=dict"], id="append_group_partial_option"),
+        param("+group=", 2, ["+group=dict", "+group=list"], id="group_append"),
+        param(
+            "group=dict +group=", 2, ["+group=dict", "+group=list"], id="group_append2"
+        ),
+        param("~gro", 2, ["~group="], id="delete_group_partial"),
+        param("~group=di", 2, ["~group=dict"], id="delete_group_partial_option"),
+        param("~group=", 2, ["~group=dict", "~group=list"], id="group_delete"),
+        param(
+            "group=dict ~group=", 2, ["~group=dict", "~group=list"], id="group_delete2"
+        ),
     ],
 )
 class TestRunCompletion:

--- a/website/docs/tutorials/basic/running_your_app/6_tab_completion.md
+++ b/website/docs/tutorials/basic/running_your_app/6_tab_completion.md
@@ -16,11 +16,16 @@ import Script from '@site/src/components/Script.jsx';
 
 ### Install tab completion
 Get the exact command to install the completion from `--hydra-help`.
-Currently, Bash, zsh and Fish are supported.   
+Currently, Bash, zsh and Fish are supported.
 We are relying on the community to implement tab completion plugins for additional shells.
 
+#### Fish instructions
 Fish support requires version >= 3.1.2.
 Previous versions will work but add an extra space after `.`.
+
+Because the fish shell implements special behavior for expanding words prefixed
+with a tilde character '~', command-line completion does not work for
+[tilde deletions](/advanced/override_grammar/basic.md#modifying-the-defaults-list).
 
 #### Zsh instructions
 Zsh is compatible with the existing Bash shell completion by appending
@@ -28,3 +33,7 @@ Zsh is compatible with the existing Bash shell completion by appending
 autoload -Uz bashcompinit && bashcompinit
 ```
 to the `.zshrc` file after `compinit`, restarting the shell and then using the commands provided for Bash.
+
+Because the zsh shell implements special behavior for expanding words prefixed
+with a tilde character '~', command-line completion does not work for
+[tilde deletions](/advanced/override_grammar/basic.md#modifying-the-defaults-list).


### PR DESCRIPTION
This PR adds logic Hydra's shell-completion, handling the cases of '+group' and '~group'.
Closes #1841.

Completions enabled by this PR:
- `+gro` -> `+group=`  (just like if no plus is given)
- `+group=` -> `+group=option`  (just like if no plus is given)
- `+` -> `+group=`
- `~gro` -> `~group`  (note no trailing equal sign) 
- `~group=` -> `~group=option`  (just like if no tilde is given)
- `~` -> `~group`

Edit:
I was not able to get the tilde completions ('~group...') working with fish or zsh; those shells have special completion logic for words starting with tilde.