### PR TITLE
Add GridSampler to Optuna Sweeper 2.0

### DIFF
--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -21,7 +21,6 @@ class Direction(Enum):
 @dataclass
 class SamplerConfig:
     _target_: str = MISSING
-    seed: Optional[int] = None
 
 
 @dataclass
@@ -31,7 +30,6 @@ class TPESamplerConfig(SamplerConfig):
     """
 
     _target_: str = "optuna.samplers.TPESampler"
-
     consider_prior: bool = True
     prior_weight: float = 1.0
     consider_magic_clip: bool = True
@@ -40,6 +38,7 @@ class TPESamplerConfig(SamplerConfig):
     n_ei_candidates: int = 24
     multivariate: bool = False
     warn_independent_sampling: bool = True
+    seed: Optional[int] = None
 
 
 @dataclass
@@ -49,6 +48,7 @@ class RandomSamplerConfig(SamplerConfig):
     """
 
     _target_: str = "optuna.samplers.RandomSampler"
+    seed: Optional[int] = None
 
 
 @dataclass
@@ -68,6 +68,7 @@ class CmaEsSamplerConfig(SamplerConfig):
     inc_popsize: int = 2
     use_separable_cma: bool = False
     source_trials: Optional[Any] = None
+    seed: Optional[int] = None
 
 
 @dataclass
@@ -83,6 +84,7 @@ class NSGAIISamplerConfig(SamplerConfig):
     crossover_prob: float = 0.9
     swapping_prob: float = 0.5
     constraints_func: Optional[Any] = None
+    seed: Optional[int] = None
 
 
 @dataclass
@@ -99,6 +101,18 @@ class MOTPESamplerConfig(SamplerConfig):
     consider_endpoints: bool = False
     n_startup_trials: int = 10
     n_ehvi_candidates: int = 24
+    seed: Optional[int] = None
+
+
+@dataclass
+class GridSamplerConfig(SamplerConfig):
+    """
+    https://optuna.readthedocs.io/en/stable/reference/generated/optuna.samplers.GridSampler.html
+    """
+
+    _target_: str = "optuna.samplers.GridSampler"
+
+    search_space: Optional[Dict[str, Any]] = None
 
 
 @dataclass
@@ -202,3 +216,10 @@ ConfigStore.instance().store(
     node=MOTPESamplerConfig,
     provider="optuna_sweeper",
 )
+
+ConfigStore.instance().store(
+     group="hydra/sweeper/sampler",
+     name="grid",
+     node=GridSamplerConfig,
+     provider="optuna_sweeper",
+ )

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -218,8 +218,8 @@ ConfigStore.instance().store(
 )
 
 ConfigStore.instance().store(
-     group="hydra/sweeper/sampler",
-     name="grid",
-     node=GridSamplerConfig,
-     provider="optuna_sweeper",
- )
+    group="hydra/sweeper/sampler",
+    name="grid",
+    node=GridSamplerConfig,
+    provider="optuna_sweeper",
+)


### PR DESCRIPTION
This is duplicate of #1840. I decided to open a new PR, since the original PR seems stale. The changes are similar to the original PR with an additional fix, so the implementation actually works (I've tested it with my application and everything works as I expect).

The `GridSampler` can now be used with a configuration like this (this follows the example from [optunas documentation](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.samplers.GridSampler.html)):

```yaml
defaults:
  - override /hydra/sweeper: optuna
  - override /hydra/sweeper/sampler: grid


hydra:
  sweeper:
    _target_: hydra_plugins.hydra_optuna_sweeper.optuna_sweeper.OptunaSweeper

    sampler:
      _target_: optuna.samplers.GridSampler
      search_space:
        x: [-50, 0, 50]
        y: [-99, 0, 99]

    # define range of hyperparameters
    search_space:
      x:
        type: float
        low: -100
        high: 100
      y:
        type: int
        low: -100
        high: 100
```

One issue I am uncertain about is @jieru-hu [remark](https://github.com/facebookresearch/hydra/pull/1840#issuecomment-933822775):

> GridSampler fits a bit awkwardly with the Optuna config: 1) it expects a search_space param to be passed in to the init the class. 2) Optuna already has a hydra.sweeper.search_space config available.

I agree with that statement, the `search_space` parameter is awkwardly duplicated. However, this has as far as I understand it nothing to do with hydra or the optuna-hydra-sweeper, since this is just how it is currently designed (compare example in the official [optuna documentation](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.samplers.GridSampler.html)) 


## Motivation

Currently the GridSampler cannot be used with the Optuna Sweeper

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

I'm not sure how to best extend the tests to cover this change, but basically we just need to call the sweeper with the grid sampler instead of the default TPESampler and provide additional values for the `search_space` param.


## Related Issues and PRs

This is a working version of #1840