### PR TITLE
test coverage: instantiation with unsupported _args_ type

### DIFF
--- a/tests/instantiate/test_positional.py
+++ b/tests/instantiate/test_positional.py
@@ -1,8 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import re
 from typing import Any
 
-from pytest import mark, param
+from pytest import mark, param, raises
 
+from hydra.errors import InstantiationException
 from hydra.utils import instantiate
 from tests.instantiate import ArgsClass
 
@@ -45,6 +47,18 @@ from tests.instantiate import ArgsClass
 )
 def test_instantiate_args_kwargs(cfg: Any, expected: Any) -> None:
     assert instantiate(cfg) == expected
+
+
+def test_instantiate_unsupported_args_type() -> None:
+    cfg = {"_target_": "tests.instantiate.ArgsClass", "_args_": {"foo": "bar"}}
+    with raises(
+        InstantiationException,
+        match=re.escape(
+            "Error instantiating 'tests.instantiate.ArgsClass' : "
+            + "Unsupported _args_ type: DictConfig. value: {'foo': 'bar'}"
+        ),
+    ):
+        instantiate(cfg)
 
 
 @mark.parametrize(


### PR DESCRIPTION
This PR adds a test to cover the `else` block in the [`_instantiate2._extract_pos_args`](https://github.com/facebookresearch/hydra/blob/5f605a863dd4aed8f432884fcd1e1b388c8fb559/hydra/_internal/instantiate/_instantiate2.py#L35) function.
