### PR TITLE
update ConfigStore API doc

### DIFF
--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -33,8 +33,9 @@ Use the version switcher in the top bar to switch between documentation versions
 
 
 ## Quick start guide
-This guide will show you some of the most important features of Hydra.
-Read the [tutorial](tutorials/basic/your_first_app/1_simple_cli.md) to gain a deeper understanding.
+This guide will show you some of the most important features you get by writing your application as a Hydra app.
+If you only want to use Hydra for config composition, check out Hydra's [compose API](advanced/compose_api.md) for an alternative.
+Please also read the full [tutorial](tutorials/basic/your_first_app/1_simple_cli.md) to gain a deeper understanding.
 
 ### Installation
 ```commandline

--- a/website/docs/tutorials/basic/your_first_app/2_config_file.md
+++ b/website/docs/tutorials/basic/your_first_app/2_config_file.md
@@ -21,7 +21,7 @@ db:
 Specify the config name by passing a `config_name` parameter to the **@hydra.main()** decorator.
 Note that you should omit the **.yaml** extension.
 Hydra also needs to know where to find your config. Specify the directory containing it relative to the application by passing `config_path`: 
-```python title="my_app.py" {1}
+```python title="my_app.py" {4}
 from omegaconf import DictConfig, OmegaConf
 import hydra
 

--- a/website/docs/tutorials/basic/your_first_app/4_config_groups.md
+++ b/website/docs/tutorials/basic/your_first_app/4_config_groups.md
@@ -54,7 +54,7 @@ timeout: 10
 ### Using config groups
 Since we moved all the configs into the `conf` directory, we need to tell Hydra where to find them using the `config_path` parameter.
 **`config_path` is a directory relative to `my_app.py`**.
-```python title="my_app.py" {1}
+```python title="my_app.py" {4}
 from omegaconf import DictConfig, OmegaConf
 import hydra
 

--- a/website/docs/tutorials/structured_config/10_config_store.md
+++ b/website/docs/tutorials/structured_config/10_config_store.md
@@ -2,10 +2,10 @@
 id: config_store
 title: Config Store API
 ---
-`ConfigStore` is a singleton storing configs in memory.
+
+Throughout the rest of tutorials, we will be using `ConfigStore` to register dataclasses as input configs in Hydra. 
+`ConfigStore` is a singleton storing configs in memory. 
 The primary API for interacting with the `ConfigStore` is the store method described below.
-
-
 
 ### API
 ```python
@@ -32,6 +32,109 @@ class ConfigStore(metaclass=Singleton):
         """
     ...
 ```
+
+### ConfigStore and YAML input configs
+
+`ConfigStore` has feature parity with YAML input configs. On top of that, it also provides typing validation. 
+`ConfigStore` can be used alone or together with YAML. We will see more examples later in this series of tutorials. 
+For now, let's see how the `ConfigStore` API translates into the YAML input configs, which we've become more familiar 
+with after the basic tutorials.
+
+Say we have a simple application and a `db` config group with a `mysql` option:
+
+<div className="row">
+
+<div className="col col--5">
+
+```python title="my_app.py"
+@hydra.main(config_path="conf")
+def my_app(cfg: DictConfig) -> None:
+    print(OmegaConf.to_yaml(cfg))
+
+
+if __name__ == "__main__":
+    my_app()
+```
+</div>
+<div className="col  col--4">
+
+```text title="Directory layout"
+├─ conf
+│  └─ db
+│      └─ mysql.yaml
+└── my_app.py
+
+
+
+```
+</div>
+<div className="col col--3">
+
+```yaml title="db/mysql.yaml"
+driver: mysql
+user: omry
+password: secret
+
+
+
+
+```
+</div>
+</div>
+
+What if we want to add an `postgresql` option now? Yes, we can easily add a `db/postgresql.yaml` config group option. But
+that is not the only way! We can also use `ConfigStore` to make another config group option for `db` available to Hydra.
+
+To achieve this, we add a few lines (highlighted) in the above `my_app.py` file:
+
+
+```python title="my_app.py" {1-9}
+@dataclass
+class PostgresSQLConfig:
+    driver: str = "postgresql"
+    user: str = "jieru"
+    password: str = "secret"
+
+cs = ConfigStore.instance()
+# Registering the Config class with the name `postgresql` with the config group `db`
+cs.store(name="postgresql", group="db", node=PostgresSQLConfig)
+
+@hydra.main(config_path="conf")
+def my_app(cfg: DictConfig) -> None:
+    print(OmegaConf.to_yaml(cfg))
+
+
+if __name__ == "__main__":
+    my_app()
+```
+
+
+Awesome, now our application has access to both `db` config group options, let's run the application to verify:
+
+<div className="row">
+
+<div className="col col--6">
+
+```commandline title="python my_app.py +db=mysql"
+db:
+  driver: mysql
+  user: omry
+  password: secret
+
+```
+</div>
+<div className="col  col--6">
+
+```commandline title="python my_app.py +db=postgresql"
+db:
+  driver: postgresql
+  user: jieru
+  password: secret
+
+```
+</div>
+</div>
+
 
 ### Example node values
 A few examples of supported node values parameters:

--- a/website/docs/tutorials/structured_config/10_config_store.md
+++ b/website/docs/tutorials/structured_config/10_config_store.md
@@ -109,7 +109,7 @@ if __name__ == "__main__":
 ```
 
 
-Awesome, now our application has access to both `db` config group options, let's run the application to verify:
+Now that our application has access to both `db` config group options, let's run the application to verify:
 
 <div className="row">
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -47,12 +47,12 @@ module.exports = {
                 label: 'Structured Configs Tutorial',
                 items: [
                     'tutorials/structured_config/intro',
+                    'tutorials/structured_config/config_store',
                     'tutorials/structured_config/minimal_example',
                     'tutorials/structured_config/hierarchical_static_config',
                     'tutorials/structured_config/config_groups',
                     'tutorials/structured_config/defaults',
                     'tutorials/structured_config/schema',
-                    'tutorials/structured_config/config_store',
                 ],
             },
         ],

--- a/website/versioned_docs/version-1.1/intro.md
+++ b/website/versioned_docs/version-1.1/intro.md
@@ -33,8 +33,9 @@ Use the version switcher in the top bar to switch between documentation versions
 
 
 ## Quick start guide
-This guide will show you some of the most important features of Hydra.
-Read the [tutorial](tutorials/basic/your_first_app/1_simple_cli.md) to gain a deeper understanding.
+This guide will show you some of the most important features you get by writing your application as a Hydra app.
+If you only want to use Hydra for config composition, check out Hydra's [compose API](advanced/compose_api.md) for an alternative.
+Please also read the full [tutorial](tutorials/basic/your_first_app/1_simple_cli.md) to gain a deeper understanding.
 
 ### Installation
 ```commandline

--- a/website/versioned_docs/version-1.1/tutorials/basic/your_first_app/2_config_file.md
+++ b/website/versioned_docs/version-1.1/tutorials/basic/your_first_app/2_config_file.md
@@ -21,7 +21,7 @@ db:
 Specify the config name by passing a `config_name` parameter to the **@hydra.main()** decorator.
 Note that you should omit the **.yaml** extension.
 Hydra also needs to know where to find your config. Specify the directory containing it relative to the application by passing `config_path`: 
-```python title="my_app.py" {1}
+```python title="my_app.py" {4}
 from omegaconf import DictConfig, OmegaConf
 import hydra
 

--- a/website/versioned_docs/version-1.1/tutorials/basic/your_first_app/4_config_groups.md
+++ b/website/versioned_docs/version-1.1/tutorials/basic/your_first_app/4_config_groups.md
@@ -54,7 +54,7 @@ timeout: 10
 ### Using config groups
 Since we moved all the configs into the `conf` directory, we need to tell Hydra where to find them using the `config_path` parameter.
 **`config_path` is a directory relative to `my_app.py`**.
-```python title="my_app.py" {1}
+```python title="my_app.py" {4}
 from omegaconf import DictConfig, OmegaConf
 import hydra
 

--- a/website/versioned_docs/version-1.1/tutorials/structured_config/10_config_store.md
+++ b/website/versioned_docs/version-1.1/tutorials/structured_config/10_config_store.md
@@ -109,7 +109,7 @@ if __name__ == "__main__":
 ```
 </div>
 
-Awesome, now our application has access to both `db` config group options, let's run the application to verify:
+Now that our application has access to both `db` config group options, let's run the application to verify:
 
 <div className="row">
 

--- a/website/versioned_docs/version-1.1/tutorials/structured_config/10_config_store.md
+++ b/website/versioned_docs/version-1.1/tutorials/structured_config/10_config_store.md
@@ -2,10 +2,10 @@
 id: config_store
 title: Config Store API
 ---
-`ConfigStore` is a singleton storing configs in memory.
+
+Throughout the rest of tutorials, we will be using `ConfigStore` to register dataclasses as input configs in Hydra. 
+`ConfigStore` is a singleton storing configs in memory. 
 The primary API for interacting with the `ConfigStore` is the store method described below.
-
-
 
 ### API
 ```python
@@ -33,6 +33,109 @@ class ConfigStore(metaclass=Singleton):
     ...
 ```
 
+### ConfigStore and YAML input configs
+
+`ConfigStore` has feature parity with YAML input configs. On top of that, it also provides typing validation. 
+`ConfigStore` can be used alone or together with YAML. We will see more examples later in this series of tutorials. 
+For now, let's see how the `ConfigStore` API translates into the YAML input configs, which we've become more familiar 
+with after the basic tutorials.
+
+Say we have a simple application and a `db` config group with a `mysql` option:
+
+<div className="row">
+
+<div className="col col--5">
+
+```python title="my_app.py"
+@hydra.main(config_path="conf")
+def my_app(cfg: DictConfig) -> None:
+    print(OmegaConf.to_yaml(cfg))
+
+
+if __name__ == "__main__":
+    my_app()
+```
+</div>
+<div className="col  col--4">
+
+```text title="Directory layout"
+├─ conf
+│  └─ db
+│      └─ mysql.yaml
+└── my_app.py
+
+
+
+```
+</div>
+<div className="col col--3">
+
+```yaml title="db/mysql.yaml"
+driver: mysql
+user: omry
+password: secret
+
+
+
+
+```
+</div>
+</div>
+
+What if we want to add an `postgresql` option now? Yes, we can easily add a `db/postgresql.yaml` config group option. But
+that is not the only way! We can also use `ConfigStore` to make another config group option for `db` available to Hydra.
+
+To achieve this, we add a few lines (highlighted) in the above `my_app.py` file:
+<div className="col col--12">
+
+```python title="my_app.py" {1-9}
+@dataclass
+class PostgresSQLConfig:
+    driver: str = "postgresql"
+    user: str = "jieru"
+    password: str = "secret"
+
+cs = ConfigStore.instance()
+# Registering the Config class with the name `postgresql` with the config group `db`
+cs.store(name="postgresql", group="db", node=PostgresSQLConfig)
+
+@hydra.main(config_path="conf")
+def my_app(cfg: DictConfig) -> None:
+    print(OmegaConf.to_yaml(cfg))
+
+
+if __name__ == "__main__":
+    my_app()
+```
+</div>
+
+Awesome, now our application has access to both `db` config group options, let's run the application to verify:
+
+<div className="row">
+
+<div className="col col--6">
+
+```commandline title="python my_app.py +db=mysql"
+db:
+  driver: mysql
+  user: omry
+  password: secret
+
+```
+</div>
+<div className="col  col--6">
+
+```commandline title="python my_app.py +db=postgresql"
+db:
+  driver: postgresql
+  user: jieru
+  password: secret
+
+```
+</div>
+</div>
+
+
 ### Example node values
 A few examples of supported node values parameters:
 ```python
@@ -54,3 +157,5 @@ cs.store(name="config2", node=MySQLConfig(host="test.db", port=3307))
 # Using a dictionary, forfeiting runtime type safety
 cs.store(name="config3", node={"host": "localhost", "port": 3308})
 ```
+
+

--- a/website/versioned_sidebars/version-1.1-sidebars.json
+++ b/website/versioned_sidebars/version-1.1-sidebars.json
@@ -96,6 +96,10 @@
             },
             {
               "type": "doc",
+              "id": "version-1.1/tutorials/structured_config/config_store"
+            },
+            {
+              "type": "doc",
               "id": "version-1.1/tutorials/structured_config/minimal_example"
             },
             {
@@ -113,10 +117,6 @@
             {
               "type": "doc",
               "id": "version-1.1/tutorials/structured_config/schema"
-            },
-            {
-              "type": "doc",
-              "id": "version-1.1/tutorials/structured_config/config_store"
             }
           ]
         }


### PR DESCRIPTION
changes includes:
1. move up configstore API doc in the tutorial, give an intro before we start to interact with it. 
2. Add an example on ConfigStore and YAML input work side by side.
3. some minor fix in other parts of the tutorial



[1] 
![image](https://user-images.githubusercontent.com/4642412/152080064-0dc04ed2-1eb9-4bf1-9137-23752293fe1e.png)
