### PR TITLE
Enable passing non-function to hydra.main

### DIFF
--- a/news/2042.bugfix
+++ b/news/2042.bugfix
@@ -1,0 +1,1 @@
+It is now possible to pass other callable objects (besides functions) to `hydra.main`.

--- a/tests/data.py
+++ b/tests/data.py
@@ -1,0 +1,20 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+def foo() -> None:
+    ...
+
+
+def foo_main_module() -> None:
+    ...
+
+
+foo_main_module.__module__ = "__main__"
+
+
+class Bar:
+    ...
+
+
+bar_instance = Bar()
+
+bar_instance_main_module = Bar()
+bar_instance_main_module.__module__ = "__main__"

--- a/tests/test_apps/passes_callable_class_to_hydra_main/__init__.py
+++ b/tests/test_apps/passes_callable_class_to_hydra_main/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/tests/test_apps/passes_callable_class_to_hydra_main/my_app.py
+++ b/tests/test_apps/passes_callable_class_to_hydra_main/my_app.py
@@ -1,0 +1,21 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from omegaconf import DictConfig
+
+import hydra
+from hydra.core.hydra_config import HydraConfig
+
+
+class MyCallable:
+    def __init__(self, state: int = 123) -> None:
+        self._state = state
+
+    def __call__(self, cfg: DictConfig) -> None:
+        print(self._state)
+        print(HydraConfig.get().job.name)
+
+
+my_callable = MyCallable()
+my_app = hydra.main(config_path=None)(my_callable)
+
+if __name__ == "__main__":
+    my_app()

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -525,6 +525,34 @@ def test_cfg_resolve_interpolation(
 
 
 @mark.parametrize(
+    "script,expected",
+    [
+        param(
+            "tests/test_apps/passes_callable_class_to_hydra_main/my_app.py",
+            dedent(
+                """\
+                123
+                my_app
+                """
+            ),
+            id="passes_callable_class_to_hydra_main",
+        ),
+    ],
+)
+def test_pass_callable_class_to_hydra_main(
+    tmpdir: Path, script: str, expected: str
+) -> None:
+    cmd = [
+        script,
+        "hydra.run.dir=" + str(tmpdir),
+        "hydra.job.chdir=True",
+    ]
+
+    result, _err = run_python_script(cmd)
+    assert_text_same(result, expected)
+
+
+@mark.parametrize(
     "other_flag",
     [None, "--run", "--multirun", "--info", "--shell-completion", "--hydra-help"],
 )

--- a/tests/test_internal_utils.py
+++ b/tests/test_internal_utils.py
@@ -1,10 +1,11 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from typing import Any
+from typing import Any, Callable, Optional
 
 from omegaconf import DictConfig, OmegaConf
 from pytest import mark, param
 
 from hydra._internal import utils
+from tests import data
 
 
 @mark.parametrize(
@@ -32,3 +33,23 @@ def test_get_column_widths(matrix: Any, expected: Any) -> None:
 )
 def test_get_class_name(config: DictConfig, expected: Any) -> None:
     assert utils._get_cls_name(config) == expected
+
+
+@mark.parametrize(
+    "task_function, expected_file, expected_module",
+    [
+        param(data.foo, None, "tests.data", id="function"),
+        param(data.foo_main_module, data.__file__, None, id="function-main-module"),
+        param(data.Bar, None, "tests.data", id="class"),
+        param(data.bar_instance, None, "tests.data", id="class_inst"),
+        param(data.bar_instance_main_module, None, None, id="class_inst-main-module"),
+    ],
+)
+def test_detect_calling_file_or_module_from_task_function(
+    task_function: Callable[..., None],
+    expected_file: Optional[str],
+    expected_module: Optional[str],
+) -> None:
+    file, module = utils.detect_calling_file_or_module_from_task_function(task_function)
+    assert file == expected_file
+    assert module == expected_module


### PR DESCRIPTION
This PR enables callable objects (besides functions) to be passed to `hydra.main`.
For example, running the following script:

```python
# my_app.py
import hydra
from omegaconf import DictConfig

class MyTaskFunction:
    def __init__(self, context) -> None:
        self._context = context

    def __call__(self, cfg: DictConfig) -> None:
        print(cfg)

if __name__ == "__main__":
    my_task_function = MyTaskFunction(context=123)
    app = hydra.main(config_path=None, config_name=None)(my_task_function)
    app()
```
Here is the behavior before and after this PR's diff:

Before:
```python
$ python my_app.py hydra.job.chdir=true
Traceback (most recent call last):
  File "my_app.py", line 14, in <module>
    app()
  File "/home/jbss/hydra.git/hydra/main.py", line 52, in decorated_main
    config_name=config_name,
  File "/home/jbss/hydra.git/hydra/_internal/utils.py", line 320, in _run_hydra
    ) = detect_calling_file_or_module_from_task_function(task_function)
  File "/home/jbss/hydra.git/hydra/_internal/utils.py", line 51, in detect_calling_file_or_module_from_task_function
    calling_file = task_function.__code__.co_filename
AttributeError: 'MyTaskFunction' object has no attribute '__code__'
```

After:
```python
$ python my_app.py hydra.job.chdir=true
{}
```

The motivation for this change is that using a callable object for `task_function` (rather than a function) allows launchers to inspect the state of a running task. This is useful for e.g. implementing checkpointing, (which should now be possible with the submitit launcher). Closes #2042.

As far as the implementation:
Previously, the `_run_hydra` function would fail (with the stacktrace above) if `task_function` is an object such that both of the following are true:
  1) `task_function.__module__` is `__main__` or is `None`
  2) The python file where the task function was defined is unknown.
Regarding case (2), usually it is possible to discover the python file in which a function was defined. However, discovering where an instance of a class was defined is not as easy. This means (before this PR) passing a class instance to `hydra.main` would fail if the instance was created in the `__main__` module.

This PR implements a fallback behavior to handle the case where both of the above (1) and (2) are true: If the module cannot be determined (because `obj.__module__` is `__main__` or is `None`) and if the python file cannot be determined, the stack frame of the call to `hydra.main` is inspected instead.
This PR re-uses the stack inspection logic employed by [`hydra.initialize`](https://github.com/facebookresearch/hydra/blob/cd256919526b551ea3c558bb2d6f77bc9fabd203/hydra/initialize.py#L76).