### PR TITLE
allow list as toplevel instantiate input

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -4,7 +4,7 @@ import copy
 import functools
 import sys
 from enum import Enum
-from typing import Any, Callable, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Sequence, Tuple, Union
 
 from omegaconf import OmegaConf, SCMode
 from omegaconf._utils import is_structured_config
@@ -82,7 +82,7 @@ def _convert_target_to_string(t: Any) -> Any:
         return t
 
 
-def _prepare_input_dict(d: Any) -> Any:
+def _prepare_input_dict_or_list(d: Union[Dict[Any, Any], List[Any]]) -> Any:
     res: Any
     if isinstance(d, dict):
         res = {}
@@ -90,13 +90,13 @@ def _prepare_input_dict(d: Any) -> Any:
             if k == "_target_":
                 v = _convert_target_to_string(d["_target_"])
             elif isinstance(v, (dict, list)):
-                v = _prepare_input_dict(v)
+                v = _prepare_input_dict_or_list(v)
             res[k] = v
     elif isinstance(d, list):
         res = []
         for v in d:
             if isinstance(v, (list, dict)):
-                v = _prepare_input_dict(v)
+                v = _prepare_input_dict_or_list(v)
             res.append(v)
     else:
         assert False
@@ -159,13 +159,13 @@ def instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
             f"\nA common problem is forgetting to annotate _target_ as a string : '_target_: str = ...'"
         )
 
-    if isinstance(config, dict):
-        config = _prepare_input_dict(config)
+    if isinstance(config, (dict, list)):
+        config = _prepare_input_dict_or_list(config)
 
-    kwargs = _prepare_input_dict(kwargs)
+    kwargs = _prepare_input_dict_or_list(kwargs)
 
     # Structured Config always converted first to OmegaConf
-    if is_structured_config(config) or isinstance(config, dict):
+    if is_structured_config(config) or isinstance(config, (dict, list)):
         config = OmegaConf.structured(config, flags={"allow_objects": True})
 
     if OmegaConf.is_dict(config):
@@ -189,9 +189,32 @@ def instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
         return instantiate_node(
             config, *args, recursive=_recursive_, convert=_convert_, partial=_partial_
         )
+    elif OmegaConf.is_list(config):
+        # Finalize config (convert targets to strings, merge with kwargs)
+        config_copy = copy.deepcopy(config)
+        config_copy._set_flag(
+            flags=["allow_objects", "struct", "readonly"], values=[True, False, False]
+        )
+        config_copy._set_parent(config._get_parent())
+        config = config_copy
+
+        OmegaConf.resolve(config)
+
+        _recursive_ = kwargs.pop(_Keys.RECURSIVE, True)
+        _convert_ = kwargs.pop(_Keys.CONVERT, ConvertMode.NONE)
+        _partial_ = kwargs.pop(_Keys.PARTIAL, False)
+
+        if _partial_:
+            raise InstantiationException(
+                "The _partial_ keyword is not compatible with top-level list instantiation"
+            )
+
+        return instantiate_node(
+            config, *args, recursive=_recursive_, convert=_convert_, partial=_partial_
+        )
     else:
         raise InstantiationException(
-            "Top level config has to be OmegaConf DictConfig, plain dict, or a Structured Config class or instance"
+            "Top level config has to be OmegaConf DictConfig/ListConfig, plain dict/list, or a Structured Config class or instance"
         )
 
 

--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -214,7 +214,8 @@ def instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
         )
     else:
         raise InstantiationException(
-            "Top level config has to be OmegaConf DictConfig/ListConfig, plain dict/list, or a Structured Config class or instance"
+            "Top level config has to be OmegaConf DictConfig/ListConfig, "
+            + "plain dict/list, or a Structured Config class or instance."
         )
 
 

--- a/news/1950.feature
+++ b/news/1950.feature
@@ -1,0 +1,1 @@
+The `instantiate` API now accepts `ListConfig`/`list`-type config as top-level input.

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -1,5 +1,4 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-
 import copy
 import pickle
 import re

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
 import copy
 import pickle
 import re
@@ -111,6 +112,26 @@ def config(request: Any, src: Any) -> Any:
             {},
             partial(AClass, a=10, b=20, c=30),
             id="class+partial",
+        ),
+        param(
+            [
+                {
+                    "_target_": "tests.instantiate.AClass",
+                    "_partial_": True,
+                    "a": 10,
+                    "b": 20,
+                    "c": 30,
+                },
+                {
+                    "_target_": "tests.instantiate.BClass",
+                    "a": 50,
+                    "b": 60,
+                    "c": 70,
+                },
+            ],
+            {},
+            [partial(AClass, a=10, b=20, c=30), BClass(a=50, b=60, c=70)],
+            id="list_of_partial_class",
         ),
         param(
             {"_target_": "tests.instantiate.AClass", "b": 20, "c": 30},
@@ -316,6 +337,28 @@ def config(request: Any, src: Any) -> Any:
             KeywordsInParamsClass(target="foo", partial="bar"),
             id="keywords_in_params",
         ),
+        param([], {}, [], id="list_as_toplevel0"),
+        param(
+            [
+                {
+                    "_target_": "tests.instantiate.AClass",
+                    "a": 10,
+                    "b": 20,
+                    "c": 30,
+                    "d": 40,
+                },
+                {
+                    "_target_": "tests.instantiate.BClass",
+                    "a": 50,
+                    "b": 60,
+                    "c": 70,
+                    "d": 80,
+                },
+            ],
+            {},
+            [AClass(10, 20, 30, 40), BClass(50, 60, 70, 80)],
+            id="list_as_toplevel2",
+        ),
     ],
 )
 def test_class_instantiate(
@@ -327,10 +370,7 @@ def test_class_instantiate(
 ) -> Any:
     passthrough["_recursive_"] = recursive
     obj = instantiate_func(config, **passthrough)
-    if isinstance(expected, partial):
-        assert partial_equal(obj, expected)
-    else:
-        assert obj == expected
+    assert partial_equal(obj, expected)
 
 
 def test_none_cases(
@@ -582,6 +622,17 @@ def test_instantiate_target_raising_exception_taking_no_arguments(
         + r"ExceptionTakingNoArgument\('Err message',?\)",
     ):
         instantiate_func({}, _target_=_target_)
+
+
+def test_toplevel_list_partial_not_allowed(instantiate_func: Any) -> None:
+    config = [{"_target_": "tests.instantiate.ClassA", "a": 10, "b": 20, "c": 30}]
+    with raises(
+        InstantiationException,
+        match=re.escape(
+            "The _partial_ keyword is not compatible with top-level list instantiation"
+        ),
+    ):
+        instantiate_func(config, _partial_=True)
 
 
 @mark.parametrize("is_partial", [True, False])


### PR DESCRIPTION
This PR enables the [`instantiate`](https://hydra.cc/docs/next/advanced/instantiate_objects/overview/) function to take a list or ListConfig as top-level input. Closes #1950.

Consider the following example:
```python
# demo.py
from hydra.utils import instantiate

lst = [
    {"_target_": "pathlib.Path", "_args_": ["foo"]},
    {"_target_": "pathlib.Path", "_args_": ["bar"]},
]

paths = instantiate(lst)
print(paths)
```
### Before this diff:
```python
$ python demo.py
Traceback (most recent call last):
  File "/home/jasha10/hydra.git/demo.py", line 9, in <module>
    paths = instantiate(lst)
  File "/home/jasha10/hydra.git/hydra/_internal/instantiate/_instantiate2.py", line 193, in instantiate
    raise InstantiationException(
hydra.errors.InstantiationException: Top level config has to be OmegaConf DictConfig, plain dict, or a Structured Config class or instance
```
### After this diff:
```python
$ python demo.py
[PosixPath('foo'), PosixPath('bar')]
```
