### PR TITLE
Add info to docs on hydra.job.chdir

### DIFF
--- a/website/docs/configure_hydra/job.md
+++ b/website/docs/configure_hydra/job.md
@@ -66,7 +66,7 @@ You can override it via the command line, or your config file.
 ### hydra.job.chdir
 
 Decides whether Hydra changes the current working directory to the output directory for each job.
-Learn more at the [Output/Working directory](/tutorials/basic/running_your_app/3_working_directory.md) page.
+Learn more at the [Output/Working directory](/tutorials/basic/running_your_app/3_working_directory.md#disable-changing-current-working-dir-to-jobs-output-dir) page.
 
 
 ### hydra.job.override_dirname

--- a/website/docs/tutorials/basic/running_your_app/3_working_directory.md
+++ b/website/docs/tutorials/basic/running_your_app/3_working_directory.md
@@ -55,7 +55,8 @@ And in the main output directory:
 
 ### Disable changing current working dir to job's output dir
 
-Set `hydra.job.chdir=False` to disable the behavior. 
+By default, Hydra's `@hydra.main` decorator makes a call to `os.chdir` before passing control to the user's decorated main function.
+Set `hydra.job.chdir=False` to disable this behavior.
 ```bash
 # check current working dir
 $ pwd  
@@ -65,7 +66,7 @@ $ pwd
 $ python my_app.py hydra.job.chdir=False
 Working directory : /home/omry/dev/hydra
 
-# output dir and files created
+# output dir and files are still created, even if `chdir` is disabled:
 $ tree -a outputs/2021-10-25/09-46-26/
 outputs/2021-10-25/09-46-26/
 ├── .hydra

--- a/website/docs/upgrades/1.1_to_1.2/changes_to_job_working_dir.md
+++ b/website/docs/upgrades/1.1_to_1.2/changes_to_job_working_dir.md
@@ -10,3 +10,7 @@ In Hydra 1.3, `hydra.job.chdir` will default to `False`.
 
 If you want to keep the old Hydra behavior, please set `hydra.job.chdir=True` explicitly for you application so it will not
 be broken by future upgrades.
+
+For more information about `hydra.job.chdir`,
+see [Output/Working directory](/tutorials/basic/running_your_app/3_working_directory.md#disable-changing-current-working-dir-to-jobs-output-dir)
+and [Job Configuration - hydra.job.chdir](/configure_hydra/job.md#hydrajobchdir).


### PR DESCRIPTION
This PR makes minor updates to the docs related to the new `hydra.job.chdir` key.
Links are updated in https://github.com/facebookresearch/hydra/commit/1e358e977d36212349a1e0bf9233b939461e3445 and https://github.com/facebookresearch/hydra/commit/3f2b8d4efc08a955f080281ae1b4c555936c0ca0, and extra context on `hydra.job.chdir` is added in https://github.com/facebookresearch/hydra/commit/e9e88baec2d61671e65175a646daa9112b3df835.