### PR TITLE
bump black version to >=22.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         files: 'tools/.*'
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.1.0
     hooks:
       - id: black
         language_version: python3.6

--- a/plugins/hydra_ax_sweeper/example/banana.py
+++ b/plugins/hydra_ax_sweeper/example/banana.py
@@ -14,7 +14,7 @@ def banana(cfg: DictConfig) -> Any:
     y = cfg.banana.y
     a = 1
     b = 100
-    z = (a - x) ** 2 + b * ((y - x ** 2) ** 2)
+    z = (a - x) ** 2 + b * ((y - x**2) ** 2)
     log.info(f"Banana_Function(x={x}, y={y})={z}")
     return z
 

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial.py
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial.py
@@ -13,7 +13,7 @@ def polynomial(cfg: DictConfig) -> Any:
     a = 100
     b = 10
     c = 1
-    result = a * (x ** 2) + b * y + c * z
+    result = a * (x**2) + b * y + c * z
     return result
 
 

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_dict_coefficients.py
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_dict_coefficients.py
@@ -11,7 +11,7 @@ def polynomial_with_dict_coefficients(cfg: DictConfig) -> Any:
     a = 100
     b = 10
     c = 1
-    return a * (coeff.x ** 2) + b * coeff.y + c * coeff.z
+    return a * (coeff.x**2) + b * coeff.y + c * coeff.z
 
 
 if __name__ == "__main__":

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_list_coefficients.py
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_list_coefficients.py
@@ -11,7 +11,7 @@ def polynomial_with_list_coefficients(cfg: DictConfig) -> Any:
     a = 100
     b = 10
     c = 1
-    return a * (x ** 2) + b * y + c * z
+    return a * (x**2) + b * y + c * z
 
 
 if __name__ == "__main__":

--- a/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
+++ b/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
@@ -30,7 +30,7 @@ def test_discovery() -> None:
 
 
 def quadratic(cfg: DictConfig) -> Any:
-    return 100 * (cfg.quadratic.x ** 2) + 1 * cfg.quadratic.y
+    return 100 * (cfg.quadratic.x**2) + 1 * cfg.quadratic.y
 
 
 @mark.parametrize(

--- a/plugins/hydra_optuna_sweeper/example/multi-objective.py
+++ b/plugins/hydra_optuna_sweeper/example/multi-objective.py
@@ -10,7 +10,7 @@ def binh_and_korn(cfg: DictConfig) -> Tuple[float, float]:
     x: float = cfg.x
     y: float = cfg.y
 
-    v0 = 4 * x ** 2 + 4 * y ** 2
+    v0 = 4 * x**2 + 4 * y**2
     v1 = (x - 5) ** 2 + (y - 5) ** 2
     return v0, v1
 

--- a/plugins/hydra_optuna_sweeper/example/sphere.py
+++ b/plugins/hydra_optuna_sweeper/example/sphere.py
@@ -7,7 +7,7 @@ from omegaconf import DictConfig
 def sphere(cfg: DictConfig) -> float:
     x: float = cfg.x
     y: float = cfg.y
-    return x ** 2 + y ** 2
+    return x**2 + y**2
 
 
 if __name__ == "__main__":

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 bandit
-black==20.8b1
+black>=22.1.0
 build
 coverage
 flake8

--- a/tests/test_examples/test_tutorials_basic.py
+++ b/tests/test_examples/test_tutorials_basic.py
@@ -112,7 +112,7 @@ def test_tutorial_config_file(tmpdir: Path, args: List[str], output_conf: Any) -
 def test_tutorial_config_file_bad_key(
     tmpdir: Path, args: List[str], expected: Any
 ) -> None:
-    """ Similar to the previous test, but also tests exception values"""
+    """Similar to the previous test, but also tests exception values"""
 
     cmd = [
         "examples/tutorials/basic/your_first_hydra_app/2_config_file/my_app.py",


### PR DESCRIPTION
Version 22.1.0 of the black formatter has [recently been released](https://github.com/psf/black/releases/tag/22.1.0).
According to the release notes, this is the first non-beta release of black, and it
is the first black release subject to the new [stability policy](https://black.readthedocs.io/en/latest/the_black_code_style/index.html#stability-policy).

This PR updates our pin on black to `>=22.1.0`.
