### PR TITLE
Docs: "Configuring Hydra" Intro: document hydra config

### DIFF
--- a/website/docs/configure_hydra/Intro.md
+++ b/website/docs/configure_hydra/Intro.md
@@ -113,10 +113,10 @@ Fields under **hydra.runtime** are populated automatically and should not be ove
 
 ### hydra.overrides
 Fields under **hydra.overrides** are populated automatically and should not be overridden.
-- **task**: Contains a list of the command-line overrides used, except `hydra` overrides.
+- **task**: Contains a list of the command-line overrides used, except `hydra` config overrides.
   Contains the same information as the `.hydra/overrides.yaml` file.
   See [Output/Working directory](/tutorials/basic/running_your_app/3_working_directory.md).
-- **hydra**: Contains a list of the command-line hydra overrides used.
+- **hydra**: Contains a list of the command-line `hydra` config overrides used.
 
 ### Other Hydra settings
 The following fields are present at the top level of the Hydra Config.
@@ -124,8 +124,8 @@ The following fields are present at the top level of the Hydra Config.
   See [overriding `hydra.searchpath`](advanced/search_path.md#overriding-hydrasearchpath-config)
 - **job_logging** and **hydra_logging**: Configure logging settings.
   See [logging](/tutorials/basic/running_your_app/4_logging.md) and [customizing logging](logging.md).
-- **sweeper**: [Sweeper](/advanced/plugins/intro.md#sweeper) plugin settings. Defaults to basic sweeper.
-- **launcher**: [Launcher](/advanced/plugins/intro.md#launcher) plugin settings. Defaults to basic launcher.
+- **sweeper**: [Sweeper](/tutorials/basic/running_your_app/2_multirun.md#sweeper) plugin settings. Defaults to basic sweeper.
+- **launcher**: [Launcher](/tutorials/basic/running_your_app/2_multirun.md#launcher) plugin settings. Defaults to basic launcher.
 - **callbacks**: [Experimental callback support](/experimental/callbacks.md).
 - **help**: Configures your app's `--help` CLI flag. See [customizing application's help](app_help.md).
 - **hydra_help**: Configures the `--hydra-help` CLI flag.

--- a/website/docs/configure_hydra/Intro.md
+++ b/website/docs/configure_hydra/Intro.md
@@ -91,6 +91,17 @@ Fields under **hydra.job**:
 - **env_copy**: Environment variable to copy from the launching machine
 - **config**: fine-grained configuration for job
 
+### hydra.run:
+Used in single-run mode (i.e. when the `--multirun` command-line flag is omitted).
+See [configuration for run](workdir.md#configuration-for-run).
+- **dir**: used to specify the output directory.
+
+### hydra.sweep:
+Used in multi-run mode (i.e. when the `--multirun` command-line flag is given)
+See [configuration for multirun](workdir.md#configuration-for-multirun).
+- **dir**: used to specify the output directory common to all jobs in the multirun sweep
+- **subdir**: used to specify the a pattern for creation of job-specific subdirectory
+
 ### hydra.runtime:
 Fields under **hydra.runtime** are populated automatically and should not be overridden.
 - **version**: Hydra's version
@@ -99,6 +110,7 @@ Fields under **hydra.runtime** are populated automatically and should not be ove
   yaml config files, as configured by [customizing the working directory pattern](workdir.md).
 - **choices**: A dictionary containing the final config group choices.
 - **config_sources**: The final list of config sources used to compose the config.
+
 
 ### Resolvers provided by Hydra
 Hydra provides the following [OmegaConf resolvers](https://omegaconf.readthedocs.io/en/latest/usage.html#resolvers) by default.

--- a/website/docs/configure_hydra/Intro.md
+++ b/website/docs/configure_hydra/Intro.md
@@ -111,6 +111,29 @@ Fields under **hydra.runtime** are populated automatically and should not be ove
 - **choices**: A dictionary containing the final config group choices.
 - **config_sources**: The final list of config sources used to compose the config.
 
+### hydra.overrides
+Fields under **hydra.overrides** are populated automatically and should not be overridden.
+- **task**: Contains a list of the command-line overrides used, except `hydra` overrides.
+  Contains the same information as the `.hydra/overrides.yaml` file.
+  See [Output/Working directory](/tutorials/basic/running_your_app/3_working_directory.md).
+- **hydra**: Contains a list of the command-line hydra overrides used.
+
+### Other Hydra settings
+The following fields are present at the top level of the Hydra Config.
+- **searchpath**: A list of paths that Hydra searches in order to find configs.
+  See [overriding `hydra.searchpath`](advanced/search_path.md#overriding-hydrasearchpath-config)
+- **job_logging** and **hydra_logging**: Configure logging settings.
+  See [logging](/tutorials/basic/running_your_app/4_logging.md) and [customizing logging](logging.md).
+- **sweeper**: [Sweeper](/advanced/plugins/intro.md#sweeper) plugin settings. Defaults to basic sweeper.
+- **launcher**: [Launcher](/advanced/plugins/intro.md#launcher) plugin settings. Defaults to basic launcher.
+- **callbacks**: [Experimental callback support](/experimental/callbacks.md).
+- **help**: Configures your app's `--help` CLI flag. See [customizing application's help](app_help.md).
+- **hydra_help**: Configures the `--hydra-help` CLI flag.
+- **output_subdir**: Configures the `.hydra` subdirectory name.
+  See [changing or disabling the output subdir](/tutorials/basic/running_your_app/3_working_directory.md#changing-or-disabling-hydras-output-subdir).
+- **verbose**: Configures per-file DEBUG-level logging.
+  See [logging](/tutorials/basic/running_your_app/4_logging.md).
+
 
 ### Resolvers provided by Hydra
 Hydra provides the following [OmegaConf resolvers](https://omegaconf.readthedocs.io/en/latest/usage.html#resolvers) by default.

--- a/website/versioned_docs/version-1.1/configure_hydra/Intro.md
+++ b/website/versioned_docs/version-1.1/configure_hydra/Intro.md
@@ -90,6 +90,17 @@ Fields under **hydra.job**:
 - **env_copy**: Environment variable to copy from the launching machine
 - **config**: fine-grained configuration for job
 
+### hydra.run:
+Used in single-run mode (i.e. when the `--multirun` command-line flag is omitted).
+See [configuration for run](workdir.md#configuration-for-run).
+- **dir**: used to specify the output directory.
+
+### hydra.sweep:
+Used in multi-run mode (i.e. when the `--multirun` command-line flag is given)
+See [configuration for multirun](workdir.md#configuration-for-multirun).
+- **dir**: used to specify the output directory common to all jobs in the multirun sweep
+- **subdir**: used to specify the a pattern for creation of job-specific subdirectory
+
 ### hydra.runtime:
 Fields under **hydra.runtime** are populated automatically and should not be overridden.
 - **version**: Hydra's version

--- a/website/versioned_docs/version-1.1/configure_hydra/Intro.md
+++ b/website/versioned_docs/version-1.1/configure_hydra/Intro.md
@@ -110,10 +110,10 @@ Fields under **hydra.runtime** are populated automatically and should not be ove
 
 ### hydra.overrides
 Fields under **hydra.overrides** are populated automatically and should not be overridden.
-- **task**: Contains a list of the command line overrides used, except `hydra` overrides.
+- **task**: Contains a list of the command line overrides used, except `hydra` config overrides.
   Contains the same information as the `.hydra/overrides.yaml` file
   See [Output/Working directory](/tutorials/basic/running_your_app/3_working_directory.md).
-- **hydra**: Contains a list of the command-line hydra overrides used.
+- **hydra**: Contains a list of the command-line `hydra` config overrides used.
 
 ### Other Hydra settings
 The following fields are present at the top level of the Hydra Config.
@@ -121,8 +121,8 @@ The following fields are present at the top level of the Hydra Config.
   See [overriding `hydra.searchpath`](advanced/search_path.md#overriding-hydrasearchpath-config)
 - **job_logging** and **hydra_logging**: Configure logging settings.
   See [logging](/tutorials/basic/running_your_app/4_logging.md) and [customizing logging](logging.md).
-- **sweeper**: [Sweeper](/advanced/plugins/intro.md#sweeper) plugin settings. Defaults to basic sweeper.
-- **launcher**: [Launcher](/advanced/plugins/intro.md#launcher) plugin settings. Defaults to basic launcher.
+- **sweeper**: [Sweeper](/tutorials/basic/running_your_app/2_multirun.md#sweeper) plugin settings. Defaults to basic sweeper.
+- **launcher**: [Launcher](/tutorials/basic/running_your_app/2_multirun.md#launcher) plugin settings. Defaults to basic launcher.
 - **callbacks**: [Experimental callback support](/experimental/callbacks.md).
 - **help**: Configures your app's `--help` CLI flag. See [customizing application's help](app_help.md).
 - **hydra_help**: Configures the `--hydra-help` CLI flag.

--- a/website/versioned_docs/version-1.1/configure_hydra/Intro.md
+++ b/website/versioned_docs/version-1.1/configure_hydra/Intro.md
@@ -108,6 +108,29 @@ Fields under **hydra.runtime** are populated automatically and should not be ove
 - **choices**: A dictionary containing the final config group choices.
 - **config_sources**: The final list of config sources used to compose the config.
 
+### hydra.overrides
+Fields under **hydra.overrides** are populated automatically and should not be overridden.
+- **task**: Contains a list of the command line overrides used, except `hydra` overrides.
+  Contains the same information as the `.hydra/overrides.yaml` file
+  See [Output/Working directory](/tutorials/basic/running_your_app/3_working_directory.md).
+
+### Other Hydra settings
+The following fields are present at the top level of the Hydra Config.
+- **searchpath**: A list of paths that Hydra searches in order to find configs.
+  See [overriding `hydra.searchpath`](advanced/search_path.md#overriding-hydrasearchpath-config)
+- **job_logging** and **hydra_logging**: Configure logging settings.
+  See [logging](/tutorials/basic/running_your_app/4_logging.md) and [customizing logging](logging.md).
+- **sweeper**: [Sweeper](/advanced/plugins/intro.md#sweeper) plugin settings. Defaults to basic sweeper.
+- **launcher**: [Launcher](/advanced/plugins/intro.md#launcher) plugin settings. Defaults to basic launcher.
+- **callbacks**: [Experimental callback support](/experimental/callbacks.md).
+- **help**: Configures your app's `--help` CLI flag. See [customizing application's help](app_help.md).
+- **hydra_help**: Configures the `--hydra-help` CLI flag.
+- **output_subdir**: Configures the `.hydra` subdirectory name.
+  See [changing or disabling the output subdir](/tutorials/basic/running_your_app/3_working_directory.md#changing-or-disabling-the-output-subdir).
+- **verbose**: Configures per-file DEBUG-level logging.
+  See [Logging](/tutorials/basic/running_your_app/4_logging.md).
+
+
 ### Resolvers provided by Hydra
 Hydra provides the following [OmegaConf resolvers](https://omegaconf.readthedocs.io/en/latest/usage.html#resolvers) by default.
 

--- a/website/versioned_docs/version-1.1/configure_hydra/Intro.md
+++ b/website/versioned_docs/version-1.1/configure_hydra/Intro.md
@@ -113,6 +113,7 @@ Fields under **hydra.overrides** are populated automatically and should not be o
 - **task**: Contains a list of the command line overrides used, except `hydra` overrides.
   Contains the same information as the `.hydra/overrides.yaml` file
   See [Output/Working directory](/tutorials/basic/running_your_app/3_working_directory.md).
+- **hydra**: Contains a list of the command-line hydra overrides used.
 
 ### Other Hydra settings
 The following fields are present at the top level of the Hydra Config.


### PR DESCRIPTION
The [Configuring Hydra - Introduction](https://hydra.cc/docs/next/configure_hydra/intro/) docs page is useful
as a quick reference for looking up what hydra settings do (e.g. `hydra.job.chdir`),
containing brief descriptions and links to other parts of the documentation.

This PR makes these docs more complete, adding reference for the following:
- hydra.run.dir
- hydra.sweep.dir
- hydra.sweep.subdir
- hydra.overrides.task
- hydra.overrides.hydra
- hydra.searchpath
- hydra.job_logging
- hydra.hydra_logging
- hydra.sweeper
- hydra.launcher
- hydra.callbacks
- hydra.help
- hydra.hydra_help
- hydra.output_subdir
- hydra.verbose
