### PR TITLE
Improve `instantiate` error message in case where `_target_` cannot be loaded

### DIFF
--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -564,8 +564,8 @@ def _locate(path: str) -> Union[type, Callable[..., Any]]:
 
     parts = [part for part in path.split(".") if part]
     for n in reversed(range(1, len(parts) + 1)):
+        mod = ".".join(parts[:n])
         try:
-            mod = ".".join(parts[:n])
             obj = import_module(mod)
         except Exception as exc_import:
             if n == 1:
@@ -578,8 +578,8 @@ def _locate(path: str) -> Union[type, Callable[..., Any]]:
             obj = getattr(obj, part)
         except AttributeError as exc_attr:
             if isinstance(obj, ModuleType):
+                mod = ".".join(parts[: m + 1])
                 try:
-                    mod = ".".join(parts[: m + 1])
                     import_module(mod)
                 except ModuleNotFoundError:
                     pass

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -571,8 +571,7 @@ def _locate(path: str) -> Union[type, Callable[..., Any]]:
             if n == 1:
                 raise ImportError(f"Error loading module '{path}'") from e
             continue
-        if obj:
-            break
+        break
     for m in range(n, len(parts)):
         part = parts[m]
         try:

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -559,7 +559,6 @@ def _locate(path: str) -> Union[type, Callable[..., Any]]:
     """
     if path == "":
         raise ImportError("Empty path")
-    import builtins
     from importlib import import_module
     from types import ModuleType
 
@@ -570,10 +569,7 @@ def _locate(path: str) -> Union[type, Callable[..., Any]]:
             obj = import_module(mod)
         except Exception as e:
             if n == 1:
-                if hasattr(builtins, parts[0]):
-                    obj = getattr(builtins, parts[0])
-                else:
-                    raise ImportError(f"Error loading module '{path}'") from e
+                raise ImportError(f"Error loading module '{path}'") from e
             continue
         if obj:
             break

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -587,7 +587,7 @@ def _locate(path: str) -> Union[type, Callable[..., Any]]:
                     raise ImportError(
                         f"Error loading '{path}': '{repr(exc_import)}'"
                     ) from exc_import
-            raise AttributeError(f"Error loading '{path}': {exc_attr}") from exc_attr
+            raise ImportError(f"Encountered AttributeError while loading '{path}': {exc_attr}") from exc_attr
     if isinstance(obj, type):
         obj_type: type = obj
         return obj_type

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -597,7 +597,7 @@ def _locate(path: str) -> Union[type, Callable[..., Any]]:
         obj_callable: Callable[..., Any] = obj
         return obj_callable
     else:
-        # dummy case
+        # reject if not callable & not a type
         raise ValueError(f"Invalid type ({type(obj)}) found for {path}")
 
 

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -587,7 +587,9 @@ def _locate(path: str) -> Union[type, Callable[..., Any]]:
                     raise ImportError(
                         f"Error loading '{path}': '{repr(exc_import)}'"
                     ) from exc_import
-            raise ImportError(f"Encountered AttributeError while loading '{path}': {exc_attr}") from exc_attr
+            raise ImportError(
+                f"Encountered AttributeError while loading '{path}': {exc_attr}"
+            ) from exc_attr
     if isinstance(obj, type):
         obj_type: type = obj
         return obj_type

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -588,7 +588,7 @@ def _locate(path: str) -> Union[type, Callable[..., Any]]:
                     ) from e
             else:
                 raise AttributeError(
-                    f"Encountered AttributeError when loading '{path}'"
+                    f"Could not get attribute '{part}' when loading '{path}'"
                 ) from e
     if isinstance(obj, type):
         obj_type: type = obj

--- a/news/1863.feature
+++ b/news/1863.feature
@@ -1,0 +1,1 @@
+Improve clarity of error messages when `hydra.utils.instantiate` encounters a `_target_` that cannot be located

--- a/tests/instantiate/import_error.py
+++ b/tests/instantiate/import_error.py
@@ -1,0 +1,1 @@
+assert False

--- a/tests/instantiate/import_error.py
+++ b/tests/instantiate/import_error.py
@@ -1,1 +1,2 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 assert False

--- a/tests/instantiate/test_helpers.py
+++ b/tests/instantiate/test_helpers.py
@@ -20,7 +20,11 @@ from tests.instantiate import (
 @mark.parametrize(
     "name,expected",
     [
-        param("int", int, id="int"),
+        param(
+            "int",
+            raises(ImportError, match=re.escape("Error loading module 'int'")),
+            id="int",
+        ),
         param("builtins.int", int, id="builtins_explicit"),
         param("builtins.int.from_bytes", int.from_bytes, id="method_of_builtin"),
         param(

--- a/tests/instantiate/test_helpers.py
+++ b/tests/instantiate/test_helpers.py
@@ -30,9 +30,10 @@ from tests.instantiate import (
         param(
             "builtins.int.not_found",
             raises(
-                AttributeError,
+                ImportError,
                 match=re.escape(
-                    "Error loading 'builtins.int.not_found': type object 'int' has no attribute 'not_found'"
+                    "Encountered AttributeError while loading 'builtins.int.not_found':"
+                    + " type object 'int' has no attribute 'not_found'"
                 ),
             ),
             id="builtin_attribute_error",
@@ -56,9 +57,9 @@ from tests.instantiate import (
         param(
             "tests.instantiate.AClass.not_found",
             raises(
-                AttributeError,
+                ImportError,
                 match=re.escape(
-                    "Error loading 'tests.instantiate.AClass.not_found':"
+                    "Encountered AttributeError while loading 'tests.instantiate.AClass.not_found':"
                     + " type object 'AClass' has no attribute 'not_found'"
                 ),
             ),
@@ -75,9 +76,10 @@ from tests.instantiate import (
         param(
             "tests.instantiate.b.c.Door",
             raises(
-                AttributeError,
+                ImportError,
                 match=re.escape(
-                    "Error loading 'tests.instantiate.b.c.Door': module 'tests.instantiate' has no attribute 'b'"
+                    "Encountered AttributeError while loading 'tests.instantiate.b.c.Door':"
+                    + " module 'tests.instantiate' has no attribute 'b'"
                 ),
             ),
             id="nested_not_found",

--- a/tests/instantiate/test_helpers.py
+++ b/tests/instantiate/test_helpers.py
@@ -3,7 +3,7 @@ import re
 from typing import Any
 
 from _pytest.python_api import RaisesContext, raises
-from pytest import mark
+from pytest import mark, param
 
 from hydra._internal.utils import _locate
 from hydra.utils import get_class
@@ -20,22 +20,69 @@ from tests.instantiate import (
 @mark.parametrize(
     "name,expected",
     [
+        param("int", int, id="int"),
+        param("builtins.int", int, id="builtins_explicit"),
+        param("builtins.int.from_bytes", int.from_bytes, id="method_of_builtin"),
+        param(
+            "builtins.int.from_boots",
+            raises(
+                AttributeError,
+                match=re.escape(
+                    "Encountered AttributeError when loading 'builtins.int.from_boots'"
+                ),
+            ),
+            id="builtin_attribute_error",
+        ),
+        param(
+            "datetime",
+            raises(
+                ValueError,
+                match=re.escape("Invalid type (<class 'module'>) found for datetime"),
+            ),
+            id="top_level_module",
+        ),
         ("tests.instantiate.Adam", Adam),
         ("tests.instantiate.Parameters", Parameters),
         ("tests.instantiate.AClass", AClass),
+        param(
+            "tests.instantiate.AClass.static_method",
+            AClass.static_method,
+            id="staticmethod",
+        ),
+        param(
+            "tests.instantiate.AClass.not_found",
+            raises(
+                AttributeError,
+                match=re.escape(
+                    "Encountered AttributeError when loading 'tests.instantiate.AClass.not_found'"
+                ),
+            ),
+            id="class_attribute_error",
+        ),
         ("tests.instantiate.ASubclass", ASubclass),
         ("tests.instantiate.NestingClass", NestingClass),
         ("tests.instantiate.AnotherClass", AnotherClass),
         ("", raises(ImportError, match=re.escape("Empty path"))),
-        [
+        (
             "not_found",
             raises(ImportError, match=re.escape("Error loading module 'not_found'")),
-        ],
-        (
+        ),
+        param(
             "tests.instantiate.b.c.Door",
             raises(
                 ImportError, match=re.escape("No module named 'tests.instantiate.b'")
             ),
+            id="nested_not_found",
+        ),
+        param(
+            "tests.instantiate.import_error",
+            raises(
+                ImportError,
+                match=re.escape(
+                    "Encountered error: `AssertionError()` when loading module 'tests.instantiate.import_error'"
+                ),
+            ),
+            id="import_assertion_error",
         ),
     ],
 )

--- a/tests/instantiate/test_helpers.py
+++ b/tests/instantiate/test_helpers.py
@@ -28,11 +28,11 @@ from tests.instantiate import (
         param("builtins.int", int, id="builtins_explicit"),
         param("builtins.int.from_bytes", int.from_bytes, id="method_of_builtin"),
         param(
-            "builtins.int.from_boots",
+            "builtins.int.not_found",
             raises(
                 AttributeError,
                 match=re.escape(
-                    "Encountered AttributeError when loading 'builtins.int.from_boots'"
+                    "Could not get attribute 'not_found' when loading 'builtins.int.not_found'"
                 ),
             ),
             id="builtin_attribute_error",
@@ -58,7 +58,7 @@ from tests.instantiate import (
             raises(
                 AttributeError,
                 match=re.escape(
-                    "Encountered AttributeError when loading 'tests.instantiate.AClass.not_found'"
+                    "Could not get attribute 'not_found' when loading 'tests.instantiate.AClass.not_found'"
                 ),
             ),
             id="class_attribute_error",

--- a/tests/instantiate/test_helpers.py
+++ b/tests/instantiate/test_helpers.py
@@ -32,7 +32,7 @@ from tests.instantiate import (
             raises(
                 AttributeError,
                 match=re.escape(
-                    "Could not get attribute 'not_found' when loading 'builtins.int.not_found'"
+                    "Error loading 'builtins.int.not_found': type object 'int' has no attribute 'not_found'"
                 ),
             ),
             id="builtin_attribute_error",
@@ -58,7 +58,8 @@ from tests.instantiate import (
             raises(
                 AttributeError,
                 match=re.escape(
-                    "Could not get attribute 'not_found' when loading 'tests.instantiate.AClass.not_found'"
+                    "Error loading 'tests.instantiate.AClass.not_found':"
+                    + " type object 'AClass' has no attribute 'not_found'"
                 ),
             ),
             id="class_attribute_error",
@@ -74,7 +75,10 @@ from tests.instantiate import (
         param(
             "tests.instantiate.b.c.Door",
             raises(
-                ImportError, match=re.escape("No module named 'tests.instantiate.b'")
+                AttributeError,
+                match=re.escape(
+                    "Error loading 'tests.instantiate.b.c.Door': module 'tests.instantiate' has no attribute 'b'"
+                ),
             ),
             id="nested_not_found",
         ),
@@ -83,7 +87,7 @@ from tests.instantiate import (
             raises(
                 ImportError,
                 match=re.escape(
-                    "Encountered error: `AssertionError()` when loading module 'tests.instantiate.import_error'"
+                    "Error loading 'tests.instantiate.import_error': 'AssertionError()'"
                 ),
             ),
             id="import_assertion_error",


### PR DESCRIPTION
This PR improves the error handling of `hydra.utils.instantiate` for the case
where `_target_` cannot be properly resolved.

Closes #1863

Below is a summary of the changed error handling (with tracebacks condensed).

### The case where a module cannot be found:
Before:
```text
>>> instantiate({"_target_": "foo"})
Traceback (most recent call last):
  ...
ValueError: Empty module name
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  ...
ImportError: Error loading module 'foo'
```
Above, note the confusing `ValueError: Empty module name`.

After:
```
>>> instantiate({"_target_": "foo"})
Traceback (most recent call last):
  ...
ModuleNotFoundError: No module named 'foo'
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  ...
ImportError: Error loading module 'foo'
```

### The case where an attribute cannot be found on an object:
Before:
```
>>> instantiate({"_target_": "pickle.dumps.missing_attribute"})
  ...
ModuleNotFoundError: No module named 'pickle.dumps'; 'pickle' is not a package
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  ...
ImportError: Encountered error: `No module named 'pickle.dumps'; 'pickle' is not a package` when loading module 'pickle.dumps.missing_attribute'
```
Note above the misleading `ModuleNotFoundError: No module named 'pickle.dumps'; 'pickle' is not a package`.

After:
```
>>> instantiate({"_target_": "pickle.dumps.missing_attribute"})
Traceback (most recent call last):
  ...
AttributeError: 'builtin_function_or_method' object has no attribute 'missing_attribute'
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  ...
ImportError: Encountered AttributeError while loading 'pickle.dumps.missing_attribute': 'builtin_function_or_method' object has no attribute 'missing_attribute'
```

### The case where an attribute cannot be found on a module (and no submodule can be found with the correct name):
Before:
```text
>>> instantiate({"_target_": "pickle.typo"})
Traceback (most recent call last):
  ...
ModuleNotFoundError: No module named 'pickle.typo'; 'pickle' is not a package
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  ...
ImportError: Encountered error: `No module named 'pickle.typo'; 'pickle' is not a package` when loading module 'pickle.typo'
```

After:
```text
>>> instantiate({"_target_": "pickle.typo"})
Traceback (most recent call last):
  ...
AttributeError: module 'pickle' has no attribute 'typo'
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  ...
ImportError: Encountered AttributeError while loading 'pickle.typo': module 'pickle' has no attribute 'typo'
```

### The case where a module contains a syntax error or other error (as in #1863)
```python
# my_module.py
class Foo  # syntax error
    print("Hi")
```
Before:
```text
>>> instantiate({"_target_": "my_module.Foo"})
Traceback (most recent call last):
  ...
ValueError: Empty module name
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  ...
ImportError: Error loading module 'my_module.Foo'
```

After:
```
>>> instantiate({"_target_": "my_module.Foo"})
Traceback (most recent call last):
  ...
  File "/home/jasha10/hydra.git/my_module.py", line 2
    class Foo  # syntax error
             ^
SyntaxError: invalid syntax
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  ...
ImportError: Error loading module 'my_module.Foo'
```