### PR TITLE
yamllint: use --strict flag in pre-commit config too

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,4 +25,4 @@ repos:
     rev: v1.25.0
     hooks:
       - id: yamllint
-        args: [-c=.yamllint]
+        args: [-c=.yamllint, --strict]


### PR DESCRIPTION
This PR is a followup to #2006, which updated our noxfile to pass the `--strict` flag to the `yamllint` tool. This PR updates the pre-commit config to also pass `--strict` to `yamllint`. Thanks @jieru-hu for reminding me about the pre-commit conifig!