### PR TITLE
add `build` to linter ignore lists

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,7 @@ exclude =
     ,tools/configen/example/gen
     ,tools/configen/tests/test_modules/expected
     ,temp
+    ,build
 
     # flake8-copyright does not support unicode, savoirfairelinux/flake8-copyright#15
     ,examples/plugins/example_configsource_plugin/hydra_plugins/example_configsource_plugin/example_configsource_plugin.py

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -24,3 +24,4 @@ skip=
     ,tools/configen/example/gen
     ,tools/configen/tests/test_modules/expected
     ,temp
+    ,build

--- a/noxfile.py
+++ b/noxfile.py
@@ -227,6 +227,7 @@ def lint(session):
         "tools/configen/example/gen",
         "tools/configen/tests/test_modules/expected",
         "temp",
+        "build",
     ]
     isort = _isort_cmd() + [f"--skip={skip}" for skip in skiplist]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ exclude = '''
     | .venv
     | _build
     | dist
+    | build
   )
 )
 '''


### PR DESCRIPTION
As of the latest version of pip (v 21.3.0), "in-tree" builds are the default.
This means that some pip operations may create a `build` folder in the source tree.

This has been causing some linter failures, e.g. when running `nox` repeatedly,
as some linters fail upon trying to lint the contents of the `build` folder.

This PR updates the linters' ignore lists, excluding `build` from linting.


I'm submitting this PR as a draft for now; I'll rebase after #1857 is merged.