### PR TITLE
prefer getattr in _locate logic

### DIFF
--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -570,16 +570,11 @@ def _locate(path: str) -> Union[type, Callable[..., Any]]:
     from types import ModuleType
 
     parts = [part for part in path.split(".") if part]
-    for n in reversed(range(1, len(parts) + 1)):
-        mod = ".".join(parts[:n])
-        try:
-            obj = import_module(mod)
-        except Exception as exc_import:
-            if n == 1:
-                raise ImportError(f"Error loading module '{path}'") from exc_import
-            continue
-        break
-    for m in range(n, len(parts)):
+    try:
+        obj = import_module(parts[0])
+    except Exception as exc_import:
+        raise ImportError(f"Error loading module '{path}'") from exc_import
+    for m in range(1, len(parts)):
         part = parts[m]
         try:
             obj = getattr(obj, part)
@@ -587,7 +582,8 @@ def _locate(path: str) -> Union[type, Callable[..., Any]]:
             if isinstance(obj, ModuleType):
                 mod = ".".join(parts[: m + 1])
                 try:
-                    import_module(mod)
+                    obj = import_module(mod)
+                    continue
                 except ModuleNotFoundError:
                     pass
                 except Exception as exc_import:

--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -8,6 +8,9 @@ from typing import Any, Dict, List, NoReturn, Optional, Tuple
 from omegaconf import MISSING, DictConfig, ListConfig
 
 from hydra.types import TargetConf
+from tests.instantiate.module_shadowed_by_function import a_function
+
+module_shadowed_by_function = a_function
 
 
 def _convert_type(obj: Any) -> Any:

--- a/tests/instantiate/module_shadowed_by_function.py
+++ b/tests/instantiate/module_shadowed_by_function.py
@@ -1,0 +1,3 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+def a_function() -> None:
+    pass

--- a/tests/instantiate/test_helpers.py
+++ b/tests/instantiate/test_helpers.py
@@ -16,6 +16,8 @@ from tests.instantiate import (
     Parameters,
 )
 
+from .module_shadowed_by_function import a_function
+
 
 @mark.parametrize(
     "name,expected",
@@ -68,6 +70,7 @@ from tests.instantiate import (
         ("tests.instantiate.ASubclass", ASubclass),
         ("tests.instantiate.NestingClass", NestingClass),
         ("tests.instantiate.AnotherClass", AnotherClass),
+        ("tests.instantiate.module_shadowed_by_function", a_function),
         ("", raises(ImportError, match=re.escape("Empty path"))),
         (
             "not_found",


### PR DESCRIPTION
This PR fixes an edge case in behavior of the `_locate` function (which serves as a backend for Hydra's `instantiate` utility). The `_locate` function takes a dotpath string as input (e.g. the string `"my_module.foobar"`) and returns a python object (e.g. the object `my_module.foobar`).

This diff reverses a regression introduced in https://github.com/facebookresearch/hydra/commit/043ec9b2f062d90ca97909d993184806d8335823.  Before that commit, `_locate` would prefer to try `getattr(my_module, "foobar")` and then do `importlib.import_module("my_module.foobar")` as a fallback. The regression was that `import_module` had higher priority, with `getattr` as a fallback.
This PR restores the earlier behavior. This matters in the case where a module `my_module/foobar.py` exists but is different from the attribute `getattr(my_module, "foobar")`. An example is the `torch.tensor` attribute (for pytorch version 1.8).

Before this PR:
```python
>>> import torch
>>> from hydra.utils import get_method
>>> assert torch.tensor is get_method("torch.tensor")
Error getting callable at torch.tensor : Invalid type (<class 'module'>) found for torch.tensor
Traceback (most recent call last):
  ...
ValueError: Invalid type (<class 'module'>) found for torch.tensor
```

After this PR:
```python
>>> import torch
>>> from hydra.utils import get_method
>>> assert torch.tensor is get_method("torch.tensor")
>>> 
```

Closes #2061.