### PR TITLE
Improve website handling of 1.1_branch

### DIFF
--- a/website/docs/development/release.md
+++ b/website/docs/development/release.md
@@ -12,4 +12,6 @@ The release process may be automated in the future.
 - Create a wheel and source dist for hydra-core: `python -m build`
 - Upload pip package: `python -m twine upload dist/*`
 - Update the link to the latest stable release in `website/docs/intro.md`
-- If you are creating a new release branch, update the website config in `website/docusaurus.config.js`
+- If you are creating a new release branch:
+  - [tag a new versioned copy of the docs using docusaurus](https://docusaurus.io/docs/versioning#tagging-a-new-version)
+  - update `website/docusaurus.config.js` with a pointer to the new release branch on github

--- a/website/docs/development/release.md
+++ b/website/docs/development/release.md
@@ -11,4 +11,5 @@ The release process may be automated in the future.
 - Update NEWS.md with towncrier
 - Create a wheel and source dist for hydra-core: `python -m build`
 - Upload pip package: `python -m twine upload dist/*`
- 
+- Update the link to the latest stable release in `website/docs/intro.md`
+- If you are creating a new release branch, update the website config in `website/docusaurus.config.js`

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -27,9 +27,9 @@ Use the version switcher in the top bar to switch between documentation versions
  
 |        |          Version          |  Release notes                                                                      | Python Versions    |
 | -------|---------------------------|-------------------------------------------------------------------------------------| -------------------|
-| &#9658;| 1.1 (Stable)              | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/v1.1.0)      | **3.6 - 3.9**      |
-|        | 1.0                       | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/v1.0.0rc1)   | **3.6 - 3.8**      |
-|        | 0.11                      | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/0.11.0)      | **2.7, 3.5 - 3.8** |
+| &#9658;| 1.1 (Stable)              | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/v1.1.1)      | **3.6 - 3.9**      |
+|        | 1.0                       | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/v1.0.7)      | **3.6 - 3.8**      |
+|        | 0.11                      | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/v0.11.3)     | **2.7, 3.5 - 3.8** |
 
 
 ## Quick start guide

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -15,8 +15,9 @@ module.exports = {
     projectName: 'hydra', // Usually your repo name.
     customFields: {
         githubLinkVersionToBaseUrl: {
-            // TODO: Update once a branch is cut for 1.1
-            "1.1": "https://github.com/facebookresearch/hydra/blob/main/",
+            // TODO: Update once a branch is cut for 1.2
+            "1.2": "https://github.com/facebookresearch/hydra/blob/main/",
+            "1.1": "https://github.com/facebookresearch/hydra/blob/1.1_branch/",
             "1.0": "https://github.com/facebookresearch/hydra/blob/1.0_branch/",
             current: "https://github.com/facebookresearch/hydra/blob/main/",
         },

--- a/website/versioned_docs/version-1.1/intro.md
+++ b/website/versioned_docs/version-1.1/intro.md
@@ -27,9 +27,9 @@ Use the version switcher in the top bar to switch between documentation versions
  
 |        |          Version          |  Release notes                                                                      | Python Versions    |
 | -------|---------------------------|-------------------------------------------------------------------------------------| -------------------|
-| &#9658;| 1.1 (Stable)              | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/v1.1.0)      | **3.6 - 3.9**      |
-|        | 1.0                       | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/v1.0.0rc1)   | **3.6 - 3.8**      |
-|        | 0.11                      | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/0.11.0)      | **2.7, 3.5 - 3.8** |
+| &#9658;| 1.1 (Stable)              | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/v1.1.1)      | **3.6 - 3.9**      |
+|        | 1.0                       | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/v1.0.7)      | **3.6 - 3.8**      |
+|        | 0.11                      | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/v0.11.3)     | **2.7, 3.5 - 3.8** |
 
 
 ## Quick start guide


### PR DESCRIPTION
This PR makes a few minor improvements to the docs:
  - The links from `intro.md` to various hydra releases are now updated to point to the most recent release on each release branch.
  - add a note to the developer release docs on the topic of updating the Hydra website for a new release
  - update `website/docusaurus.config.js` with pointer to the Hydra 1.1 release branch.

This PR began as an attempt to resolve issue #1871, but it turns out that there may be a docusaurus issue preventing that issue from being closed.