### PR TITLE
1.1_branch: fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ commands:
       - run:
           name: Preparing environment - system
           command: |
-            choco install -y --no-progress miniconda3
+            choco install -y --no-progress miniconda3 --params '"/AddToPath:1"'
             C:\tools\miniconda3\Scripts\conda.exe init powershell
             choco install -y --no-progress openssl javaruntime
       - run:

--- a/noxfile.py
+++ b/noxfile.py
@@ -313,7 +313,7 @@ def lint_plugins_in_dir(session, directory: str) -> None:
 def test_tools(session):
     install_cmd = ["pip", "install"]
     _upgrade_basic(session)
-    session.install("pytest")
+    session.install("pytest<7")
     install_hydra(session, install_cmd)
 
     tools = [
@@ -425,7 +425,7 @@ def coverage(session):
     }
 
     _upgrade_basic(session)
-    session.install("coverage", "pytest")
+    session.install("coverage", "pytest<7")
     install_hydra(session, ["pip", "install", "-e"])
     session.run("coverage", "erase", env=coverage_env)
 
@@ -500,5 +500,5 @@ def benchmark(session):
     _upgrade_basic(session)
     install_dev_deps(session)
     install_hydra(session, INSTALL_COMMAND)
-    session.install("pytest")
+    session.install("pytest<7")
     run_pytest(session, "build_helpers", "tests/benchmark.py", *session.posargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -344,7 +344,7 @@ def _get_standalone_apps_dirs():
 def test_core(session):
     _upgrade_basic(session)
     install_hydra(session, INSTALL_COMMAND)
-    session.install("pytest")
+    session.install("pytest<7")
 
     if not SKIP_CORE_TESTS:
         run_pytest(session, "build_helpers", "tests", *session.posargs)
@@ -382,7 +382,7 @@ def test_plugins_in_directory(
     session, install_cmd, directory: str, test_hydra_core: bool
 ):
     _upgrade_basic(session)
-    session.install("pytest")
+    session.install("pytest<7")
     install_hydra(session, install_cmd)
     selected_plugin = select_plugins(session=session, directory=directory)
     for plugin in selected_plugin:
@@ -472,7 +472,7 @@ def test_jupyter_notebooks(session):
             f"Not testing Jupyter notebook on Python {session.python}, supports [{','.join(versions)}]"
         )
     _upgrade_basic(session)
-    session.install("jupyter", "nbval", "pyzmq")
+    session.install("jupyter", "nbval", "pyzmq", "pytest<7")
     if platform.system() == "Windows":
         # Newer versions of pywin32 are causing CI issues on Windows.
         # see https://github.com/mhammond/pywin32/issues/1709

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,7 +10,7 @@ mypy==0.790
 nox
 packaging
 pre-commit
-pytest
+pytest<7
 pytest-benchmark
 pytest-snail
 read-version


### PR DESCRIPTION
Fix CI on 1.1_branch.

Commits:
 
 - https://github.com/facebookresearch/hydra/pull/2053/commits/18c967d729b9718cf7337c3a7c16f66cccfc4145: pin pytest for several of the nox sessions.
 - https://github.com/facebookresearch/hydra/pull/2053/commits/72036095e9b0a6a3bc130c726f7708a23abd09e7: cherry pick from [#2045](#2045), working around windows conda installation issue
 - https://github.com/facebookresearch/hydra/pull/2053/commits/adceca39f6f39caa1e1a40b5e42a3b076f450c3f: more pytest pins

The first two commits are necessary to make the CI pass; the third commit is just for the sake of consistency (so that `pytest<7` is pinned everywhere).