### PR TITLE
docs: Move `sweeper.params` example link

### DIFF
--- a/website/docs/tutorials/basic/running_your_app/2_multirun.md
+++ b/website/docs/tutorials/basic/running_your_app/2_multirun.md
@@ -21,6 +21,8 @@ The following sweeps over all combinations of the dbs and schemas.
 ```
 The printed configurations have been omitted for brevity.
 
+#### Sweeping via `hydra.sweeper.params`
+
 You can also define sweeping in the input configs by overriding
 `hydra.sweeper.params`. Using the above example, the same multirun could be achieved via the following config.
 

--- a/website/docs/tutorials/basic/running_your_app/2_multirun.md
+++ b/website/docs/tutorials/basic/running_your_app/2_multirun.md
@@ -4,10 +4,6 @@ title: Multi-run
 sidebar_label: Multi-run
 ---
 
-import {ExampleGithubLink} from "@site/src/components/GithubLink"
-
-<ExampleGithubLink to="examples/tutorials/basic/running_your_hydra_app/5_basic_sweep"/>
-
 Sometimes you want to run the same application with multiple different configurations.  
 E.g. running a performance test on each of the databases with each of the schemas.
 
@@ -27,6 +23,10 @@ The printed configurations have been omitted for brevity.
 
 You can also define sweeping in the input configs by overriding
 `hydra.sweeper.params`. Using the above example, the same multirun could be achieved via the following config.
+
+import {ExampleGithubLink} from "@site/src/components/GithubLink"
+
+<ExampleGithubLink to="examples/tutorials/basic/running_your_hydra_app/5_basic_sweep"/>
 
 ```yaml
 hydra:

--- a/website/docs/tutorials/basic/running_your_app/2_multirun.md
+++ b/website/docs/tutorials/basic/running_your_app/2_multirun.md
@@ -23,12 +23,12 @@ The printed configurations have been omitted for brevity.
 
 #### Sweeping via `hydra.sweeper.params`
 
-You can also define sweeping in the input configs by overriding
-`hydra.sweeper.params`. Using the above example, the same multirun could be achieved via the following config.
-
 import {ExampleGithubLink} from "@site/src/components/GithubLink"
 
 <ExampleGithubLink to="examples/tutorials/basic/running_your_hydra_app/5_basic_sweep"/>
+
+You can also define sweeping in the input configs by overriding
+`hydra.sweeper.params`. Using the above example, the same multirun could be achieved via the following config.
 
 ```yaml
 hydra:


### PR DESCRIPTION
Minor docs update: moving the link to [this sweep example](https://github.com/facebookresearch/hydra/tree/main/examples/tutorials/basic/running_your_hydra_app/5_basic_sweep) so that it is closer to relevant text in the docs.
Follows up on #1886.