### PR TITLE
Exception formatting: handle case where `module is None`

### DIFF
--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -4,10 +4,10 @@ import inspect
 import logging.config
 import os
 import sys
+import traceback
 import warnings
 from dataclasses import dataclass
 from os.path import dirname, join, normpath, realpath
-from traceback import print_exc, print_exception
 from types import FrameType, TracebackType
 from typing import Any, List, Optional, Sequence, Tuple
 
@@ -246,7 +246,7 @@ def run_and_report(func: Any) -> Any:
                     if search_max == 0 or tb is None:
                         # could not detect run_job, probably a runtime exception before we got there.
                         # do not sanitize the stack trace.
-                        print_exc()
+                        traceback.print_exc()
                         sys.exit(1)
 
                     # strip OmegaConf frames from bottom of stack
@@ -255,8 +255,7 @@ def run_and_report(func: Any) -> Any:
                     while end is not None:
                         frame = end.tb_frame
                         mdl = inspect.getmodule(frame)
-                        assert mdl is not None
-                        name = mdl.__name__
+                        name = mdl.__name__ if mdl is not None else ""
                         if name.startswith("omegaconf."):
                             break
                         end = end.tb_next
@@ -286,7 +285,7 @@ def run_and_report(func: Any) -> Any:
                         assert iter_tb.tb_next is not None
                         iter_tb = iter_tb.tb_next
 
-                    print_exception(None, value=ex, tb=final_tb)  # type: ignore
+                    traceback.print_exception(None, value=ex, tb=final_tb)  # type: ignore
                 sys.stderr.write(
                     "\nSet the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.\n"
                 )

--- a/news/2342.bugfix
+++ b/news/2342.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where Hydra's exception-handling logic could raise an `AssertionError`


### PR DESCRIPTION
Fix an issue where Hydra's exception-handling logic could raise an `AssertionError` if the module from which in the exception's originates cannot be determined.

Closes #2010. Closes #2342.
See #2342 for a way to reproduce the bug.

Details:

Hydra's exception-handling logic automatically removes omegaconf-related stack frames before printing the handled traceback. This requires inspecting the stack frames (when an exception arises) to determine which stack frames belong to OmegaConf. Hydra uses the function `inspect.getmodule` to determine the module to which a given stack frame belongs.

In the case where the module from which a stack frame originated cannot be determined, `inspect.getmodule` returns `None`. Previously, this would cause Hydra to throw an `AssertionError`. This PR adds logic to handle the case where the module cannot be determined, avoiding the `AssertionError`.