### PR TITLE
Remove deprecated handling of old Plugin.setup signature

### DIFF
--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -11,7 +11,7 @@ from enum import Enum
 from os.path import splitext
 from pathlib import Path
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Union, cast
+from typing import Any, Dict, Optional, Sequence, Union, cast
 
 from omegaconf import DictConfig, OmegaConf, open_dict, read_write
 
@@ -19,9 +19,6 @@ from hydra._internal.deprecation_warning import deprecation_warning
 from hydra.core.hydra_config import HydraConfig
 from hydra.core.singleton import Singleton
 from hydra.types import HydraContext, TaskFunction
-
-if TYPE_CHECKING:
-    from hydra._internal.callbacks import Callbacks
 
 log = logging.getLogger(__name__)
 
@@ -85,25 +82,17 @@ def filter_overrides(overrides: Sequence[str]) -> Sequence[str]:
     return [x for x in overrides if not x.startswith("hydra.")]
 
 
-def _get_callbacks_for_run_job(hydra_context: Optional[HydraContext]) -> "Callbacks":
+def _check_hydra_context(hydra_context: Optional[HydraContext]) -> None:
     if hydra_context is None:
-        # DEPRECATED: remove in 1.2
-        # hydra_context will be required in 1.2
-        deprecation_warning(
-            message=dedent(
+        # hydra_context is required as of Hydra 1.2.
+        # We can remove this check in Hydra 1.3.
+        raise TypeError(
+            dedent(
                 """
-                run_job's signature has changed in Hydra 1.1. Please pass in hydra_context.
-                Support for the old style will be removed in Hydra 1.2.
+                run_job's signature has changed: the `hydra_context` arg is now required.
                 For more info, check https://github.com/facebookresearch/hydra/pull/1581."""
             ),
         )
-        from hydra._internal.callbacks import Callbacks
-
-        callbacks = Callbacks()
-    else:
-        callbacks = hydra_context.callbacks
-
-    return callbacks
 
 
 def run_job(
@@ -111,10 +100,11 @@ def run_job(
     config: DictConfig,
     job_dir_key: str,
     job_subdir_key: Optional[str],
+    hydra_context: HydraContext,
     configure_logging: bool = True,
-    hydra_context: Optional[HydraContext] = None,
 ) -> "JobReturn":
-    callbacks = _get_callbacks_for_run_job(hydra_context)
+    _check_hydra_context(hydra_context)
+    callbacks = hydra_context.callbacks
 
     old_cwd = os.getcwd()
     orig_hydra_cfg = HydraConfig.instance().cfg

--- a/news/1953.maintenance
+++ b/news/1953.maintenance
@@ -1,0 +1,1 @@
+Remove support for deprecated arg `config_loader` to Plugin.setup, and update signature of `run_job` to require `hydra_context`.

--- a/tests/test_hydra_context_warnings.py
+++ b/tests/test_hydra_context_warnings.py
@@ -73,8 +73,7 @@ def test_setup_plugins(
     monkeypatch.setattr(Plugins, "check_usage", lambda _: None)
     monkeypatch.setattr(plugin_instance, "_instantiate", lambda _: plugin)
 
-    classname = type(plugin).__name__
-    msg = f"setup() got an unexpected keyword argument 'hydra_context'"
+    msg = "setup() got an unexpected keyword argument 'hydra_context'"
     with raises(TypeError, match=re.escape(msg)):
         if isinstance(plugin, Launcher):
             Plugins.instance().instantiate_launcher(

--- a/tests/test_hydra_context_warnings.py
+++ b/tests/test_hydra_context_warnings.py
@@ -5,7 +5,7 @@ from typing import Any, List, Sequence, Union
 from unittest.mock import Mock
 
 from omegaconf import DictConfig, OmegaConf
-from pytest import mark, warns
+from pytest import mark, raises, warns
 
 from hydra import TaskFunction
 from hydra._internal.callbacks import Callbacks
@@ -73,19 +73,14 @@ def test_setup_plugins(
     monkeypatch.setattr(Plugins, "check_usage", lambda _: None)
     monkeypatch.setattr(plugin_instance, "_instantiate", lambda _: plugin)
 
-    msg = dedent(
-        """
-        Plugin's setup() signature has changed in Hydra 1.1.
-        Support for the old style will be removed in Hydra 1.2.
-        For more info, check https://github.com/facebookresearch/hydra/pull/1581."""
-    )
-    with warns(expected_warning=UserWarning, match=re.escape(msg)):
+    classname = type(plugin).__name__
+    msg = f"setup() got an unexpected keyword argument 'hydra_context'"
+    with raises(TypeError, match=re.escape(msg)):
         if isinstance(plugin, Launcher):
             Plugins.instance().instantiate_launcher(
+                hydra_context=hydra_context,
                 task_function=task_function,
                 config=config,
-                config_loader=config_loader,
-                hydra_context=hydra_context,
             )
         else:
             Plugins.instance().instantiate_sweeper(

--- a/tests/test_hydra_context_warnings.py
+++ b/tests/test_hydra_context_warnings.py
@@ -5,7 +5,7 @@ from typing import Any, List, Sequence, Union
 from unittest.mock import Mock
 
 from omegaconf import DictConfig, OmegaConf
-from pytest import mark, raises, warns
+from pytest import mark, raises
 
 from hydra import TaskFunction
 from hydra._internal.callbacks import Callbacks
@@ -13,7 +13,7 @@ from hydra._internal.config_loader_impl import ConfigLoaderImpl
 from hydra._internal.utils import create_config_search_path
 from hydra.core.config_loader import ConfigLoader
 from hydra.core.plugins import Plugins
-from hydra.core.utils import JobReturn, _get_callbacks_for_run_job
+from hydra.core.utils import JobReturn, _check_hydra_context
 from hydra.plugins.launcher import Launcher
 from hydra.plugins.sweeper import Sweeper
 from hydra.test_utils.test_utils import chdir_hydra_root
@@ -93,9 +93,8 @@ def test_run_job() -> None:
     hydra_context = None
     msg = dedent(
         """
-        run_job's signature has changed in Hydra 1.1. Please pass in hydra_context.
-        Support for the old style will be removed in Hydra 1.2.
+        run_job's signature has changed: the `hydra_context` arg is now required.
         For more info, check https://github.com/facebookresearch/hydra/pull/1581."""
     )
-    with warns(expected_warning=UserWarning, match=msg):
-        _get_callbacks_for_run_job(hydra_context)
+    with raises(TypeError, match=msg):
+        _check_hydra_context(hydra_context)


### PR DESCRIPTION
This PR is a follow-up to PR #1581.
Removes support for the old (deprecated) signature for Launcher.setup and Sweeper.setup
