### PR TITLE
Implement `Plugins.register`

### DIFF
--- a/examples/plugins/example_registered_plugin/README.md
+++ b/examples/plugins/example_registered_plugin/README.md
@@ -1,0 +1,2 @@
+# Hydra example plugin via `Plugins.register`
+This plugin is not very useful, but it demonstrates how to register a plugin using the `Plugins.register` method.

--- a/examples/plugins/example_registered_plugin/example_registered_plugin/__init__.py
+++ b/examples/plugins/example_registered_plugin/example_registered_plugin/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from hydra.core.plugins import Plugins
+from hydra.plugins.plugin import Plugin
+
+
+class ExampleRegisteredPlugin(Plugin):
+    def __init__(self, v: int) -> None:
+        self.v = v
+
+    def add(self, x: int) -> int:
+        return self.v + x
+
+
+def register_example_plugin() -> None:
+    """The Hydra user should call this function before invoking @hydra.main"""
+    Plugins.instance().register(ExampleRegisteredPlugin)

--- a/examples/plugins/example_registered_plugin/setup.py
+++ b/examples/plugins/example_registered_plugin/setup.py
@@ -1,0 +1,34 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+# type: ignore
+from setuptools import setup
+
+with open("README.md", "r") as fh:
+    LONG_DESC = fh.read()
+setup(
+    name="hydra-example-registered-plugin",
+    version="1.0.0",
+    author="Jasha Sommer-Simpson",
+    author_email="jasha10@fb.com",
+    description="Example of Hydra Plugin Registration",
+    long_description=LONG_DESC,
+    long_description_content_type="text/markdown",
+    url="https://github.com/facebookresearch/hydra/",
+    packages=["example_registered_plugin"],
+    classifiers=[
+        # Feel free to use another license.
+        "License :: OSI Approved :: MIT License",
+        # Hydra uses Python version and Operating system to determine
+        # In which environments to test this plugin
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Operating System :: OS Independent",
+    ],
+    install_requires=[
+        # consider pinning to a specific major version of Hydra to avoid unexpected problems
+        # if a new major version of Hydra introduces breaking changes for plugins.
+        # e.g: "hydra-core==1.1.*",
+        "hydra-core",
+    ],
+)

--- a/examples/plugins/example_registered_plugin/tests/__init__.py
+++ b/examples/plugins/example_registered_plugin/tests/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/examples/plugins/example_registered_plugin/tests/test_example_registered_plugin.py
+++ b/examples/plugins/example_registered_plugin/tests/test_example_registered_plugin.py
@@ -1,0 +1,22 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from hydra.core.plugins import Plugins
+from hydra.plugins.plugin import Plugin
+
+from example_registered_plugin import ExampleRegisteredPlugin, register_example_plugin
+
+
+def test_discovery() -> None:
+    # Tests that this plugin can be discovered after Plugins.register is called
+
+    plugin_name = ExampleRegisteredPlugin.__name__
+
+    assert plugin_name not in [x.__name__ for x in Plugins.instance().discover(Plugin)]
+
+    register_example_plugin()
+
+    assert plugin_name in [x.__name__ for x in Plugins.instance().discover(Plugin)]
+
+
+def test_example_plugin() -> None:
+    a = ExampleRegisteredPlugin(10)
+    assert a.add(20) == 30

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,6 +41,7 @@ class Plugin:
     name: str
     path: str
     module: str
+    source_dir: str
 
 
 def get_current_os() -> str:
@@ -167,11 +168,19 @@ def select_plugins(session, directory: str) -> List[Plugin]:
             )
             continue
 
+        if "hydra_plugins" in os.listdir(os.path.join(BASE, directory, plugin["path"])):
+            module = "hydra_plugins." + plugin["dir_name"]
+            source_dir = "hydra_plugins"
+        else:
+            module = plugin["dir_name"]
+            source_dir = plugin["dir_name"]
+
         ret.append(
             Plugin(
                 name=plugin_name,
                 path=plugin["path"],
-                module="hydra_plugins." + plugin["dir_name"],
+                source_dir=source_dir,
+                module=module,
             )
         )
 
@@ -313,6 +322,7 @@ def lint_plugins_in_dir(session, directory: str) -> None:
     # Mypy for plugins
     for plugin in plugins:
         path = os.path.join(directory, plugin.path)
+        source_dir = plugin.source_dir
         session.chdir(path)
         session.run(*_black_cmd(), silent=SILENT)
         session.run(*_isort_cmd(), silent=SILENT)
@@ -329,7 +339,7 @@ def lint_plugins_in_dir(session, directory: str) -> None:
             "--strict",
             "--install-types",
             "--non-interactive",
-            f"{path}/hydra_plugins",
+            f"{path}/{source_dir}",
             "--config-file",
             f"{BASE}/.mypy.ini",
             silent=SILENT,

--- a/tests/test_plugin_interface.py
+++ b/tests/test_plugin_interface.py
@@ -1,8 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from typing import List, Type
 
-from pytest import mark
+from pytest import mark, raises
 
+from hydra.core.config_search_path import ConfigSearchPath
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
 from hydra.plugins.plugin import Plugin
@@ -31,3 +32,23 @@ def test_discover(plugin_type: Type[Plugin], expected: List[str]) -> None:
     expected_classes = [get_class(c) for c in expected]
     for ex in expected_classes:
         assert ex in plugins
+
+
+def test_register_plugin() -> None:
+    class MyPlugin(SearchPathPlugin):
+        def manipulate_search_path(self, search_path: ConfigSearchPath) -> None:
+            ...
+
+    Plugins.instance().register(MyPlugin)
+
+    assert MyPlugin in Plugins.instance().discover(Plugin)
+    assert MyPlugin in Plugins.instance().discover(SearchPathPlugin)
+    assert MyPlugin not in Plugins.instance().discover(Launcher)
+
+
+def test_register_bad_plugin() -> None:
+    class NotAPlugin:
+        ...
+
+    with raises(ValueError, match="Not a valid Hydra Plugin"):
+        Plugins.instance().register(NotAPlugin)  # type: ignore

--- a/website/docs/advanced/plugins/develop.md
+++ b/website/docs/advanced/plugins/develop.md
@@ -11,16 +11,36 @@ If you develop plugins, please join the <a href="https://hydra-framework.zulipch
 
 import GithubLink from "@site/src/components/GithubLink"
 
-When developing Hydra plugins, keep the following things in mind:
+Hydra plugins must be registered before they can be used. There are two ways to register a plugin:
+- via the automatic plugin discovery process, which discovers plugins located in the `hydra_plugins` namespace package
+- by calling the `register` method on Hydra's `Plugins` singleton class
+
+## Automatic Plugin discovery process
+
+If you create a Plugin and want it to be discovered automatically by Hydra, keep the following things in mind:
 - Hydra plugins can be either a standalone Python package, or a part of your existing Python package. 
   In both cases - They should be in the namespace module `hydra_plugins` (This is a top level module, Your plugin will __NOT__ be discovered if you place it in `mylib.hydra_plugins`).
 - Do __NOT__ place an `__init__.py` file in `hydra_plugins` (doing so may break other installed Hydra plugins).
   
-## Plugin discovery process
 The plugin discovery process runs whenever Hydra starts. During plugin discovery, Hydra scans for plugins in all the submodules of `hydra_plugins`. Hydra will import each module and look for plugins defined in that module.
 Any module under `hydra_plugins` that is slow to import will slow down the startup of __ALL__ Hydra applications.
 Plugins with expensive imports can exclude individual files from Hydra's plugin discovery process by prefixing them with `_` (but not `__`).
 For example, the file `_my_plugin_lib.py` would not be imported and scanned, while `my_plugin_lib.py` would be.
+
+## Plugin registration via the `Plugins.register` method
+
+Plugins can be manually registered by calling the `register` method on the instance of Hydra's `Plugins` singleton class.
+```python
+from hydra.core.plugins import Plugins
+from hydra.plugins.plugin import Plugin
+
+class MyPlugin(Plugin):
+  ...
+
+def register_my_plugin() -> None:
+    """Hydra users should call this function before invoking @hydra.main"""
+    Plugins.instance().register(MyPlugin)
+```
 
 ## Getting started
 


### PR DESCRIPTION
This PR is a proof-of-concept implementation of "Idea 1" from [this design doc](https://docs.google.com/document/d/1VxVKK3ERaSyhC90KGUOH4Qrgvibzz5su7nb_oIq0yoY/edit?usp=sharing).

The PR adds a `register` method to the `hydra.core.plugins.Plugins` singleton class.
The idea is to allow calling `Plugins.instance().register(MyPlugin)` as a method for registering plugins.

The motivation for adding a `Plugins.register` method is to ease the user experience surrounding Hydra plugins.
Currently, using a plugin requires installing a module into the `hydra_plugins` namespace package.
Hydra's plugin discovery mechanism leaves users with no way to turn the plugin off except for uninstalling the module.

This PR is based on discussion [here](https://github.com/facebookresearch/hydra/issues/2001), specifically [this comment](https://github.com/facebookresearch/hydra/issues/2001#issuecomment-1033140954).

cc @nmichlo



Commits:
- https://github.com/facebookresearch/hydra/pull/2026/commits/66b54a196e099439b8828163469121f8b67b3f75: implementation of `Plugins.register` and tests
- https://github.com/facebookresearch/hydra/pull/2026/commits/8c79510e18128ff8e18446a27b6fada25974ddf5: create `examples/plugins/example_registered_plugin`
- https://github.com/facebookresearch/hydra/pull/2026/commits/77d955fe16f3953aa9e81de5ddb7aa5a4356b146: Documentation