### PR TITLE
Improve instantiate handling of callable _target_ kwarg

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -70,9 +70,7 @@ def _call_target(_target_: Callable, _partial_: bool, *args, **kwargs) -> Any:  
 
 
 def _convert_target_to_string(t: Any) -> Any:
-    if isinstance(t, type):
-        return f"{t.__module__}.{t.__name__}"
-    elif callable(t):
+    if callable(t):
         return f"{t.__module__}.{t.__qualname__}"
     else:
         return t

--- a/news/1914.bugfix
+++ b/news/1914.bugfix
@@ -1,0 +1,1 @@
+Fix a resolution error occurring when a nested class is passed as a `_target_` keyword argument to `instantiate`

--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -64,12 +64,33 @@ class ArgsClass:
             return NotImplemented
 
 
+class OuterClass:
+    def __init__(self) -> None:
+        pass
+
+    @classmethod
+    def method(self) -> str:
+        return "OuterClass.method return"
+
+    class Nested:
+        def __init__(self) -> None:
+            pass
+
+        @classmethod
+        def method(self) -> str:
+            return "OuterClass.Nested.method return"
+
+
 def add_values(a: int, b: int) -> int:
     return a + b
 
 
 def module_function(x: int) -> int:
     return x
+
+
+def module_function2() -> str:
+    return "fn return"
 
 
 @dataclass


### PR DESCRIPTION
This PR closes #1914.

Commits
- https://github.com/facebookresearch/hydra/commit/90468cbbaf7963f6cd89658f5e7c73b8c2c54073: add failing test

  As of this commit, the following fails:
  ```
  pytest tests/instantiate -k 'test_instantiate_with_callable_target_keyword[instantiate2-nested]'
  ```
- https://github.com/facebookresearch/hydra/commit/1122135b11dbcf9e02c2d8ffc6c0785512898417: patch `_convert_target_to_string`
