### PR TITLE
Follow up on hydra.main(config_path) deprecation

### DIFF
--- a/hydra/experimental/initialize.py
+++ b/hydra/experimental/initialize.py
@@ -6,7 +6,6 @@ from typing import Any, Optional
 from hydra._internal.deprecation_warning import deprecation_warning
 from hydra.core.global_hydra import GlobalHydra
 from hydra.core.singleton import Singleton
-from hydra.initialize import _UNSPECIFIED_
 
 
 def get_gh_backup() -> Any:
@@ -26,7 +25,7 @@ def restore_gh_from_backup(_gh_backup: Any) -> Any:
 class initialize:
     def __init__(
         self,
-        config_path: Optional[str] = _UNSPECIFIED_,
+        config_path: Optional[str] = None,
         job_name: Optional[str] = None,
         caller_stack_depth: int = 1,
     ) -> None:

--- a/hydra/initialize.py
+++ b/hydra/initialize.py
@@ -1,10 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import copy
 import os
-from textwrap import dedent
 from typing import Any, Optional
 
-from hydra._internal.deprecation_warning import deprecation_warning
 from hydra._internal.hydra import Hydra
 from hydra._internal.utils import (
     create_config_search_path,
@@ -30,9 +28,6 @@ def restore_gh_from_backup(_gh_backup: Any) -> Any:
         Singleton._instances[GlobalHydra] = _gh_backup
 
 
-_UNSPECIFIED_: Any = object()
-
-
 class initialize:
     """
     Initializes Hydra and add the config_path to the config search path.
@@ -51,25 +46,11 @@ class initialize:
 
     def __init__(
         self,
-        config_path: Optional[str] = _UNSPECIFIED_,
+        config_path: Optional[str] = None,
         job_name: Optional[str] = None,
         caller_stack_depth: int = 1,
     ) -> None:
         self._gh_backup = get_gh_backup()
-
-        # DEPRECATED: remove in 1.2
-        # in 1.2, the default config_path should be changed to None
-        if config_path is _UNSPECIFIED_:
-            url = "https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_hydra_main_config_path"
-            deprecation_warning(
-                message=dedent(
-                    f"""\
-                config_path is not specified in hydra.initialize().
-                See {url} for more information."""
-                ),
-                stacklevel=2,
-            )
-            config_path = "."
 
         if config_path is not None and os.path.isabs(config_path):
             raise HydraException("config_path in initialize() must be relative")

--- a/hydra/main.py
+++ b/hydra/main.py
@@ -1,19 +1,15 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import functools
-from textwrap import dedent
 from typing import Any, Callable, Optional
 
 from omegaconf import DictConfig
 
-from ._internal.deprecation_warning import deprecation_warning
 from ._internal.utils import _run_hydra, get_args_parser
 from .types import TaskFunction
 
-_UNSPECIFIED_: Any = object()
-
 
 def main(
-    config_path: Optional[str] = _UNSPECIFIED_,
+    config_path: Optional[str] = None,
     config_name: Optional[str] = None,
 ) -> Callable[[TaskFunction], Any]:
     """
@@ -21,20 +17,6 @@ def main(
                         If config_path is None no directory is added to the Config search path.
     :param config_name: The name of the config (usually the file name without the .yaml extension)
     """
-
-    # DEPRECATED: remove in 1.2
-    # in 1.2, the default config_path should be changed to None
-    if config_path is _UNSPECIFIED_:
-        url = "https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_hydra_main_config_path"
-        deprecation_warning(
-            message=dedent(
-                f"""
-            config_path is not specified in @hydra.main().
-            See {url} for more information."""
-            ),
-            stacklevel=2,
-        )
-        config_path = "."
 
     def main_decorator(task_function: TaskFunction) -> Callable[[], None]:
         @functools.wraps(task_function)

--- a/news/1940.api_change
+++ b/news/1940.api_change
@@ -1,0 +1,1 @@
+Change the default value of the `@hydra.main` decorator's `config_path` argument from '.' to `None`.

--- a/tests/test_apps/hydra_main_without_config_path/my_app.py
+++ b/tests/test_apps/hydra_main_without_config_path/my_app.py
@@ -8,7 +8,6 @@ from hydra.core.hydra_config import HydraConfig
 @hydra.main()
 def my_app(_: DictConfig) -> None:
     config_sources = HydraConfig.get().runtime.config_sources
-    print(config_sources)
     # Check that no directory has been added to the Config search path
     for source in config_sources:
         assert (

--- a/tests/test_apps/hydra_main_without_config_path/my_app.py
+++ b/tests/test_apps/hydra_main_without_config_path/my_app.py
@@ -2,11 +2,18 @@
 from omegaconf import DictConfig
 
 import hydra
+from hydra.core.hydra_config import HydraConfig
 
 
 @hydra.main()
 def my_app(_: DictConfig) -> None:
-    pass
+    config_sources = HydraConfig.get().runtime.config_sources
+    print(config_sources)
+    # Check that no directory has been added to the Config search path
+    for source in config_sources:
+        assert (
+            source.schema != "file"
+        ), f"Found a config source with file schema: {source}"
 
 
 if __name__ == "__main__":

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -624,14 +624,8 @@ def test_deprecated_initialize_config_module() -> None:
 
 
 def test_initialize_without_config_path(tmpdir: Path) -> None:
-    expected = dedent(
-        """\
-        config_path is not specified in hydra.initialize().
-        See https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_hydra_main_config_path for more information."""
-    )
-    with warns(expected_warning=UserWarning, match=re.escape(expected)):
-        with initialize():
-            pass
+    with initialize():
+        pass
 
 
 @mark.usefixtures("initialize_hydra_no_path")

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1415,22 +1415,7 @@ def test_hydra_main_without_config_path(tmpdir: Path) -> None:
         f"hydra.run.dir={tmpdir}",
         "hydra.job.chdir=True",
     ]
-    _, err = run_python_script(cmd, allow_warnings=True)
-
-    expected = dedent(
-        """
-        .*my_app.py:7: UserWarning:
-        config_path is not specified in @hydra.main().
-        See https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_hydra_main_config_path for more information.
-          @hydra.main()
-        """
-    )
-    assert_regex_match(
-        from_line=expected,
-        to_line=err,
-        from_name="Expected error",
-        to_name="Actual error",
-    )
+    _ = run_python_script(cmd)
 
 
 def test_job_chdir_not_specified(tmpdir: Path) -> None:


### PR DESCRIPTION
This PR follows up on a deprecation, changing the `hydra.main` `config_path` argument's default from `'.'` to `None`
