### PR TITLE
web: direct to github discussions rather than zulip

### DIFF
--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -142,8 +142,8 @@ There is a whole lot more to Hydra. Read the [tutorial](tutorials/basic/your_fir
 
 ## Other stuff
 ### Community
-Ask questions in the chat or StackOverflow (Use the tag #fb-hydra):
-* [Zulip Chat](https://hydra-framework.zulipchat.com)
+Ask questions on github or StackOverflow (Use the tag #fb-hydra):
+* [github](https://github.com/facebookresearch/hydra/discussions)
 * [StackOverflow](https://stackoverflow.com/questions/tagged/fb-hydra)
 
 Follow Hydra on Twitter and Facebook:

--- a/website/versioned_docs/version-0.11/intro.md
+++ b/website/versioned_docs/version-0.11/intro.md
@@ -146,8 +146,8 @@ There is a whole lot more to Hydra. Read the [tutorial](tutorial/1_simple_cli_ap
 
 ## Other stuff
 ### Community
-Ask questions in the chat or StackOverflow (Use the tag #fb-hydra):
-* [Zulip Chat](https://hydra-framework.zulipchat.com)
+Ask questions on github or StackOverflow (Use the tag #fb-hydra):
+* [github](https://github.com/facebookresearch/hydra/discussions)
 * [StackOverflow](https://stackoverflow.com/questions/tagged/fb-hydra)
 
 Follow Hydra on Twitter and Facebook:

--- a/website/versioned_docs/version-1.0/intro.md
+++ b/website/versioned_docs/version-1.0/intro.md
@@ -143,8 +143,8 @@ There is a whole lot more to Hydra. Read the [tutorial](tutorials/basic/your_fir
 
 ## Other stuff
 ### Community
-Ask questions in the chat or StackOverflow (Use the tag #fb-hydra):
-* [Zulip Chat](https://hydra-framework.zulipchat.com)
+Ask questions on github or StackOverflow (Use the tag #fb-hydra):
+* [github](https://github.com/facebookresearch/hydra/discussions)
 * [StackOverflow](https://stackoverflow.com/questions/tagged/fb-hydra)
 
 Follow Hydra on Twitter and Facebook:

--- a/website/versioned_docs/version-1.1/intro.md
+++ b/website/versioned_docs/version-1.1/intro.md
@@ -142,8 +142,8 @@ There is a whole lot more to Hydra. Read the [tutorial](tutorials/basic/your_fir
 
 ## Other stuff
 ### Community
-Ask questions in the chat or StackOverflow (Use the tag #fb-hydra):
-* [Zulip Chat](https://hydra-framework.zulipchat.com)
+Ask questions on github or StackOverflow (Use the tag #fb-hydra):
+* [github](https://github.com/facebookresearch/hydra/discussions)
 * [StackOverflow](https://stackoverflow.com/questions/tagged/fb-hydra)
 
 Follow Hydra on Twitter and Facebook:


### PR DESCRIPTION
github discussions provide better integrations
and a more cohesive support surface.
