### PR TITLE
remove handling of deprecated "old optional" defaults list syntax

### DIFF
--- a/news/1952.maintenance
+++ b/news/1952.maintenance
@@ -1,0 +1,1 @@
+For version_base >= 1.2, remove deprecated "old optional" defaults list syntax


### PR DESCRIPTION
In previous versions of hydra, the following two defaults lists were equivalent:
```yaml
defaults:
  - optional foo: bar
```
```yaml
defaults:
  - foo: bar
    optional: true
```
This PR removes support for the ~former~ latter syntax.
