### PR TITLE
update optuna sweeper news file

### DIFF
--- a/plugins/hydra_optuna_sweeper/NEWS.md
+++ b/plugins/hydra_optuna_sweeper/NEWS.md
@@ -1,3 +1,11 @@
+1.1.2 (2022-01-23)
+=======================
+
+### Bug Fixes
+
+- Fix a bug where Optuna Sweeper parses the override value incorrectly ([#1811](https://github.com/facebookresearch/hydra/issues/1811))
+
+
 1.1.1 (2021-09-01)
 =======================
 

--- a/plugins/hydra_optuna_sweeper/news/1811.bugfix
+++ b/plugins/hydra_optuna_sweeper/news/1811.bugfix
@@ -1,1 +1,0 @@
-Fix a bug where Optuna Sweeper parses the override value incorrectly


### PR DESCRIPTION
This PR is a cherry pick of commit https://github.com/facebookresearch/hydra/pull/1990/commits/77af244dcef98d322ad92ee18309ce2080d22a92 from `1.1_branch` to `main` branch.
This syncs the state of the Optuna sweeper news file following the [v1.1.2 release](#1990) of that plugin.