### PR TITLE
enable CI for python3.9 on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ workflows:
       - test_win:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8"]
+              py_version: ["3.6", "3.7", "3.8", "3.9"]
 
 
   plugin_tests:
@@ -269,7 +269,7 @@ workflows:
       - test_plugin_win:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8",]
+              py_version: ["3.6", "3.7", "3.8", "3.9"]
               test_plugin: [<< pipeline.parameters.test_plugins >>]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,9 +92,8 @@ commands:
             choco install -y --no-progress openssl javaruntime
       - run:
           name: Preparing environment - Hydra
-          # Using virtualenv==20.0.33 higher versions of virtualenv are not compatible with conda on windows. Relevant issue: https://github.com/ContinuumIO/anaconda-issues/issues/12094
           command: |
-            conda create -n hydra python=<< parameters.py_version >> virtualenv==20.0.33 -qy
+            conda create -n hydra python=<< parameters.py_version >> -qy
             conda activate hydra
             pip install nox dataclasses --progress-bar off
       - save_cache:

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1435,7 +1435,7 @@ def test_frozen_primary_config(
     [
         param(
             False,
-            r"^\S*/my_app\.py:10: UserWarning: Feature FooBar is deprecated$",
+            r"^\S*[/\\]my_app\.py:10: UserWarning: Feature FooBar is deprecated$",
             id="deprecation_warning",
         ),
         param(
@@ -1444,7 +1444,7 @@ def test_frozen_primary_config(
                 r"""
                 ^Error executing job with overrides: \[\]\n?
                 Traceback \(most recent call last\):
-                  File "\S*/my_app.py", line 10, in my_app
+                  File "\S*[/\\]my_app.py", line 10, in my_app
                     deprecation_warning\("Feature FooBar is deprecated"\)
                   File "\S*\.py", line 11, in deprecation_warning
                     raise HydraDeprecationError\(.*\)


### PR DESCRIPTION
CI is working on mac+linux for python 3.6/3.7/3.8/3.9.
On windows, it is not enabled for 3.9.
This PR will be an attempt to get python3.9 CI working with Windows.
