### PR TITLE
fix ci pytest2

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -475,7 +475,9 @@ def test_jupyter_notebooks(session):
             f"Not testing Jupyter notebook on Python {session.python}, supports [{','.join(versions)}]"
         )
 
-    session.install("jupyter", "nbval", "pyzmq")
+    session.install(
+        "jupyter", "nbval", "pyzmq", "pytest<7.0.0"
+    )  # pytest pinned due to https://github.com/computationalmodelling/nbval/issues/180
     if platform.system() == "Windows":
         # Newer versions of pywin32 are causing CI issues on Windows.
         # see https://github.com/mhammond/pywin32/issues/1709

--- a/tests/instantiate/test_positional_only_arguments.py
+++ b/tests/instantiate/test_positional_only_arguments.py
@@ -8,7 +8,7 @@ from hydra.utils import instantiate
 
 if sys.version_info < (3, 8):
     skip(
-        msg="Positional-only syntax is only supported in Python 3.8 or newer",
+        reason="Positional-only syntax is only supported in Python 3.8 or newer",
         allow_module_level=True,
     )
 


### PR DESCRIPTION
This PR is an attempt to fix Hyda's CI failure on the `main` branch.
Unlike #2015, this PR only pins pytest for the jupyter notebook tests.
Closes #2015.