### PR TITLE
multirun works with hydra.verbose=True

### DIFF
--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -384,7 +384,10 @@ class Hydra:
                 log.debug("\t\t{}".format(plugin_name))
 
     def _print_search_path(
-        self, config_name: Optional[str], overrides: List[str]
+        self,
+        config_name: Optional[str],
+        overrides: List[str],
+        run_mode: RunMode = RunMode.RUN,
     ) -> None:
         assert log is not None
         log.debug("")
@@ -395,7 +398,7 @@ class Hydra:
         cfg = self.compose_config(
             config_name=config_name,
             overrides=overrides,
-            run_mode=RunMode.RUN,
+            run_mode=run_mode,
             with_log_configuration=False,
         )
         HydraConfig.instance().set_config(cfg)
@@ -458,10 +461,15 @@ class Hydra:
         self._log_footer(header=header, filler="-")
 
     def _print_config_info(
-        self, config_name: Optional[str], overrides: List[str]
+        self,
+        config_name: Optional[str],
+        overrides: List[str],
+        run_mode: RunMode = RunMode.RUN,
     ) -> None:
         assert log is not None
-        self._print_search_path(config_name=config_name, overrides=overrides)
+        self._print_search_path(
+            config_name=config_name, overrides=overrides, run_mode=run_mode
+        )
         self._print_defaults_tree(config_name=config_name, overrides=overrides)
         self._print_defaults_list(config_name=config_name, overrides=overrides)
 
@@ -469,7 +477,7 @@ class Hydra:
             lambda: self.compose_config(
                 config_name=config_name,
                 overrides=overrides,
-                run_mode=RunMode.RUN,
+                run_mode=run_mode,
                 with_log_configuration=False,
             )
         )
@@ -480,13 +488,16 @@ class Hydra:
         log.info(OmegaConf.to_yaml(cfg))
 
     def _print_defaults_list(
-        self, config_name: Optional[str], overrides: List[str]
+        self,
+        config_name: Optional[str],
+        overrides: List[str],
+        run_mode: RunMode = RunMode.RUN,
     ) -> None:
         assert log is not None
         defaults = self.config_loader.compute_defaults_list(
             config_name=config_name,
             overrides=overrides,
-            run_mode=RunMode.RUN,
+            run_mode=run_mode,
         )
 
         box: List[List[str]] = [
@@ -534,10 +545,11 @@ class Hydra:
         self,
         config_name: Optional[str],
         overrides: List[str],
+        run_mode: RunMode = RunMode.RUN,
     ) -> None:
         assert log is not None
         if log.isEnabledFor(logging.DEBUG):
-            self._print_all_info(config_name, overrides)
+            self._print_all_info(config_name, overrides, run_mode)
 
     def compose_config(
         self,
@@ -566,21 +578,30 @@ class Hydra:
             configure_log(cfg.hydra.hydra_logging, cfg.hydra.verbose)
             global log
             log = logging.getLogger(__name__)
-            self._print_debug_info(config_name, overrides)
+            self._print_debug_info(config_name, overrides, run_mode)
         return cfg
 
     def _print_plugins_info(
-        self, config_name: Optional[str], overrides: List[str]
+        self,
+        config_name: Optional[str],
+        overrides: List[str],
+        run_mode: RunMode = RunMode.RUN,
     ) -> None:
         self._print_plugins()
         self._print_plugins_profiling_info(top_n=10)
 
-    def _print_all_info(self, config_name: Optional[str], overrides: List[str]) -> None:
+    def _print_all_info(
+        self,
+        config_name: Optional[str],
+        overrides: List[str],
+        run_mode: RunMode = RunMode.RUN,
+    ) -> None:
+
         from .. import __version__
 
         self._log_header(f"Hydra {__version__}", filler="=")
         self._print_plugins()
-        self._print_config_info(config_name, overrides)
+        self._print_config_info(config_name, overrides, run_mode)
 
     def _print_defaults_tree_impl(
         self,
@@ -616,20 +637,27 @@ class Hydra:
             log.info(pad + to_str(tree))
 
     def _print_defaults_tree(
-        self, config_name: Optional[str], overrides: List[str]
+        self,
+        config_name: Optional[str],
+        overrides: List[str],
+        run_mode: RunMode = RunMode.RUN,
     ) -> None:
         assert log is not None
         defaults = self.config_loader.compute_defaults_list(
             config_name=config_name,
             overrides=overrides,
-            run_mode=RunMode.RUN,
+            run_mode=run_mode,
         )
         log.info("")
         self._log_header("Defaults Tree", filler="*")
         self._print_defaults_tree_impl(defaults.defaults_tree)
 
     def show_info(
-        self, info: str, config_name: Optional[str], overrides: List[str]
+        self,
+        info: str,
+        config_name: Optional[str],
+        overrides: List[str],
+        run_mode: RunMode = RunMode.RUN,
     ) -> None:
         options = {
             "all": self._print_all_info,
@@ -647,4 +675,6 @@ class Hydra:
             opts = sorted(options.keys())
             log.error(f"Info usage: --info [{'|'.join(opts)}]")
         else:
-            options[info](config_name=config_name, overrides=overrides)
+            options[info](
+                config_name=config_name, overrides=overrides, run_mode=run_mode
+            )

--- a/news/1897.bugfix
+++ b/news/1897.bugfix
@@ -1,0 +1,1 @@
+hydra.verbose=True now works with multirun.

--- a/tests/test_apps/hydra_verbose/__init__.py
+++ b/tests/test_apps/hydra_verbose/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/tests/test_apps/hydra_verbose/config.yaml
+++ b/tests/test_apps/hydra_verbose/config.yaml
@@ -1,0 +1,3 @@
+hydra:
+  verbose:
+    True

--- a/tests/test_apps/hydra_verbose/my_app.py
+++ b/tests/test_apps/hydra_verbose/my_app.py
@@ -1,0 +1,13 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from omegaconf import DictConfig
+
+import hydra
+
+
+@hydra.main(config_path=".", config_name="config")
+def my_app(_: DictConfig) -> None:
+    pass
+
+
+if __name__ == "__main__":
+    my_app()

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1570,3 +1570,18 @@ def test_disable_chdir_with_app_chdir(tmpdir: Path, chdir: bool) -> None:
     result, _err = run_python_script(cmd)
     _path = os.getcwd() if chdir else Path(tmpdir) / "subdir"
     assert f"current dir: {_path}" in result
+
+
+@mark.parametrize(
+    "multirun",
+    [False, True],
+)
+def test_hydra_verbose_1897(tmpdir: Path, multirun: bool) -> None:
+    cmd = [
+        "tests/test_apps/hydra_verbose/my_app.py",
+        f"hydra.run.dir={tmpdir}",
+        "hydra.job.chdir=False",
+    ]
+    if multirun:
+        cmd += ["+a=1,2", "-m"]
+    run_python_script(cmd)


### PR DESCRIPTION
closes #1897 


when `hydra.verbose=True`, the Hydra app will log all the debug info, in particular [this](https://github.com/facebookresearch/hydra/blob/abb36af33e83f391a22d6269fd2f317378171ec9/hydra/_internal/hydra.py#L565-L570) will be called. However, we hard coded all the run mode to be `RUN` for printing out debug info. This means the command line overrides in this case (`a=1,2`) cannot be [parsed correctly](https://github.com/facebookresearch/hydra/blob/85323ea76dc9b5f848e45b26d4d283fa90221901/hydra/_internal/config_loader_impl.py#L234-L236) since the mode is set to RUN instead of MULTIRUN.

