### PR TITLE
Docs: add notes on command line quoting

### DIFF
--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -147,6 +147,19 @@ Quoted strings can accept any value between the quotes, but some characters need
 </div>
 </div>
 
+It may be necessary to use multiple pairs of quotes to prevent your
+shell from consuming quotation marks before they are passed to hydra.
+
+```shell
+$ python my_app.py +foo="{a: 10}"  # the string `+foo={a: 10}` is passed to Hydra by bash
+foo:
+  a: 10
+
+$ python my_app.py '+foo="{a: 10}"'  # the string `+foo="{a: 10}"` is passed to Hydra by bash
+foo: '{a: 10}'
+
+```
+
 ### Whitespaces in unquoted values
 Unquoted Override values can contain non leading or trailing whitespaces.
 For example, `msg=hello world` is a legal override (key is `msg` and value is the string `hello world`).

--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -196,11 +196,13 @@ As an example, in the following `dir` is set to the string `job{a=1,b=2,c=3}`:
 $ python my_app.py 'dir=job\{a\=1\,b\=2\,c\=3\}'
 ```
 
-Some characters, such as the bar symbol `'|'`, are not legal in unquoted strings.
-Strings containing such characters must be quoted:
+Hydra's parser considers some characters, such as the left-bracket symbol `'['`, to be illegal in unquoted strings.
+Strings containing such characters must be quoted, or the offending character(s) escaped with backslashes:
 
 ```shell
-$ python my_app.py 'dir="A|B"'
+$ python my_app.py 'dir=A[B'    # error
+$ python my_app.py 'dir="A[B"'  # ok
+$ python my_app.py 'dir=A\[B'   # ok
 ```
 
 ### Primitives

--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -186,6 +186,13 @@ As an example, in the following `dir` is set to the string `job{a=1,b=2,c=3}`:
 $ python my_app.py 'dir=job\{a\=1\,b\=2\,c\=3\}'
 ```
 
+Some characters, such as the bar symbol `'|'`, are not legal in unquoted strings.
+Strings containing such characters must be quoted:
+
+```shell
+$ python my_app.py 'dir="A|B"'
+```
+
 ### Primitives
 - `id` : oompa10, loompa_12
 - `null`: null

--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -187,7 +187,8 @@ $ python my_app.py 'msg=    hello world    '
 ```
 
 ### Escaped characters in unquoted values
-Some otherwise special characters may be included in unquoted values by escaping them with a `\`.
+Hydra's parser considers some characters to be illegal in unquoted strings.
+These otherwise special characters may be included in unquoted values by escaping them with a `\`.
 These characters are: `\()[]{}:=, \t` (the last two ones being the whitespace and tab characters).
 
 As an example, in the following `dir` is set to the string `job{a=1,b=2,c=3}`:
@@ -196,11 +197,10 @@ As an example, in the following `dir` is set to the string `job{a=1,b=2,c=3}`:
 $ python my_app.py 'dir=job\{a\=1\,b\=2\,c\=3\}'
 ```
 
-Hydra's parser considers some characters, such as the left-bracket symbol `'['`, to be illegal in unquoted strings.
-Strings containing such characters must be quoted, or the offending character(s) escaped with backslashes:
+As an alternative to escaping special characters with a backslash, the value containing the special character may be quoted:
 
 ```shell
-$ python my_app.py 'dir=A[B'    # error
+$ python my_app.py 'dir=A[B'    # parser error
 $ python my_app.py 'dir="A[B"'  # ok
 $ python my_app.py 'dir=A\[B'   # ok
 ```

--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -151,14 +151,24 @@ It may be necessary to use multiple pairs of quotes to prevent your
 shell from consuming quotation marks before they are passed to hydra.
 
 ```shell
-$ python my_app.py +foo="{a: 10}"  # the string `+foo={a: 10}` is passed to Hydra by bash
+$ python my_app.py '+foo="{a: 10}"'
+foo: '{a: 10}'
+
+$ python my_app.py '+foo={a: 10}'
 foo:
   a: 10
 
-$ python my_app.py '+foo="{a: 10}"'  # the string `+foo="{a: 10}"` is passed to Hydra by bash
-foo: '{a: 10}'
-
 ```
+
+Here are some best practices around quoting in CLI overrides:
+- Quote the whole key=value pair with single quotes, as in the first two
+  examples above. These quotes are for the benefit of the shell.
+- Do not quote keys.
+- Only quote values if they contain a space. It will work if you always quote
+  values, but it will turn numbers/dicts/lists into strings (as in the first
+  example above).
+- When you are quoting values, use double quotes to avoid collision with the
+  outer single quoted consumed by the shell.
 
 ### Whitespaces in unquoted values
 Unquoted Override values can contain non leading or trailing whitespaces.

--- a/website/versioned_docs/version-1.1/advanced/override_grammar/basic.md
+++ b/website/versioned_docs/version-1.1/advanced/override_grammar/basic.md
@@ -147,6 +147,19 @@ Quoted strings can accept any value between the quotes, but some characters need
 </div>
 </div>
 
+It may be necessary to use multiple pairs of quotes to prevent your
+shell from consuming quotation marks before they are passed to hydra.
+
+```shell
+$ python my_app.py +foo="{a: 10}"  # the string `+foo={a: 10}` is passed to Hydra by bash
+foo:
+  a: 10
+
+$ python my_app.py '+foo="{a: 10}"'  # the string `+foo="{a: 10}"` is passed to Hydra by bash
+foo: '{a: 10}'
+
+```
+
 ### Whitespaces in unquoted values
 Unquoted Override values can contain non leading or trailing whitespaces.
 For example, `msg=hello world` is a legal override (key is `msg` and value is the string `hello world`).

--- a/website/versioned_docs/version-1.1/advanced/override_grammar/basic.md
+++ b/website/versioned_docs/version-1.1/advanced/override_grammar/basic.md
@@ -151,14 +151,27 @@ It may be necessary to use multiple pairs of quotes to prevent your
 shell from consuming quotation marks before they are passed to hydra.
 
 ```shell
-$ python my_app.py +foo="{a: 10}"  # the string `+foo={a: 10}` is passed to Hydra by bash
+$ python my_app.py '+foo="{a: 10}"'
+foo: '{a: 10}'
+
+$ python my_app.py '+foo={a: 10}'
 foo:
   a: 10
 
-$ python my_app.py '+foo="{a: 10}"'  # the string `+foo="{a: 10}"` is passed to Hydra by bash
-foo: '{a: 10}'
-
+$ python my_app.py +foo={a: 10}  # Two strings are passed to Hydra: `+foo={a:` and `10}`. This is an error.
+no viable alternative at input '{a:'.
+...
 ```
+
+Here are some best practices around quoting in CLI overrides:
+- Quote the whole key=value pair with single quotes, as in the first two
+  examples above. These quotes are for the benefit of the shell.
+- Do not quote keys.
+- Only quote values if they contain a space. It will work if you always quote
+  values, but it will turn numbers/dicts/lists into strings (as in the first
+  example above).
+- When you are quoting values, use double quotes to avoid collision with the
+  outer single quoted consumed by the shell.
 
 ### Whitespaces in unquoted values
 Unquoted Override values can contain non leading or trailing whitespaces.

--- a/website/versioned_docs/version-1.1/advanced/override_grammar/basic.md
+++ b/website/versioned_docs/version-1.1/advanced/override_grammar/basic.md
@@ -186,6 +186,13 @@ As an example, in the following `dir` is set to the string `job{a=1,b=2,c=3}`:
 $ python my_app.py 'dir=job\{a\=1\,b\=2\,c\=3\}'
 ```
 
+Some characters, such as the bar symbol `'|'`, are not legal in unquoted strings.
+Strings containing such characters must be quoted:
+
+```shell
+$ python my_app.py 'dir="A|B"'
+```
+
 ### Primitives
 - `id` : oompa10, loompa_12
 - `null`: null

--- a/website/versioned_docs/version-1.1/advanced/override_grammar/basic.md
+++ b/website/versioned_docs/version-1.1/advanced/override_grammar/basic.md
@@ -190,7 +190,8 @@ $ python my_app.py 'msg=    hello world    '
 ```
 
 ### Escaped characters in unquoted values
-Some otherwise special characters may be included in unquoted values by escaping them with a `\`.
+Hydra's parser considers some characters to be illegal in unquoted strings.
+These otherwise special characters may be included in unquoted values by escaping them with a `\`.
 These characters are: `\()[]{}:=, \t` (the last two ones being the whitespace and tab characters).
 
 As an example, in the following `dir` is set to the string `job{a=1,b=2,c=3}`:
@@ -199,11 +200,10 @@ As an example, in the following `dir` is set to the string `job{a=1,b=2,c=3}`:
 $ python my_app.py 'dir=job\{a\=1\,b\=2\,c\=3\}'
 ```
 
-Hydra's parser considers some characters, such as the left-bracket symbol `'['`, to be illegal in unquoted strings.
-Strings containing such characters must be quoted, or the offending character(s) escaped with backslashes:
+As an alternative to escaping special characters with a backslash, the value containing the special character may be quoted:
 
 ```shell
-$ python my_app.py 'dir=A[B'    # error
+$ python my_app.py 'dir=A[B'    # parser error
 $ python my_app.py 'dir="A[B"'  # ok
 $ python my_app.py 'dir=A\[B'   # ok
 ```

--- a/website/versioned_docs/version-1.1/advanced/override_grammar/basic.md
+++ b/website/versioned_docs/version-1.1/advanced/override_grammar/basic.md
@@ -199,11 +199,13 @@ As an example, in the following `dir` is set to the string `job{a=1,b=2,c=3}`:
 $ python my_app.py 'dir=job\{a\=1\,b\=2\,c\=3\}'
 ```
 
-Some characters, such as the bar symbol `'|'`, are not legal in unquoted strings.
-Strings containing such characters must be quoted:
+Hydra's parser considers some characters, such as the left-bracket symbol `'['`, to be illegal in unquoted strings.
+Strings containing such characters must be quoted, or the offending character(s) escaped with backslashes:
 
 ```shell
-$ python my_app.py 'dir="A|B"'
+$ python my_app.py 'dir=A[B'    # error
+$ python my_app.py 'dir="A[B"'  # ok
+$ python my_app.py 'dir=A\[B'   # ok
 ```
 
 ### Primitives


### PR DESCRIPTION
This PR adds two notes to the documentation on command-line overrides.
Related to #1843.