### PR TITLE
docs: change "Example" button to "Example (Click here)"

### DIFF
--- a/website/src/components/GithubLink.jsx
+++ b/website/src/components/GithubLink.jsx
@@ -30,12 +30,12 @@ export default function GithubLink(props) {
 }
 
 export function ExampleGithubLink(props) {
-    const text = props.text ?? "Example" 
+    const text = props.text ?? "Example (Click Here)" 
     return (
         <GithubLink {...props}>
             <span>&nbsp;</span><img
                 src={"https://img.shields.io/badge/-" + text + "-informational"}
-                alt="Example"
+                alt="Example (Click Here)"
             />
         </GithubLink>
     );


### PR DESCRIPTION
Changes the Example buttons in the docs to say "Example (Click here)"

The motivation for this change is to make it clear that the button is clickable!
