### PR TITLE
Update config.py

### DIFF
--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
@@ -54,7 +54,8 @@ class SlurmQueueConf(BaseQueueConf):
     gpus_per_task: Optional[int] = None
     mem_per_gpu: Optional[str] = None
     mem_per_cpu: Optional[str] = None
-    account: Optional[str] = None 
+    account: Optional[str] = None
+
     # Following parameters are submitit specifics
     #
     # USR1 signal delay before timeout

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
@@ -54,7 +54,7 @@ class SlurmQueueConf(BaseQueueConf):
     gpus_per_task: Optional[int] = None
     mem_per_gpu: Optional[str] = None
     mem_per_cpu: Optional[str] = None
-
+    account: Optional[str] = None 
     # Following parameters are submitit specifics
     #
     # USR1 signal delay before timeout

--- a/plugins/hydra_submitit_launcher/news/1920.feature
+++ b/plugins/hydra_submitit_launcher/news/1920.feature
@@ -1,0 +1,1 @@
+Add support for submitit parameter `account`

--- a/website/docs/plugins/submitit_launcher.md
+++ b/website/docs/plugins/submitit_launcher.md
@@ -55,6 +55,7 @@ cpus_per_gpu: null
 gpus_per_task: null
 mem_per_gpu: null
 mem_per_cpu: null
+account: null
 signal_delay_s: 120
 max_num_timeout: 0
 additional_parameters: {}


### PR DESCRIPTION
Add account parameter of slurm

<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

The slurm cluster used by me needs me to specify the **account** parameter in the bash script. It wasn't present in this current version.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

No need for tests. I added it as an optional parameter

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
[1664](https://github.com/facebookincubator/submitit/pull/1664) is related to this.
