### PR TITLE
Change `OptunaSweeper.storage` and OptunaSweeperConf.storage to `Any`

### DIFF
--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -111,7 +111,7 @@ class OptunaSweeperImpl(Sweeper):
         self,
         sampler: Any,
         direction: Any,
-        storage: Optional[str],
+        storage: Optional[Any],
         study_name: Optional[str],
         n_trials: int,
         n_jobs: int,

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -147,7 +147,7 @@ class OptunaSweeperConf:
     # For example, you can use SQLite if you set 'sqlite:///example.db'
     # Please refer to the reference for further details
     # https://optuna.readthedocs.io/en/stable/reference/storages.html
-    storage: Optional[str] = None
+    storage: Optional[Any] = None
 
     # Name of study to persist optimization results
     study_name: Optional[str] = None

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/optuna_sweeper.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/optuna_sweeper.py
@@ -15,7 +15,7 @@ class OptunaSweeper(Sweeper):
         self,
         sampler: SamplerConfig,
         direction: Any,
-        storage: Optional[str],
+        storage: Optional[Any],
         study_name: Optional[str],
         n_trials: int,
         n_jobs: int,


### PR DESCRIPTION
## Motivation

I'm using a Postgresql database as backend for Optuna. To configure this, I need a config like this:

```yaml
hydra:
  sweeper:
    _target_: hydra_plugins.hydra_optuna_sweeper.optuna_sweeper.OptunaSweeper

    storage:
      _target_: optuna.storages.RDBStorage
      url: postgresql://optuna_db:123456789@127.0.0.1/optuna
      engine_kwargs:
         pool_recycle: 20
         pool_pre_ping: True
```

However, this fails with 

```
Cannot convert 'DictConfig' to string: '{'_target_': 'optuna.storages.RDBStorage', 'url': 'postgresql://optuna_db:123456789@127.0.0.1/optuna', 'engine_kwargs': {'pool_recycle': 20, 'pool_pre_ping': True}}'
    full_key: hydra.sweeper.storage
    object_type=OptunaSweeperConf
```

Changing `storage: Optional[str]` to `storage: Optional[Any]` resolves this issue. I would rather have implemented `Union[str, Dict[str, Any]]`, but this is not allowed by OmegaConf (apparently `Union` is not supported).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

I suppose the current tests cover this.
