### PR TITLE
tools/release/conf: add `_self_` to defaults list and `chdir=true`

### DIFF
--- a/tools/release/conf/config.yaml
+++ b/tools/release/conf/config.yaml
@@ -1,3 +1,8 @@
 defaults:
   - config_schema
   - set: all
+  - _self_
+
+hydra:
+  job:
+    chdir: true


### PR DESCRIPTION
This PR updates the config.yaml file for [`tools/release`](https://github.com/facebookresearch/hydra/tree/1.1_branch/tools/release).
- add `_self_` to defaults list
- explicitly set `hydra.job.chdir=true`
