### PR TITLE
fix broken website links

### DIFF
--- a/website/docs/plugins/nevergrad_sweeper.md
+++ b/website/docs/plugins/nevergrad_sweeper.md
@@ -27,7 +27,7 @@ defaults:
 ```
 
 The default configuration is defined and documented <GithubLink to="plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/config.py">here</GithubLink>.
-There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins) for more information.
+There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins.md) for more information.
 
 ## Example of training using Nevergrad hyperparameter search
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -10,6 +10,9 @@ module.exports = {
     tagline: 'A framework for elegantly configuring complex applications',
     url: 'https://hydra.cc',
     baseUrl: '/',
+    onBrokenLinks: 'throw',
+    onBrokenMarkdownLinks: 'warn',
+    trailingSlash: true,
     favicon: 'img/Hydra-head.svg',
     organizationName: 'facebookresearch', // Usually your GitHub org/user name.
     projectName: 'hydra', // Usually your repo name.

--- a/website/versioned_docs/version-1.0/advanced/override_grammar/basic.md
+++ b/website/versioned_docs/version-1.0/advanced/override_grammar/basic.md
@@ -225,7 +225,7 @@ key="a,b","c,d"               # Elements can be quoted strings, ChoiceSweep("a,b
 key=[a,b],[c,d]               # Elements can be real lists, ChoiceSweep([a,b], [c,d])
 key={a:10, b:20},{c:30,d:40}  # And dictionaries: ChoiceSweep({a:10, b:20}, {c:30,d:40})
 ```
-More sweeping options are described in the [Extended Grammar page](extended).
+More sweeping options are described in the [Extended Grammar page](extended.md).
 
 :::important
 You may need to quote your choice sweep in the shell.
@@ -234,7 +234,7 @@ You may need to quote your choice sweep in the shell.
 
 ### Functions
 Hydra supports several functions in the command line.
-See the [Extended Grammar page](extended) for more information.
+See the [Extended Grammar page](extended.md) for more information.
 
 ## Working with your shell
 All shells interprets command line inputs and may change what is passed to the process.

--- a/website/versioned_docs/version-1.0/configure_hydra/workdir.md
+++ b/website/versioned_docs/version-1.0/configure_hydra/workdir.md
@@ -39,7 +39,7 @@ hydra:
 
 Run output directory can contain override parameters for the job:
 
-See [Override dirname](./job#hydrajoboverride_dirname) in the Job configuration page for details on how to customize
+See [Override dirname](./job.md#hydrajoboverride_dirname) in the Job configuration page for details on how to customize
 `hydra.job.override_dirname`.
 
 ```yaml


### PR DESCRIPTION
## Motivation

Broken links on website that can lead to misleading "Page not found" pages.

Repro steps
- go to [hydra.cc/docs/next/plugins/nevergrad_sweeper/](https://hydra.cc/docs/next/plugins/nevergrad_sweeper/) (note trailing slash, without it the issue does not reproduce)
- click on `this page` link
- see "page not found"

The fix is to force trailing slashes for all pages and to throw during website build to prevent broken links being added in the future.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

- Navigate to `nevergrad_sweeper` page by pasting URL to the browser bar without a trailing slash
- Expect trailing slash to be added on page load
- Navigating to `this page` link should work