### PR TITLE
Fix CI.

### DIFF
--- a/plugins/hydra_ray_launcher/setup.py
+++ b/plugins/hydra_ray_launcher/setup.py
@@ -27,6 +27,7 @@ setup(
         "boto3==1.17.17",
         "hydra-core>=1.1.0.dev7",
         "ray[default]==1.6.0",
+        "aiohttp<3.8.0",
         "cloudpickle==1.6.0",
         "pickle5==0.0.11",
     ],

--- a/plugins/hydra_ray_launcher/setup.py
+++ b/plugins/hydra_ray_launcher/setup.py
@@ -27,6 +27,7 @@ setup(
         "boto3==1.17.17",
         "hydra-core>=1.1.0.dev7",
         "ray[default]==1.6.0",
+        # https://github.com/facebookresearch/hydra/pull/1874
         "aiohttp<3.8.0",
         "cloudpickle==1.6.0",
         "pickle5==0.0.11",

--- a/plugins/hydra_ray_launcher/setup.py
+++ b/plugins/hydra_ray_launcher/setup.py
@@ -28,7 +28,7 @@ setup(
         "hydra-core>=1.1.0.dev7",
         "ray[default]==1.6.0",
         # https://github.com/aio-libs/aiohttp/issues/6203
-        "aiohttp<3.8.0",
+        "aiohttp!=3.8.0",
         "cloudpickle==1.6.0",
         "pickle5==0.0.11",
     ],

--- a/plugins/hydra_ray_launcher/setup.py
+++ b/plugins/hydra_ray_launcher/setup.py
@@ -27,7 +27,7 @@ setup(
         "boto3==1.17.17",
         "hydra-core>=1.1.0.dev7",
         "ray[default]==1.6.0",
-        # https://github.com/facebookresearch/hydra/pull/1874
+        # https://github.com/aio-libs/aiohttp/issues/6203
         "aiohttp<3.8.0",
         "cloudpickle==1.6.0",
         "pickle5==0.0.11",


### PR DESCRIPTION
`aiohttp` (ray's dependency) released 3.8.0 yesterday, it is installing an `examples` top level package and as a result make it not possible for the hydra's examples module being discovered. for now, im pinning the version. 
This issue has already been fixed in aiohttp and should become available in the next release.