### PR TITLE
importlib plugin discovery

### DIFF
--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -181,10 +181,8 @@ class Plugins(metaclass=Singleton):
                     if module_name.startswith("_") and not module_name.startswith("__"):
                         continue
                     import_time = timer()
-                    m = importer.find_module(modname)  # type: ignore
-                    assert m is not None
                     with warnings.catch_warnings(record=True) as recorded_warnings:
-                        loaded_mod = m.load_module(modname)
+                        loaded_mod = importlib.import_module(modname)
                     import_time = timer() - import_time
                     if len(recorded_warnings) > 0:
                         sys.stderr.write(

--- a/tests/standalone_apps/discovery_test_plugin/hydra_plugins/discovery_test/import_test_plugin.py
+++ b/tests/standalone_apps/discovery_test_plugin/hydra_plugins/discovery_test/import_test_plugin.py
@@ -1,0 +1,6 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from hydra.plugins.plugin import Plugin
+
+
+class ImportTestPlugin(Plugin):
+    ...

--- a/tests/standalone_apps/discovery_test_plugin/tests/test_discovery.py
+++ b/tests/standalone_apps/discovery_test_plugin/tests/test_discovery.py
@@ -2,6 +2,8 @@
 import os
 from pathlib import Path
 
+from hydra_plugins.discovery_test.import_test_plugin import ImportTestPlugin
+
 from hydra.core.plugins import Plugins
 from hydra.plugins.plugin import Plugin
 
@@ -25,3 +27,10 @@ def test_skipped_imports(tmpdir: Path) -> None:
     assert "HiddenTestPlugin" not in discovered_plugins
 
     assert "NotHiddenTestPlugin" in discovered_plugins
+
+
+def test_imported_plugin_is_discovered_plugin() -> None:
+    # Tests that discovered object is the same object as imported object
+    discovered_plugins = {x.__name__: x for x in Plugins.instance().discover(Plugin)}
+    assert "ImportTestPlugin" in discovered_plugins
+    assert ImportTestPlugin is discovered_plugins["ImportTestPlugin"]


### PR DESCRIPTION
This PR hopefully closes #1830 by using importlib to load plugin modules instead of using pkgutil.

The diff ensures that, if user code loades a plugin or other object (such as a dataclass) from a plugin package, the object loaded in the user code will have the same identity as the object loaded by Hydra's plugin discovery mechanism.
