### PR TITLE
Adding eli5 video to the home page

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -46,6 +46,27 @@ const features = [
   },
 ];
 
+function VideoContainer() {
+  return (
+    <div className="container text--center margin-bottom--xl margin-top--lg">
+      <div className="row">
+        <div className="col">
+          <h2>Check it out in the intro video</h2>
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube.com/embed/Slc3gRQpnBI"
+              title="Explain Like I'm 5: Hydra"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function Home() {
   const context = useDocusaurusContext();
   const {siteConfig = {}} = context;
@@ -90,6 +111,7 @@ function Home() {
         </div>
       </header>
       <main>
+        <VideoContainer />
         {features && features.length && (
           <section className={styles.features}>
             <div className="container">


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Litho home page](https://fblitho.com/) or in Docusaurus home page](https://docusaurus.io/)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan
![image](https://user-images.githubusercontent.com/12485205/154303179-1aa9bdb2-f2eb-4345-8073-67da09504fd2.png)

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
