### PR TITLE
Improve `instantiate` handling of exceptions raised by user code

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -60,13 +60,19 @@ def _call_target(_target_: Callable, _partial_: bool, *args, **kwargs) -> Any:  
         for v in kwargs.values():
             if OmegaConf.is_config(v):
                 v._set_parent(None)
-        if _partial_:
-            return functools.partial(_target_, *args, **kwargs)
-        return _target_(*args, **kwargs)
     except Exception as e:
         raise type(e)(
             f"Error instantiating '{_convert_target_to_string(_target_)}' : {e}"
         ).with_traceback(sys.exc_info()[2])
+
+    try:
+        if _partial_:
+            return functools.partial(_target_, *args, **kwargs)
+        return _target_(*args, **kwargs)
+    except Exception as e:
+        raise InstantiationException(
+            f"Error instantiating '{_convert_target_to_string(_target_)}' : {repr(e)}"
+        ) from e
 
 
 def _convert_target_to_string(t: Any) -> Any:

--- a/news/1911.api_change
+++ b/news/1911.api_change
@@ -1,0 +1,1 @@
+If user code raises an exception when called by `instantiate`, raise an `InstantiateError` exception instead of an instance of the same exception class that was raised by the user code.

--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -3,7 +3,7 @@ import collections
 import collections.abc
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NoReturn, Optional, Tuple
 
 from omegaconf import MISSING, DictConfig, ListConfig
 
@@ -91,6 +91,16 @@ def module_function(x: int) -> int:
 
 def module_function2() -> str:
     return "fn return"
+
+
+class ExceptionTakingNoArgument(Exception):
+    def __init__(self) -> None:
+        """Init method taking only one argument (self)"""
+        super().__init__("Err message")
+
+
+def raise_exception_taking_no_argument() -> NoReturn:
+    raise ExceptionTakingNoArgument()
 
 
 @dataclass

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -565,10 +565,8 @@ def test_instantiate_with_missing_module(instantiate_func: Any) -> None:
     _target_ = "tests.instantiate.ClassWithMissingModule"
     with raises(
         InstantiationException,
-        match=re.escape(
-            f"Error instantiating '{_target_}' : "
-            + "ModuleNotFoundError(\"No module named 'some_missing_module'\")"
-        ),
+        match=re.escape(f"Error instantiating '{_target_}' : ")
+        + r"ModuleNotFoundError\(\"No module named 'some_missing_module'\",?\)",
     ):
         # can't instantiate when importing a missing module
         instantiate_func({"_target_": _target_})
@@ -580,10 +578,8 @@ def test_instantiate_target_raising_exception_taking_no_arguments(
     _target_ = "tests.instantiate.raise_exception_taking_no_argument"
     with raises(
         InstantiationException,
-        match=re.escape(
-            f"Error instantiating '{_target_}' : "
-            + "ExceptionTakingNoArgument('Err message')"
-        ),
+        match=re.escape(f"Error instantiating '{_target_}' : ")
+        + r"ExceptionTakingNoArgument\('Err message',?\)",
     ):
         instantiate_func({}, _target_=_target_)
 

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -460,7 +460,10 @@ def test_class_instantiate_omegaconf_node(instantiate_func: Any, config: Any) ->
 
 @mark.parametrize("src", [{"_target_": "tests.instantiate.Adam"}])
 def test_instantiate_adam(instantiate_func: Any, config: Any) -> None:
-    with raises(TypeError):
+    with raises(
+        InstantiationException,
+        match=r"Error instantiating 'tests\.instantiate\.Adam' : TypeError\(.*\)",
+    ):
         # can't instantiate without passing params
         instantiate_func(config)
 
@@ -501,7 +504,10 @@ def test_regression_1483(instantiate_func: Any, is_partial: bool) -> None:
 def test_instantiate_adam_conf(
     instantiate_func: Any, is_partial: bool, expected_params: Any
 ) -> None:
-    with raises(TypeError):
+    with raises(
+        InstantiationException,
+        match=r"Error instantiating 'tests\.instantiate\.Adam' : TypeError\(.*\)",
+    ):
         # can't instantiate without passing params
         instantiate_func(AdamConf())
 
@@ -556,11 +562,30 @@ def test_instantiate_bad_adam_conf(instantiate_func: Any, recwarn: Any) -> None:
 
 def test_instantiate_with_missing_module(instantiate_func: Any) -> None:
 
+    _target_ = "tests.instantiate.ClassWithMissingModule"
     with raises(
-        ModuleNotFoundError, match=re.escape("No module named 'some_missing_module'")
+        InstantiationException,
+        match=re.escape(
+            f"Error instantiating '{_target_}' : "
+            + "ModuleNotFoundError(\"No module named 'some_missing_module'\")"
+        ),
     ):
         # can't instantiate when importing a missing module
-        instantiate_func({"_target_": "tests.instantiate.ClassWithMissingModule"})
+        instantiate_func({"_target_": _target_})
+
+
+def test_instantiate_target_raising_exception_taking_no_arguments(
+    instantiate_func: Any,
+) -> None:
+    _target_ = "tests.instantiate.raise_exception_taking_no_argument"
+    with raises(
+        InstantiationException,
+        match=re.escape(
+            f"Error instantiating '{_target_}' : "
+            + "ExceptionTakingNoArgument('Err message')"
+        ),
+    ):
+        instantiate_func({}, _target_=_target_)
 
 
 @mark.parametrize("is_partial", [True, False])


### PR DESCRIPTION
This PR fixes a bug that arises when `instantiate` is invoked on a callable that raises a custom exception that has a non-standard signature.

## Background info about the bug:
This PR closes #1911.

A call to `instantiate({"_target_": target_callable, **kwargs})` works by locating the `target_callable` and calling it on the given arguments `**kwargs`.
The call to `target_callable` is performed inside of the [`hydra._internal.instantiate._instantiate2._call_target`](https://github.com/facebookresearch/hydra/blob/86b544bf1b635058094ff29690d85b5091147312/hydra/_internal/instantiate/_instantiate2.py#L62) function:
```python
def _call_target(_target_: Callable, *args, **kwargs) -> Any:  # type: ignore
    """Call target (type) with args and kwargs."""
    try:
        ...
        return _target_(*args, **kwargs)
    except Exception as e:
        raise type(e)(
            f"Error instantiating '{_convert_target_to_string(_target_)}' : {e}"
        ).with_traceback(sys.exc_info()[2])
```
This `_call_target` function has a `try`/`except` block that catches exceptions that might be raisd by the `target_callable`.
In the `_call_target` function's `except` block, another exception is raised with an error message giving context about the exception. The exception raised in the `except` block is of the same type as the exception that was originally caught.
This is problematic because we must assume that the exception class `type(e)` can be called with one argument; we are making the assumption here that `type(e).__init__` accepts a string error message as it's first and only argument.
This assumption fails if the user's code raises a custom exception whose `__init__` function takes a non-standard number of arguments (as was the case in bug report #1911).

## Proposed Changes
This PR fixes the reported bug by not raising an exception of `type(e)` if something goes wrong with the call to `_target_`.
Instead, an instance of `hydra.errors.InstantiationException` is raised *from* `e` (a lá [exception chaining](https://docs.python.org/3/tutorial/errors.html#exception-chaining)).

Since this PR changes the type of exception that will be raised if user code throws an exception, it should be considered an API change.

Commits:
  - https://github.com/facebookresearch/hydra/commit/2505edae29bff0b4e9252d5f5ef54d66ff5c658d: Add failing tests
  - https://github.com/facebookresearch/hydra/commit/a2dbbf87a876db74961e7f1edca8652992a91827: raise InstantiationException instead of type(e)
  - https://github.com/facebookresearch/hydra/commit/247a3ed7051a0ed71ada0843df07c1ff51db15bf: add news fragment
  - https://github.com/facebookresearch/hydra/pull/1916/commits/95494eeb09df52ad7a18d19bafabeb6132b646e7: update test regex patterns for python3.6 compatibility.

I'm not planning to merge this PR until after #1905 and #1915 are finished, as those PRs also touch code related to `instantiate`.