### PR TITLE
yamllint: use --strict flag

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -235,7 +235,7 @@ def lint(session):
 
     session.run("mypy", ".", "--strict", silent=SILENT)
     session.run("flake8", "--config", ".flake8")
-    session.run("yamllint", ".")
+    session.run("yamllint", "--strict", ".")
 
     example_dirs = [
         "examples/advanced/",

--- a/tests/test_apps/hydra_verbose/config.yaml
+++ b/tests/test_apps/hydra_verbose/config.yaml
@@ -1,3 +1,3 @@
 hydra:
   verbose:
-    True
+    true


### PR DESCRIPTION
This PR adds the `--strict` flag for our use of the `yamllint` tool.
This means that warnings emitted by yamllint will be treated as errors. This is consistent with our other tools in the CI pipeline, e.g. pytest is run with the `-Werror` flag, converting warnings to errors.