### PR TITLE
Support backwards compatible operation by default

### DIFF
--- a/examples/advanced/ad_hoc_composition/hydra_compose_example.py
+++ b/examples/advanced/ad_hoc_composition/hydra_compose_example.py
@@ -6,6 +6,6 @@ from hydra import compose, initialize
 if __name__ == "__main__":
     # initialize the Hydra subsystem.
     # This is needed for apps that cannot have a standard @hydra.main() entry point
-    initialize(config_path="conf")
+    initialize(version_base=None, config_path="conf")
     cfg = compose("config.yaml", overrides=["db=mysql", "db.user=${oc.env:USER}"])
     print(OmegaConf.to_yaml(cfg, resolve=True))

--- a/examples/advanced/config_search_path/my_app.py
+++ b/examples/advanced/config_search_path/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/advanced/defaults_list_interpolation/my_app.py
+++ b/examples/advanced/defaults_list_interpolation/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/advanced/hydra_app_example/hydra_app/main.py
+++ b/examples/advanced/hydra_app_example/hydra_app/main.py
@@ -14,7 +14,7 @@ def add(app_cfg: DictConfig, key1: str, key2: str) -> Any:
     return ret
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     add(cfg.app, "num1", "num2")
 

--- a/examples/advanced/hydra_app_example/tests/test_example.py
+++ b/examples/advanced/hydra_app_example/tests/test_example.py
@@ -12,7 +12,7 @@ from hydra import compose, initialize, initialize_config_module
 # 2. The module with your configs should be importable. it needs to have a __init__.py (can be empty).
 # 3. The config path is relative to the file calling initialize (this file)
 def test_with_initialize() -> None:
-    with initialize(config_path="../hydra_app/conf"):
+    with initialize(version_base=None, config_path="../hydra_app/conf"):
         # config is relative to a module
         cfg = compose(config_name="config", overrides=["app.user=test_user"])
         assert cfg == {
@@ -26,7 +26,7 @@ def test_with_initialize() -> None:
 # 3. The module should be absolute
 # 4. This approach is not sensitive to the location of this file, the test can be relocated freely.
 def test_with_initialize_config_module() -> None:
-    with initialize_config_module(config_module="hydra_app.conf"):
+    with initialize_config_module(version_base=None, config_module="hydra_app.conf"):
         # config is relative to a module
         cfg = compose(config_name="config", overrides=["app.user=test_user"])
         assert cfg == {
@@ -38,7 +38,9 @@ def test_with_initialize_config_module() -> None:
 # Usage in unittest style tests is similar.
 class TestWithUnittest(unittest.TestCase):
     def test_generated_config(self) -> None:
-        with initialize_config_module(config_module="hydra_app.conf"):
+        with initialize_config_module(
+            version_base=None, config_module="hydra_app.conf"
+        ):
             cfg = compose(config_name="config", overrides=["app.user=test_user"])
             assert cfg == {
                 "app": {"user": "test_user", "num1": 10, "num2": 20},
@@ -57,6 +59,6 @@ class TestWithUnittest(unittest.TestCase):
     ],
 )
 def test_user_logic(overrides: List[str], expected: int) -> None:
-    with initialize_config_module(config_module="hydra_app.conf"):
+    with initialize_config_module(version_base=None, config_module="hydra_app.conf"):
         cfg = compose(config_name="config", overrides=overrides)
         assert hydra_app.main.add(cfg.app, "num1", "num2") == expected

--- a/examples/advanced/nested_defaults_list/my_app.py
+++ b/examples/advanced/nested_defaults_list/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/advanced/package_overrides/simple.py
+++ b/examples/advanced/package_overrides/simple.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="simple")
+@hydra.main(version_base=None, config_path="conf", config_name="simple")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/advanced/package_overrides/two_packages.py
+++ b/examples/advanced/package_overrides/two_packages.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="two_packages")
+@hydra.main(version_base=None, config_path="conf", config_name="two_packages")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/advanced/ray_example/ray_compose_example.py
+++ b/examples/advanced/ray_example/ray_compose_example.py
@@ -15,7 +15,7 @@ def train(overrides: List[str], cfg: DictConfig) -> Tuple[List[str], float]:
     return overrides, 0.9
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     ray.init(**cfg.ray.init)
 

--- a/examples/configure_hydra/custom_help/my_app.py
+++ b/examples/configure_hydra/custom_help/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/configure_hydra/job_name/no_config_file_override.py
+++ b/examples/configure_hydra/job_name/no_config_file_override.py
@@ -5,7 +5,7 @@ import hydra
 from hydra.core.hydra_config import HydraConfig
 
 
-@hydra.main(config_path=None)
+@hydra.main(version_base=None)
 def experiment(_cfg: DictConfig) -> None:
     print(HydraConfig.get().job.name)
 

--- a/examples/configure_hydra/job_name/with_config_file_override.py
+++ b/examples/configure_hydra/job_name/with_config_file_override.py
@@ -5,7 +5,7 @@ import hydra
 from hydra.core.hydra_config import HydraConfig
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def experiment(_cfg: DictConfig) -> None:
     print(HydraConfig.get().job.name)
 

--- a/examples/configure_hydra/job_override_dirname/my_app.py
+++ b/examples/configure_hydra/job_override_dirname/my_app.py
@@ -6,7 +6,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(_cfg: DictConfig) -> None:
     print(f"Working dir {os.getcwd()}")
 

--- a/examples/configure_hydra/logging/my_app.py
+++ b/examples/configure_hydra/logging/my_app.py
@@ -8,7 +8,7 @@ import hydra
 log = logging.getLogger(__name__)
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(_cfg: DictConfig) -> None:
     log.info("Info level message")
 

--- a/examples/configure_hydra/workdir/my_app.py
+++ b/examples/configure_hydra/workdir/my_app.py
@@ -6,7 +6,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def experiment(_cfg: DictConfig) -> None:
     print(os.getcwd())
 

--- a/examples/instantiate/docs_example/my_app.py
+++ b/examples/instantiate/docs_example/my_app.py
@@ -39,7 +39,7 @@ class Trainer:
         return f"Trainer(\n  optimizer={self.optimizer},\n  dataset={self.dataset}\n)"
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     optimizer = instantiate(cfg.trainer.optimizer)
     print(optimizer)

--- a/examples/instantiate/object/my_app.py
+++ b/examples/instantiate/object/my_app.py
@@ -31,7 +31,7 @@ class PostgreSQLConnection(DBConnection):
         print(f"PostgreSQL connecting to {self.host}")
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     connection = instantiate(cfg.db)
     connection.connect()

--- a/examples/instantiate/object_recursive/my_app.py
+++ b/examples/instantiate/object_recursive/my_app.py
@@ -28,7 +28,7 @@ class Car:
         print(f"Driver : {self.driver.name}, {len(self.wheels)} wheels")
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     car: Car = instantiate(cfg.car)
     car.drive()

--- a/examples/instantiate/partial/my_app.py
+++ b/examples/instantiate/partial/my_app.py
@@ -28,7 +28,7 @@ class Model:
         return f"Model(Optimizer={self.optim})"
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     model = instantiate(cfg.model)
     print(model)

--- a/examples/instantiate/schema/my_app.py
+++ b/examples/instantiate/schema/my_app.py
@@ -69,7 +69,7 @@ cs.store(group="db", name="mysql", node=MySQLConfig)
 cs.store(group="db", name="postgresql", node=PostGreSQLConfig)
 
 
-@hydra.main(config_path=None, config_name="config")
+@hydra.main(version_base=None, config_name="config")
 def my_app(cfg: Config) -> None:
     connection = instantiate(cfg.db)
     connection.connect()

--- a/examples/instantiate/schema_recursive/my_app.py
+++ b/examples/instantiate/schema_recursive/my_app.py
@@ -46,7 +46,7 @@ def pretty_print(tree: Tree, name: str = "root", depth: int = 0) -> None:
         pretty_print(tree.right, name="right", depth=depth + 1)
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: Config) -> None:
     tree: Tree = instantiate(cfg.tree)
     pretty_print(tree)

--- a/examples/jupyter_notebooks/compose_configs_in_notebook.ipynb
+++ b/examples/jupyter_notebooks/compose_configs_in_notebook.ipynb
@@ -51,7 +51,7 @@
     }
    ],
    "source": [
-    "with initialize(config_path=\"cloud_app/conf\"):\n",
+    "with initialize(version_base=None, config_path=\"cloud_app/conf\"):\n",
     "    cfg = compose(overrides=[\"+db=mysql\"])\n",
     "    print(cfg)"
    ]
@@ -79,7 +79,7 @@
     }
    ],
    "source": [
-    "with initialize_config_module(config_module=\"cloud_app.conf\"):\n",
+    "with initialize_config_module(version_base=None, config_module=\"cloud_app.conf\"):\n",
     "    cfg = compose(overrides=[\"+db=mysql\"])\n",
     "    print(cfg)"
    ]
@@ -108,7 +108,7 @@
    ],
    "source": [
     "abs_config_dir=os.path.abspath(\"cloud_app/conf\")\n",
-    "with initialize_config_dir(config_dir=abs_config_dir):\n",
+    "with initialize_config_dir(version_base=None, config_dir=abs_config_dir):\n",
     "    cfg = compose(overrides=[\"+db=mysql\"])\n",
     "    print(cfg)"
    ]
@@ -138,7 +138,7 @@
     }
    ],
    "source": [
-    "initialize(config_path=\"cloud_app/conf\")\n",
+    "initialize(version_base=None, config_path=\"cloud_app/conf\")\n",
     "compose(overrides=[\"+db=mysql\"])"
    ]
   },

--- a/examples/patterns/configuring_experiments/my_app.py
+++ b/examples/patterns/configuring_experiments/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/patterns/extending_configs/my_app.py
+++ b/examples/patterns/extending_configs/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/patterns/multi-select/my_app.py
+++ b/examples/patterns/multi-select/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/patterns/specializing_config/example.py
+++ b/examples/patterns/specializing_config/example.py
@@ -9,7 +9,7 @@ import hydra
 log = logging.getLogger(__name__)
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def experiment(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/patterns/write_protect_config_node/frozen.py
+++ b/examples/patterns/write_protect_config_node/frozen.py
@@ -16,7 +16,7 @@ cs = ConfigStore.instance()
 cs.store(name="config", node=SerialPort)
 
 
-@hydra.main(config_path=None, config_name="config")
+@hydra.main(version_base=None, config_name="config")
 def my_app(cfg: SerialPort) -> None:
     print(cfg)
 

--- a/examples/plugins/example_launcher_plugin/example/my_app.py
+++ b/examples/plugins/example_launcher_plugin/example/my_app.py
@@ -3,7 +3,7 @@ import hydra
 from omegaconf import OmegaConf, DictConfig
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/plugins/example_searchpath_plugin/tests/test_example_search_path_plugin.py
+++ b/examples/plugins/example_searchpath_plugin/tests/test_example_search_path_plugin.py
@@ -17,7 +17,7 @@ def test_discovery() -> None:
 
 
 def test_config_installed() -> None:
-    with initialize(config_path=None):
+    with initialize(version_base=None):
         config_loader = GlobalHydra.instance().config_loader()
         assert "my_default_output_dir" in config_loader.get_group_options(
             "hydra/output"

--- a/examples/plugins/example_sweeper_plugin/example/my_app.py
+++ b/examples/plugins/example_sweeper_plugin/example/my_app.py
@@ -3,7 +3,7 @@ import hydra
 from omegaconf import OmegaConf, DictConfig
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/tutorials/basic/running_your_hydra_app/3_working_directory/my_app.py
+++ b/examples/tutorials/basic/running_your_hydra_app/3_working_directory/my_app.py
@@ -6,7 +6,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path=None)
+@hydra.main(version_base=None)
 def my_app(_cfg: DictConfig) -> None:
     print(f"Working directory : {os.getcwd()}")
 

--- a/examples/tutorials/basic/running_your_hydra_app/4_logging/my_app.py
+++ b/examples/tutorials/basic/running_your_hydra_app/4_logging/my_app.py
@@ -9,7 +9,7 @@ import hydra
 log = logging.getLogger(__name__)
 
 
-@hydra.main(config_path=None)
+@hydra.main(version_base=None)
 def my_app(_cfg: DictConfig) -> None:
     log.info("Info level message")
     log.debug("Debug level message")

--- a/examples/tutorials/basic/running_your_hydra_app/5_basic_sweep/my_app.py
+++ b/examples/tutorials/basic/running_your_hydra_app/5_basic_sweep/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(f"driver={cfg.db.driver}, timeout={cfg.db.timeout}")
 

--- a/examples/tutorials/basic/your_first_hydra_app/1_simple_cli/my_app.py
+++ b/examples/tutorials/basic/your_first_hydra_app/1_simple_cli/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path=None)
+@hydra.main(version_base=None)
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/tutorials/basic/your_first_hydra_app/2_config_file/my_app.py
+++ b/examples/tutorials/basic/your_first_hydra_app/2_config_file/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/tutorials/basic/your_first_hydra_app/3_using_config/my_app.py
+++ b/examples/tutorials/basic/your_first_hydra_app/3_using_config/my_app.py
@@ -5,7 +5,7 @@ from pytest import raises
 import hydra
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     assert cfg.node.loompa == 10  # attribute style access
     assert cfg["node"]["loompa"] == 10  # dictionary style access

--- a/examples/tutorials/basic/your_first_hydra_app/4_config_groups/my_app.py
+++ b/examples/tutorials/basic/your_first_hydra_app/4_config_groups/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf")
+@hydra.main(version_base=None, config_path="conf")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/tutorials/basic/your_first_hydra_app/5_defaults/my_app.py
+++ b/examples/tutorials/basic/your_first_hydra_app/5_defaults/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/tutorials/basic/your_first_hydra_app/6_composition/my_app.py
+++ b/examples/tutorials/basic/your_first_hydra_app/6_composition/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/tutorials/structured_configs/1_minimal/my_app.py
+++ b/examples/tutorials/structured_configs/1_minimal/my_app.py
@@ -16,7 +16,7 @@ cs = ConfigStore.instance()
 cs.store(name="config", node=MySQLConfig)
 
 
-@hydra.main(config_path=None, config_name="config")
+@hydra.main(version_base=None, config_name="config")
 def my_app(cfg: MySQLConfig) -> None:
     print(f"Host: {cfg.host}, port: {cfg.port}")
 

--- a/examples/tutorials/structured_configs/1_minimal/my_app_type_error.py
+++ b/examples/tutorials/structured_configs/1_minimal/my_app_type_error.py
@@ -16,7 +16,7 @@ cs = ConfigStore.instance()
 cs.store(name="config", node=MySQLConfig)
 
 
-@hydra.main(config_path=None, config_name="config")
+@hydra.main(version_base=None, config_name="config")
 def my_app(cfg: MySQLConfig) -> None:
     # pork should be port!
     if cfg.pork == 80:  # type: ignore

--- a/examples/tutorials/structured_configs/2_static_complex/my_app.py
+++ b/examples/tutorials/structured_configs/2_static_complex/my_app.py
@@ -28,7 +28,7 @@ cs = ConfigStore.instance()
 cs.store(name="config", node=MyConfig)
 
 
-@hydra.main(config_path=None, config_name="config")
+@hydra.main(version_base=None, config_name="config")
 def my_app(cfg: MyConfig) -> None:
     print(f"Title={cfg.ui.title}, size={cfg.ui.width}x{cfg.ui.height} pixels")
 

--- a/examples/tutorials/structured_configs/3_config_groups/my_app.py
+++ b/examples/tutorials/structured_configs/3_config_groups/my_app.py
@@ -35,7 +35,7 @@ cs.store(group="db", name="mysql", node=MySQLConfig)
 cs.store(group="db", name="postgresql", node=PostGreSQLConfig)
 
 
-@hydra.main(config_path=None, config_name="config")
+@hydra.main(version_base=None, config_name="config")
 def my_app(cfg: Config) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/tutorials/structured_configs/3_config_groups/my_app_with_inheritance.py
+++ b/examples/tutorials/structured_configs/3_config_groups/my_app_with_inheritance.py
@@ -40,7 +40,7 @@ cs.store(group="db", name="mysql", node=MySQLConfig)
 cs.store(group="db", name="postgresql", node=PostGreSQLConfig)
 
 
-@hydra.main(config_path=None, config_name="config")
+@hydra.main(version_base=None, config_name="config")
 def my_app(cfg: Config) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/tutorials/structured_configs/4_defaults/my_app.py
+++ b/examples/tutorials/structured_configs/4_defaults/my_app.py
@@ -48,7 +48,7 @@ cs.store(group="db", name="postgresql", node=PostGreSQLConfig)
 cs.store(name="config", node=Config)
 
 
-@hydra.main(config_path=None, config_name="config")
+@hydra.main(version_base=None, config_name="config")
 def my_app(cfg: Config) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/tutorials/structured_configs/5.1_structured_config_schema_same_config_group/my_app.py
+++ b/examples/tutorials/structured_configs/5.1_structured_config_schema_same_config_group/my_app.py
@@ -43,7 +43,7 @@ cs.store(group="db", name="base_mysql", node=MySQLConfig)
 cs.store(group="db", name="base_postgresql", node=PostGreSQLConfig)
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: Config) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/examples/tutorials/structured_configs/5.2_structured_config_schema_different_config_group/my_app.py
+++ b/examples/tutorials/structured_configs/5.2_structured_config_schema_different_config_group/my_app.py
@@ -23,6 +23,7 @@ database_lib.register_configs()
 
 
 @hydra.main(
+    version_base=None,
     config_path="conf",
     config_name="config",
 )

--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -224,7 +224,7 @@ class ConfigLoaderImpl(ConfigLoader):
         from_shell: bool = True,
         validate_sweep_overrides: bool = True,
     ) -> DictConfig:
-        from hydra import __version__
+        from hydra import __version__, version
 
         self.ensure_main_config_source_available()
         caching_repo = CachingConfigRepository(self.repository)
@@ -277,6 +277,7 @@ class ConfigLoaderImpl(ConfigLoader):
                 cfg.hydra.job.env_set[key] = os.environ[key]
 
         cfg.hydra.runtime.version = __version__
+        cfg.hydra.runtime.version_base = version.getbase()
         cfg.hydra.runtime.cwd = os.getcwd()
 
         cfg.hydra.runtime.config_sources = [

--- a/hydra/conf/__init__.py
+++ b/hydra/conf/__init__.py
@@ -96,6 +96,7 @@ class ConfigSourceInfo:
 @dataclass
 class RuntimeConf:
     version: str = MISSING
+    version_base: str = MISSING
     cwd: str = MISSING
     config_sources: List[ConfigSourceInfo] = MISSING
     output_dir: str = MISSING

--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Optional, Sequence, Union, cast
 
 from omegaconf import DictConfig, OmegaConf, open_dict, read_write
 
+from hydra import version
 from hydra._internal.deprecation_warning import deprecation_warning
 from hydra.core.hydra_config import HydraConfig
 from hydra.core.singleton import Singleton
@@ -145,6 +146,10 @@ def run_job(
         Path(str(output_dir)).mkdir(parents=True, exist_ok=True)
 
         _chdir = hydra_cfg.hydra.job.chdir
+
+        if _chdir is None:
+            if version.base_at_least("1.2"):
+                _chdir = False
 
         if _chdir is None:
             url = "https://hydra.cc/docs/upgrades/1.1_to_1.2/changes_to_job_working_dir"

--- a/hydra/initialize.py
+++ b/hydra/initialize.py
@@ -61,19 +61,22 @@ class initialize:
 
         version.setbase(version_base)
 
-        # DEPRECATED: remove in 1.2
-        # in 1.2, the default config_path should be changed to None
         if config_path is _UNSPECIFIED_:
-            url = "https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_hydra_main_config_path"
-            deprecation_warning(
-                message=dedent(
-                    f"""\
-                config_path is not specified in hydra.initialize().
-                See {url} for more information."""
-                ),
-                stacklevel=2,
-            )
-            config_path = "."
+            if version.base_at_least("1.2"):
+                config_path = None
+            elif version_base is _UNSPECIFIED_:
+                url = "https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_hydra_main_config_path"
+                deprecation_warning(
+                    message=dedent(
+                        f"""\
+                    config_path is not specified in hydra.initialize().
+                    See {url} for more information."""
+                    ),
+                    stacklevel=2,
+                )
+                config_path = "."
+            else:
+                config_path = "."
 
         if config_path is not None and os.path.isabs(config_path):
             raise HydraException("config_path in initialize() must be relative")

--- a/hydra/initialize.py
+++ b/hydra/initialize.py
@@ -4,6 +4,7 @@ import os
 from textwrap import dedent
 from typing import Any, Optional
 
+from hydra import version
 from hydra._internal.deprecation_warning import deprecation_warning
 from hydra._internal.hydra import Hydra
 from hydra._internal.utils import (
@@ -52,10 +53,13 @@ class initialize:
     def __init__(
         self,
         config_path: Optional[str] = _UNSPECIFIED_,
+        version_base: Optional[str] = _UNSPECIFIED_,
         job_name: Optional[str] = None,
         caller_stack_depth: int = 1,
     ) -> None:
         self._gh_backup = get_gh_backup()
+
+        version.setbase(version_base)
 
         # DEPRECATED: remove in 1.2
         # in 1.2, the default config_path should be changed to None
@@ -106,8 +110,15 @@ class initialize_config_module:
     :param job_name: the value for hydra.job.name (default is 'app')
     """
 
-    def __init__(self, config_module: str, job_name: str = "app"):
+    def __init__(
+        self,
+        config_module: str,
+        version_base: Optional[str] = _UNSPECIFIED_,
+        job_name: str = "app",
+    ):
         self._gh_backup = get_gh_backup()
+
+        version.setbase(version_base)
 
         Hydra.create_main_hydra_file_or_module(
             calling_file=None,
@@ -135,8 +146,16 @@ class initialize_config_dir:
     :param job_name: the value for hydra.job.name (default is 'app')
     """
 
-    def __init__(self, config_dir: str, job_name: str = "app") -> None:
+    def __init__(
+        self,
+        config_dir: str,
+        version_base: Optional[str] = _UNSPECIFIED_,
+        job_name: str = "app",
+    ) -> None:
         self._gh_backup = get_gh_backup()
+
+        version.setbase(version_base)
+
         # Relative here would be interpreted as relative to cwd, which - depending on when it run
         # may have unexpected meaning. best to force an absolute path to avoid confusion.
         # Can consider using hydra.utils.to_absolute_path() to convert it at a future point if there is demand.

--- a/hydra/main.py
+++ b/hydra/main.py
@@ -26,19 +26,22 @@ def main(
 
     version.setbase(version_base)
 
-    # DEPRECATED: remove in 1.2
-    # in 1.2, the default config_path should be changed to None
     if config_path is _UNSPECIFIED_:
-        url = "https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_hydra_main_config_path"
-        deprecation_warning(
-            message=dedent(
-                f"""
-            config_path is not specified in @hydra.main().
-            See {url} for more information."""
-            ),
-            stacklevel=2,
-        )
-        config_path = "."
+        if version.base_at_least("1.2"):
+            config_path = None
+        elif version_base is _UNSPECIFIED_:
+            url = "https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_hydra_main_config_path"
+            deprecation_warning(
+                message=dedent(
+                    f"""
+                config_path is not specified in @hydra.main().
+                See {url} for more information."""
+                ),
+                stacklevel=2,
+            )
+            config_path = "."
+        else:
+            config_path = "."
 
     def main_decorator(task_function: TaskFunction) -> Callable[[], None]:
         @functools.wraps(task_function)

--- a/hydra/main.py
+++ b/hydra/main.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Optional
 
 from omegaconf import DictConfig
 
+from . import version
 from ._internal.deprecation_warning import deprecation_warning
 from ._internal.utils import _run_hydra, get_args_parser
 from .types import TaskFunction
@@ -15,12 +16,15 @@ _UNSPECIFIED_: Any = object()
 def main(
     config_path: Optional[str] = _UNSPECIFIED_,
     config_name: Optional[str] = None,
+    version_base: Optional[str] = _UNSPECIFIED_,
 ) -> Callable[[TaskFunction], Any]:
     """
     :param config_path: The config path, a directory relative to the declaring python file.
                         If config_path is None no directory is added to the Config search path.
     :param config_name: The name of the config (usually the file name without the .yaml extension)
     """
+
+    version.setbase(version_base)
 
     # DEPRECATED: remove in 1.2
     # in 1.2, the default config_path should be changed to None

--- a/hydra/test_utils/completion.py
+++ b/hydra/test_utils/completion.py
@@ -4,7 +4,9 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="configs/completion_test", config_name="config")
+@hydra.main(
+    version_base=None, config_path="configs/completion_test", config_name="config"
+)
 def run_cli(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/hydra/test_utils/example_app.py
+++ b/hydra/test_utils/example_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="configs", config_name="db_conf")
+@hydra.main(version_base=None, config_path="configs", config_name="db_conf")
 def run_cli(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/hydra/test_utils/launcher_common_tests.py
+++ b/hydra/test_utils/launcher_common_tests.py
@@ -620,7 +620,7 @@ class IntegrationTestSuite:
         integration_test(
             tmpdir=self.get_test_scratch_dir(tmpdir),
             task_config=cfg,
-            overrides=overrides,
+            overrides=overrides + ["hydra.job.chdir=True"],
             prints="os.getcwd()",
             expected_outputs=expected_outputs,
             generate_custom_cmd=self.generate_custom_cmd(),
@@ -649,6 +649,7 @@ class IntegrationTestSuite:
     ) -> None:
         expected_dir = "cli_dir/cli_dir_0"
         overrides = extra_flags + [
+            "hydra.job.chdir=True",
             "hydra.sweep.dir=cli_dir",
             "hydra.sweep.subdir=cli_dir_${hydra.job.num}",
         ]

--- a/hydra/test_utils/test_utils.py
+++ b/hydra/test_utils/test_utils.py
@@ -290,7 +290,7 @@ from hydra.core.hydra_config import HydraConfig
 
 $PROLOG
 
-@hydra.main(config_path='.', config_name='config')
+@hydra.main(version_base=None, config_path='.', config_name='config')
 def experiment(cfg):
     with open("$OUTPUT_FILE", "w") as f:
 $PRINTS

--- a/hydra/version.py
+++ b/hydra/version.py
@@ -1,0 +1,80 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+# Source of truth for Hydra's version
+
+from textwrap import dedent
+from typing import Any, Optional
+
+from packaging.version import Version
+
+from . import __version__
+from ._internal.deprecation_warning import deprecation_warning
+from .core.singleton import Singleton
+from .errors import HydraException
+
+_UNSPECIFIED_: Any = object()
+
+__compat_version__: Version = Version("1.1")
+
+
+class VersionBase(metaclass=Singleton):
+    def __init__(self) -> None:
+        self.version_base: Optional[Version] = _UNSPECIFIED_
+
+    def setbase(self, version: "Version") -> None:
+        assert isinstance(
+            version, Version
+        ), f"Unexpected Version type : {type(version)}"
+        self.version_base = version
+
+    def getbase(self) -> Optional[Version]:
+        return self.version_base
+
+    @staticmethod
+    def instance(*args: Any, **kwargs: Any) -> "VersionBase":
+        return Singleton.instance(VersionBase, *args, **kwargs)  # type: ignore
+
+    @staticmethod
+    def set_instance(instance: "VersionBase") -> None:
+        assert isinstance(instance, VersionBase)
+        Singleton._instances[VersionBase] = instance  # type: ignore
+
+
+def _get_version(ver: str) -> Version:
+    # Only consider major.minor as packaging will compare "1.2.0.dev2" < "1.2"
+    pver = Version(ver)
+    return Version(f"{pver.major}.{pver.minor}")
+
+
+def base_at_least(ver: str) -> bool:
+    _version_base = VersionBase.instance().getbase()
+    if type(_version_base) is type(_UNSPECIFIED_):
+        VersionBase.instance().setbase(__compat_version__)
+        _version_base = __compat_version__
+    assert isinstance(_version_base, Version)
+    return _version_base >= _get_version(ver)
+
+
+def getbase() -> Optional[Version]:
+    return VersionBase.instance().getbase()
+
+
+def setbase(ver: Any) -> None:
+    if type(ver) is type(_UNSPECIFIED_):
+        deprecation_warning(
+            message=dedent(
+                f"""
+            The version_base parameter is not specified.
+            Please specify a compatability version level, or None.
+            Will assume defaults for version {__compat_version__}"""
+            ),
+            stacklevel=3,
+        )
+        _version_base = __compat_version__
+    elif ver is None:
+        _version_base = _get_version(__version__)
+    else:
+        _version_base = _get_version(ver)
+        if _version_base < __compat_version__:
+            raise HydraException(f'version_base must be >= "{__compat_version__}"')
+    VersionBase.instance().setbase(_version_base)

--- a/plugins/hydra_ax_sweeper/example/banana.py
+++ b/plugins/hydra_ax_sweeper/example/banana.py
@@ -8,7 +8,7 @@ from omegaconf import DictConfig
 log = logging.getLogger(__name__)
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def banana(cfg: DictConfig) -> Any:
     x = cfg.banana.x
     y = cfg.banana.y

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial.py
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial.py
@@ -5,7 +5,7 @@ import hydra
 from omegaconf import DictConfig
 
 
-@hydra.main(config_path=".", config_name="polynomial")
+@hydra.main(version_base=None, config_path=".", config_name="polynomial")
 def polynomial(cfg: DictConfig) -> Any:
     x = cfg.polynomial.x
     y = cfg.polynomial.y

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_dict_coefficients.py
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_dict_coefficients.py
@@ -5,7 +5,9 @@ import hydra
 from omegaconf import DictConfig
 
 
-@hydra.main(config_path=".", config_name="polynomial_with_dict_coefficients")
+@hydra.main(
+    version_base=None, config_path=".", config_name="polynomial_with_dict_coefficients"
+)
 def polynomial_with_dict_coefficients(cfg: DictConfig) -> Any:
     coeff = cfg.polynomial.coefficients
     a = 100

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_list_coefficients.py
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_list_coefficients.py
@@ -5,7 +5,9 @@ import hydra
 from omegaconf import DictConfig
 
 
-@hydra.main(config_path=".", config_name="polynomial_with_coefficients")
+@hydra.main(
+    version_base=None, config_path=".", config_name="polynomial_with_coefficients"
+)
 def polynomial_with_list_coefficients(cfg: DictConfig) -> Any:
     x, y, z = cfg.polynomial.coefficients
     a = 100

--- a/plugins/hydra_colorlog/tests/test_colorlog.py
+++ b/plugins/hydra_colorlog/tests/test_colorlog.py
@@ -12,7 +12,9 @@ def test_config_installed() -> None:
     Tests that color options are available for both hydra/hydra_logging and hydra/job_logging
     """
 
-    with initialize(config_path="../hydra_plugins/hydra_colorlog/conf"):
+    with initialize(
+        version_base=None, config_path="../hydra_plugins/hydra_colorlog/conf"
+    ):
         config_loader = GlobalHydra.instance().config_loader()
         assert "colorlog" in config_loader.get_group_options("hydra/job_logging")
         assert "colorlog" in config_loader.get_group_options("hydra/hydra_logging")

--- a/plugins/hydra_nevergrad_sweeper/example/my_app.py
+++ b/plugins/hydra_nevergrad_sweeper/example/my_app.py
@@ -7,7 +7,7 @@ from omegaconf import DictConfig
 log = logging.getLogger(__name__)
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def dummy_training(cfg: DictConfig) -> float:
     """A dummy function to minimize
     Minimum is 0.0 at:

--- a/plugins/hydra_optuna_sweeper/example/multi-objective.py
+++ b/plugins/hydra_optuna_sweeper/example/multi-objective.py
@@ -5,7 +5,7 @@ import hydra
 from omegaconf import DictConfig
 
 
-@hydra.main(config_path="multi-objective-conf", config_name="config")
+@hydra.main(version_base=None, config_path="multi-objective-conf", config_name="config")
 def binh_and_korn(cfg: DictConfig) -> Tuple[float, float]:
     x: float = cfg.x
     y: float = cfg.y

--- a/plugins/hydra_optuna_sweeper/example/sphere.py
+++ b/plugins/hydra_optuna_sweeper/example/sphere.py
@@ -3,7 +3,7 @@ import hydra
 from omegaconf import DictConfig
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def sphere(cfg: DictConfig) -> float:
     x: float = cfg.x
     y: float = cfg.y

--- a/plugins/hydra_ray_launcher/examples/upload_download/train.py
+++ b/plugins/hydra_ray_launcher/examples/upload_download/train.py
@@ -8,7 +8,7 @@ from omegaconf import DictConfig
 log = logging.getLogger(__name__)
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     log.info("Start training...")
     model = MyModel(cfg.random_seed)

--- a/plugins/hydra_ray_launcher/integration_test_tools/create_integration_test_ami.py
+++ b/plugins/hydra_ray_launcher/integration_test_tools/create_integration_test_ami.py
@@ -29,7 +29,9 @@ def _run_command(command: str) -> str:
     return output
 
 
-@hydra.main(config_path=".", config_name="create_integration_test_ami_config")
+@hydra.main(
+    version_base=None, config_path=".", config_name="create_integration_test_ami_config"
+)
 def set_up_machine(cfg: DictConfig) -> None:
     security_group_id = cfg.security_group_id
     assert security_group_id != "", "Security group cannot be empty!"

--- a/plugins/hydra_submitit_launcher/example/my_app.py
+++ b/plugins/hydra_submitit_launcher/example/my_app.py
@@ -10,7 +10,7 @@ from omegaconf import DictConfig
 log = logging.getLogger(__name__)
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     env = submitit.JobEnvironment()
     log.info(f"Process ID {os.getpid()} executing task {cfg.task}, with {env}")

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,4 @@
 omegaconf~=2.1
 antlr4-python3-runtime==4.8
 importlib-resources;python_version<'3.9'
+packaging

--- a/tests/jupyter/a_module.py
+++ b/tests/jupyter/a_module.py
@@ -5,13 +5,15 @@ from hydra import initialize, initialize_config_dir, initialize_config_module
 
 
 def hydra_initialize() -> None:
-    initialize(config_path="../../hydra/test_utils/configs")
+    initialize(version_base=None, config_path="../../hydra/test_utils/configs")
 
 
 def hydra_initialize_config_dir() -> None:
     abs_conf_dir = Path.cwd() / "../../hydra/test_utils/configs"
-    initialize_config_dir(config_dir=str(abs_conf_dir))
+    initialize_config_dir(version_base=None, config_dir=str(abs_conf_dir))
 
 
 def hydra_initialize_config_module() -> None:
-    initialize_config_module(config_module="hydra.test_utils.configs")
+    initialize_config_module(
+        version_base=None, config_module="hydra.test_utils.configs"
+    )

--- a/tests/jupyter/test_initialize_in_module.ipynb
+++ b/tests/jupyter/test_initialize_in_module.ipynb
@@ -98,7 +98,7 @@
    ],
    "source": [
     "GlobalHydra.instance().clear()\n",
-    "initialize(config_path=\"../../hydra/test_utils/configs\")\n",
+    "initialize(version_base=None, config_path=\"../../hydra/test_utils/configs\")\n",
     "compose(overrides=[\"+group1=file1\"])"
    ]
   },
@@ -121,7 +121,7 @@
    "source": [
     "GlobalHydra.instance().clear()\n",
     "abs_conf_dir = Path.cwd() / \"../../hydra/test_utils/configs\"\n",
-    "initialize_config_dir(config_dir=str(abs_conf_dir))\n",
+    "initialize_config_dir(version_base=None, config_dir=str(abs_conf_dir))\n",
     "compose(overrides=[\"+group1=file1\"])"
    ]
   },
@@ -143,7 +143,7 @@
    ],
    "source": [
     "GlobalHydra.instance().clear()\n",
-    "initialize_config_module(config_module=\"hydra.test_utils.configs\")\n",
+    "initialize_config_module(version_base=None, config_module=\"hydra.test_utils.configs\")\n",
     "compose(overrides=[\"+group1=file1\"])"
    ]
   }

--- a/tests/standalone_apps/initialization_test_app/initialization_test_app/main.py
+++ b/tests/standalone_apps/initialization_test_app/initialization_test_app/main.py
@@ -6,36 +6,42 @@ from hydra import compose, initialize, initialize_config_dir, initialize_config_
 
 
 def main() -> None:
-    with initialize(config_path="conf"):
+    with initialize(version_base=None, config_path="conf"):
         cfg = compose(config_name="config", return_hydra_config=True)
         assert cfg.config == {"hello": "world"}
         assert cfg.hydra.job.name == "main"
 
-    with initialize(config_path="conf", job_name="test_job"):
+    with initialize(version_base=None, config_path="conf", job_name="test_job"):
         cfg = compose(config_name="config", return_hydra_config=True)
         assert cfg.config == {"hello": "world"}
         assert cfg.hydra.job.name == "test_job"
 
     abs_config_dir = os.path.abspath("initialization_test_app/conf")
-    with initialize_config_dir(config_dir=abs_config_dir):
+    with initialize_config_dir(version_base=None, config_dir=abs_config_dir):
         cfg = compose(config_name="config", return_hydra_config=True)
         assert cfg.config == {"hello": "world"}
         assert cfg.hydra.job.name == "app"
 
-    with initialize_config_dir(config_dir=abs_config_dir, job_name="test_job"):
+    with initialize_config_dir(
+        version_base=None, config_dir=abs_config_dir, job_name="test_job"
+    ):
         cfg = compose(config_name="config", return_hydra_config=True)
         assert cfg.config == {"hello": "world"}
         assert cfg.hydra.job.name == "test_job"
 
     # Those tests can only work if the module is installed
     if len(sys.argv) > 1 and sys.argv[1] == "module_installed":
-        with initialize_config_module(config_module="initialization_test_app.conf"):
+        with initialize_config_module(
+            version_base=None, config_module="initialization_test_app.conf"
+        ):
             cfg = compose(config_name="config", return_hydra_config=True)
             assert cfg.config == {"hello": "world"}
             assert cfg.hydra.job.name == "app"
 
         with initialize_config_module(
-            config_module="initialization_test_app.conf", job_name="test_job"
+            version_base=None,
+            config_module="initialization_test_app.conf",
+            job_name="test_job",
         ):
             cfg = compose(config_name="config", return_hydra_config=True)
             assert cfg.config == {"hello": "world"}

--- a/tests/standalone_apps/namespace_pkg_config_source_test/namespace_test/test_namespace.py
+++ b/tests/standalone_apps/namespace_pkg_config_source_test/namespace_test/test_namespace.py
@@ -27,7 +27,9 @@ class TestCoreConfigSources(ConfigSourceTestSuite):
 
 
 def test_config_in_dir() -> None:
-    with initialize(config_path="../some_namespace/namespace_test/dir"):
+    with initialize(
+        version_base=None, config_path="../some_namespace/namespace_test/dir"
+    ):
         config_loader = GlobalHydra.instance().config_loader()
         assert "cifar10" in config_loader.get_group_options("dataset")
         assert "imagenet" in config_loader.get_group_options("dataset")

--- a/tests/test_apps/app_can_fail/my_app.py
+++ b/tests/test_apps/app_can_fail/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path=None)
+@hydra.main(version_base=None)
 def my_app(cfg: DictConfig) -> None:
     val = 1 / cfg.divisor
     print(f"val={val}")

--- a/tests/test_apps/app_change_dir/my_app.py
+++ b/tests/test_apps/app_change_dir/my_app.py
@@ -8,7 +8,7 @@ import hydra
 from hydra.core.hydra_config import HydraConfig
 
 
-@hydra.main(config_path=None)
+@hydra.main(version_base=None)
 def main(_: DictConfig) -> None:
     subdir = Path(HydraConfig.get().run.dir) / Path("subdir")
     subdir.mkdir(exist_ok=True, parents=True)

--- a/tests/test_apps/app_exception/my_app.py
+++ b/tests/test_apps/app_exception/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path=None)
+@hydra.main(version_base=None)
 def my_app(_: DictConfig) -> None:
     1 / 0
 

--- a/tests/test_apps/app_print_hydra_mode/my_app.py
+++ b/tests/test_apps/app_print_hydra_mode/my_app.py
@@ -5,7 +5,7 @@ import hydra
 from hydra.core.hydra_config import HydraConfig
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(_: DictConfig) -> None:
     print(HydraConfig.get().mode)
 

--- a/tests/test_apps/app_with_callbacks/custom_callback/my_app.py
+++ b/tests/test_apps/app_with_callbacks/custom_callback/my_app.py
@@ -38,7 +38,7 @@ class CustomCallback(Callback):
         log.info(f"{self.name} on_multirun_end")
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     log.info(OmegaConf.to_yaml(cfg))
 

--- a/tests/test_apps/app_with_cfg/my_app.py
+++ b/tests/test_apps/app_with_cfg/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(_: DictConfig) -> None:
     pass
 

--- a/tests/test_apps/app_with_cfg_groups/my_app.py
+++ b/tests/test_apps/app_with_cfg_groups/my_app.py
@@ -6,7 +6,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> Any:
     return cfg
 

--- a/tests/test_apps/app_with_cfg_groups_no_header/my_app.py
+++ b/tests/test_apps/app_with_cfg_groups_no_header/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/tests/test_apps/app_with_config_with_free_group/my_app.py
+++ b/tests/test_apps/app_with_config_with_free_group/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(_: DictConfig) -> None:
     pass
 

--- a/tests/test_apps/app_with_multiple_config_dirs/my_app.py
+++ b/tests/test_apps/app_with_multiple_config_dirs/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path=".")
+@hydra.main(version_base=None, config_path=".")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/tests/test_apps/app_with_no_chdir_override/my_app.py
+++ b/tests/test_apps/app_with_no_chdir_override/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path=".")
+@hydra.main(version_base="1.1", config_path=".")
 def my_app(_: DictConfig) -> None:
     pass
 

--- a/tests/test_apps/app_with_pickle_job_info_callback/my_app.py
+++ b/tests/test_apps/app_with_pickle_job_info_callback/my_app.py
@@ -13,7 +13,7 @@ from hydra.core.hydra_config import HydraConfig
 log = logging.getLogger(__name__)
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> str:
     def pickle_cfg(path: Path, obj: Any) -> Any:
         with open(str(path), "wb") as file:

--- a/tests/test_apps/app_with_runtime_config_error/my_app.py
+++ b/tests/test_apps/app_with_runtime_config_error/my_app.py
@@ -8,7 +8,7 @@ def foo(cfg: DictConfig) -> None:
     cfg.foo = "bar"  # does not exist in the config
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     foo(cfg)
 

--- a/tests/test_apps/app_with_unicode_in_config/my_app.py
+++ b/tests/test_apps/app_with_unicode_in_config/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/tests/test_apps/app_without_config/my_app.py
+++ b/tests/test_apps/app_without_config/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path=None)
+@hydra.main(version_base=None)
 def my_app(_: DictConfig) -> None:
     pass
 

--- a/tests/test_apps/custom_env_defaults/my_app.py
+++ b/tests/test_apps/custom_env_defaults/my_app.py
@@ -9,7 +9,7 @@ import hydra
 log = logging.getLogger(__name__)
 
 
-@hydra.main(config_path=None)
+@hydra.main(version_base=None)
 def my_app(_: DictConfig) -> None:
     assert os.getenv("FOO") == "bar"
 

--- a/tests/test_apps/defaults_in_schema_missing/my_app.py
+++ b/tests/test_apps/defaults_in_schema_missing/my_app.py
@@ -34,7 +34,7 @@ cs.store(group="db", name="mysql", node=MySQLConfig, provider="main")
 cs.store(name="config", node=Config, provider="main")
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/tests/test_apps/defaults_pkg_with_dot/my_app.py
+++ b/tests/test_apps/defaults_pkg_with_dot/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(cfg)
 

--- a/tests/test_apps/deprecation_warning/my_app.py
+++ b/tests/test_apps/deprecation_warning/my_app.py
@@ -5,7 +5,7 @@ import hydra
 from hydra._internal.deprecation_warning import deprecation_warning
 
 
-@hydra.main(config_path=None)
+@hydra.main(version_base=None)
 def my_app(cfg: DictConfig) -> None:
     deprecation_warning("Feature FooBar is deprecated")
 

--- a/tests/test_apps/hydra_resolver_in_output_dir/my_app.py
+++ b/tests/test_apps/hydra_resolver_in_output_dir/my_app.py
@@ -5,7 +5,7 @@ import hydra
 from hydra.core.hydra_config import HydraConfig
 
 
-@hydra.main(config_path=None)
+@hydra.main(version_base=None)
 def my_app(_: DictConfig) -> None:
     print(HydraConfig.instance().get().runtime.output_dir)
 

--- a/tests/test_apps/hydra_to_cfg_interpolation/my_app.py
+++ b/tests/test_apps/hydra_to_cfg_interpolation/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(cfg.c)
 

--- a/tests/test_apps/hydra_verbose/my_app.py
+++ b/tests/test_apps/hydra_verbose/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(_: DictConfig) -> None:
     pass
 

--- a/tests/test_apps/init_in_app_without_module/main.py
+++ b/tests/test_apps/init_in_app_without_module/main.py
@@ -4,23 +4,25 @@ import os
 from hydra import compose, initialize, initialize_config_dir
 
 if __name__ == "__main__":
-    with initialize(config_path="."):
+    with initialize(version_base=None, config_path="."):
         cfg = compose(config_name="config", return_hydra_config=True)
         assert cfg.config == {"hello": "world"}
         assert cfg.hydra.job.name == "main"
 
-    with initialize(config_path=".", job_name="test_job"):
+    with initialize(version_base=None, config_path=".", job_name="test_job"):
         cfg = compose(config_name="config", return_hydra_config=True)
         assert cfg.config == {"hello": "world"}
         assert cfg.hydra.job.name == "test_job"
 
     abs_config__dir = os.path.abspath("")
-    with initialize_config_dir(config_dir=abs_config__dir):
+    with initialize_config_dir(version_base=None, config_dir=abs_config__dir):
         cfg = compose(config_name="config", return_hydra_config=True)
         assert cfg.config == {"hello": "world"}
         assert cfg.hydra.job.name == "app"
 
-    with initialize_config_dir(config_dir=abs_config__dir, job_name="test_job"):
+    with initialize_config_dir(
+        version_base=None, config_dir=abs_config__dir, job_name="test_job"
+    ):
         cfg = compose(config_name="config", return_hydra_config=True)
         assert cfg.config == {"hello": "world"}
         assert cfg.hydra.job.name == "test_job"

--- a/tests/test_apps/multirun_structured_conflict/my_app.py
+++ b/tests/test_apps/multirun_structured_conflict/my_app.py
@@ -16,7 +16,7 @@ config_store = ConfigStore.instance()
 config_store.store(group="test", name="default", node=TestConfig)
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def run(config: DictConfig) -> None:
     print(config.test.param)
 

--- a/tests/test_apps/passes_callable_class_to_hydra_main/my_app.py
+++ b/tests/test_apps/passes_callable_class_to_hydra_main/my_app.py
@@ -15,7 +15,7 @@ class MyCallable:
 
 
 my_callable = MyCallable()
-my_app = hydra.main(config_path=None)(my_callable)
+my_app = hydra.main(version_base=None)(my_callable)
 
 if __name__ == "__main__":
     my_app()

--- a/tests/test_apps/run_as_module_1/my_app.py
+++ b/tests/test_apps/run_as_module_1/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/tests/test_apps/run_as_module_2/my_app.py
+++ b/tests/test_apps/run_as_module_2/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/tests/test_apps/run_as_module_3/module/my_app.py
+++ b/tests/test_apps/run_as_module_3/module/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path=None, config_name="config")
+@hydra.main(version_base=None, config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/tests/test_apps/run_as_module_4/module/my_app.py
+++ b/tests/test_apps/run_as_module_4/module/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/tests/test_apps/run_dir_test/my_app.py
+++ b/tests/test_apps/run_dir_test/my_app.py
@@ -9,7 +9,7 @@ from hydra.core.hydra_config import HydraConfig
 from hydra.utils import get_original_cwd
 
 
-@hydra.main(config_path=None)
+@hydra.main(version_base=None)
 def my_app(_: DictConfig) -> None:
     run_dir = str(Path.cwd().relative_to(get_original_cwd()))
     time.sleep(2)

--- a/tests/test_apps/schema_overrides_hydra/my_app.py
+++ b/tests/test_apps/schema_overrides_hydra/my_app.py
@@ -19,7 +19,7 @@ class Config:
 ConfigStore.instance().store(name="config_schema", node=Config)
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: Config) -> None:
     print(
         f"job_name: {HydraConfig().get().job.name}, "

--- a/tests/test_apps/simple_app/my_app.py
+++ b/tests/test_apps/simple_app/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path=None)
+@hydra.main(version_base=None)
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg, resolve=True))
 

--- a/tests/test_apps/simple_interpolation/my_app.py
+++ b/tests/test_apps/simple_interpolation/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(cfg.c)
 

--- a/tests/test_apps/structured_with_none_list/my_app.py
+++ b/tests/test_apps/structured_with_none_list/my_app.py
@@ -17,7 +17,7 @@ cs = ConfigStore.instance()
 cs.store(name="config", node=Config)
 
 
-@hydra.main(config_path=None, config_name="config")
+@hydra.main(version_base=None, config_name="config")
 def main(cfg: DictConfig) -> None:
     print(cfg)
 

--- a/tests/test_apps/sweep_complex_defaults/my_app.py
+++ b/tests/test_apps/sweep_complex_defaults/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/tests/test_apps/sys_exit/my_app.py
+++ b/tests/test_apps/sys_exit/my_app.py
@@ -6,7 +6,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path=None)
+@hydra.main(version_base=None)
 def my_app(_: DictConfig) -> None:
     sys.exit(42)
 

--- a/tests/test_apps/user-config-dir/my_app.py
+++ b/tests/test_apps/user-config-dir/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -12,12 +12,12 @@ from omegaconf import MISSING, OmegaConf
 from pytest import fixture, mark, param, raises, warns
 
 from hydra import (
+    __version__,
     compose,
     initialize,
     initialize_config_dir,
     initialize_config_module,
     version,
-    __version__,
 )
 from hydra._internal.config_search_path_impl import ConfigSearchPathImpl
 from hydra.core.config_search_path import SearchPathQuery
@@ -32,7 +32,7 @@ chdir_hydra_root()
 @fixture
 def initialize_hydra(config_path: Optional[str]) -> Any:
     try:
-        init = initialize(config_path=config_path)
+        init = initialize(version_base=None, config_path=config_path)
         init.__enter__()
         yield
     finally:
@@ -98,7 +98,7 @@ def test_initialize_compat_version_base(hydra_restore_singletons: Any) -> None:
 
 def test_initialize_with_config_path(hydra_restore_singletons: Any) -> None:
     assert not GlobalHydra().is_initialized()
-    initialize(config_path="../hydra/test_utils/configs")
+    initialize(version_base=None, config_path="../hydra/test_utils/configs")
     assert GlobalHydra().is_initialized()
 
     gh = GlobalHydra.instance()
@@ -230,7 +230,10 @@ class TestComposeInits:
     def test_initialize_ctx(
         self, config_file: str, overrides: List[str], expected: Any
     ) -> None:
-        with initialize(config_path="../examples/jupyter_notebooks/cloud_app/conf"):
+        with initialize(
+            version_base=None,
+            config_path="../examples/jupyter_notebooks/cloud_app/conf",
+        ):
             ret = compose(config_file, overrides)
             assert ret == expected
 
@@ -245,6 +248,7 @@ class TestComposeInits:
         ):
             with initialize_config_dir(
                 config_dir="../examples/jupyter_notebooks/cloud_app/conf",
+                version_base=None,
                 job_name="job_name",
             ):
                 ret = compose(config_file, overrides)
@@ -255,6 +259,7 @@ class TestComposeInits:
     ) -> None:
         with initialize_config_module(
             config_module="examples.jupyter_notebooks.cloud_app.conf",
+            version_base=None,
             job_name="job_name",
         ):
             ret = compose(config_file, overrides)
@@ -267,7 +272,7 @@ def test_initialize_ctx_with_absolute_dir(
     with raises(
         HydraException, match=re.escape("config_path in initialize() must be relative")
     ):
-        with initialize(config_path=str(tmpdir)):
+        with initialize(version_base=None, config_path=str(tmpdir)):
             compose(overrides=["+test_group=test"])
 
 
@@ -282,7 +287,10 @@ def test_initialize_config_dir_ctx_with_absolute_dir(
     with open(str(cfg_file), "w") as f:
         OmegaConf.save(cfg, f)
 
-    with initialize_config_dir(config_dir=str(tmpdir)):
+    with initialize_config_dir(
+        config_dir=str(tmpdir),
+        version_base=None,
+    ):
         ret = compose(overrides=["+test_group=test"])
         assert ret == {"test_group": cfg}
 
@@ -294,7 +302,9 @@ def test_jobname_override_initialize_ctx(
     hydra_restore_singletons: Any, job_name: Optional[str], expected: str
 ) -> None:
     with initialize(
-        config_path="../examples/jupyter_notebooks/cloud_app/conf", job_name=job_name
+        version_base=None,
+        config_path="../examples/jupyter_notebooks/cloud_app/conf",
+        job_name=job_name,
     ):
         ret = compose(return_hydra_config=True)
         assert ret.hydra.job.name == expected
@@ -303,26 +313,33 @@ def test_jobname_override_initialize_ctx(
 def test_jobname_override_initialize_config_dir_ctx(
     hydra_restore_singletons: Any, tmpdir: Any
 ) -> None:
-    with initialize_config_dir(config_dir=str(tmpdir), job_name="test_job"):
+    with initialize_config_dir(
+        config_dir=str(tmpdir), version_base=None, job_name="test_job"
+    ):
         ret = compose(return_hydra_config=True)
         assert ret.hydra.job.name == "test_job"
 
 
 def test_initialize_config_module_ctx(hydra_restore_singletons: Any) -> None:
     with initialize_config_module(
-        config_module="examples.jupyter_notebooks.cloud_app.conf"
+        config_module="examples.jupyter_notebooks.cloud_app.conf",
+        version_base=None,
     ):
         ret = compose(return_hydra_config=True)
         assert ret.hydra.job.name == "app"
 
     with initialize_config_module(
-        config_module="examples.jupyter_notebooks.cloud_app.conf", job_name="test_job"
+        config_module="examples.jupyter_notebooks.cloud_app.conf",
+        job_name="test_job",
+        version_base=None,
     ):
         ret = compose(return_hydra_config=True)
         assert ret.hydra.job.name == "test_job"
 
     with initialize_config_module(
-        config_module="examples.jupyter_notebooks.cloud_app.conf", job_name="test_job"
+        config_module="examples.jupyter_notebooks.cloud_app.conf",
+        job_name="test_job",
+        version_base=None,
     ):
         ret = compose(return_hydra_config=True)
         assert ret.hydra.job.name == "test_job"
@@ -336,7 +353,8 @@ def test_missing_init_py_error(hydra_restore_singletons: Any) -> None:
 
     with raises(Exception, match=re.escape(expected)):
         with initialize_config_module(
-            config_module="hydra.test_utils.configs.missing_init_py"
+            config_module="hydra.test_utils.configs.missing_init_py",
+            version_base=None,
         ):
             hydra = GlobalHydra.instance().hydra
             assert hydra is not None
@@ -350,7 +368,10 @@ def test_missing_bad_config_dir_error(hydra_restore_singletons: Any) -> None:
     )
 
     with raises(Exception, match=re.escape(expected)):
-        with initialize_config_dir(config_dir="/no_way_in_hell_1234567890"):
+        with initialize_config_dir(
+            config_dir="/no_way_in_hell_1234567890",
+            version_base=None,
+        ):
             hydra = GlobalHydra.instance().hydra
             assert hydra is not None
             compose(config_name="test.yaml", overrides=[])
@@ -358,7 +379,9 @@ def test_missing_bad_config_dir_error(hydra_restore_singletons: Any) -> None:
 
 def test_initialize_with_module(hydra_restore_singletons: Any) -> None:
     with initialize_config_module(
-        config_module="tests.test_apps.app_with_cfg_groups.conf", job_name="my_pp"
+        config_module="tests.test_apps.app_with_cfg_groups.conf",
+        job_name="my_pp",
+        version_base=None,
     ):
         assert compose(config_name="config") == {
             "optimizer": {"type": "nesterov", "lr": 0.001}
@@ -366,7 +389,9 @@ def test_initialize_with_module(hydra_restore_singletons: Any) -> None:
 
 
 def test_hydra_main_passthrough(hydra_restore_singletons: Any) -> None:
-    with initialize(config_path="test_apps/app_with_cfg_groups/conf"):
+    with initialize(
+        version_base=None, config_path="test_apps/app_with_cfg_groups/conf"
+    ):
         from tests.test_apps.app_with_cfg_groups.my_app import my_app  # type: ignore
 
         cfg = compose(config_name="config", overrides=["optimizer.lr=1.0"])
@@ -649,7 +674,9 @@ def test_deprecated_initialize_config_dir() -> None:
             "hydra.experimental.initialize_config_dir() is no longer experimental. Use hydra.initialize_config_dir()"
         ),
     ):
-        with expr_initialize_config_dir(config_dir=str(Path(".").absolute())):
+        with expr_initialize_config_dir(
+            config_dir=str(Path(".").absolute()),
+        ):
             assert compose() == {}
 
 
@@ -666,7 +693,7 @@ def test_deprecated_initialize_config_module() -> None:
         ),
     ):
         with expr_initialize_config_module(
-            config_module="examples.jupyter_notebooks.cloud_app.conf"
+            config_module="examples.jupyter_notebooks.cloud_app.conf",
         ):
             assert compose() == {}
 

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -11,7 +11,14 @@ from typing import Any, Dict, List, Optional
 from omegaconf import MISSING, OmegaConf
 from pytest import fixture, mark, param, raises, warns
 
-from hydra import compose, initialize, initialize_config_dir, initialize_config_module, version, __version__
+from hydra import (
+    compose,
+    initialize,
+    initialize_config_dir,
+    initialize_config_module,
+    version,
+    __version__,
+)
 from hydra._internal.config_search_path_impl import ConfigSearchPathImpl
 from hydra.core.config_search_path import SearchPathQuery
 from hydra.core.config_store import ConfigStore
@@ -35,7 +42,7 @@ def initialize_hydra(config_path: Optional[str]) -> Any:
 @fixture
 def initialize_hydra_no_path() -> Any:
     try:
-        init = initialize(config_path=None)
+        init = initialize(version_base=None)
         init.__enter__()
         yield
     finally:
@@ -44,7 +51,7 @@ def initialize_hydra_no_path() -> Any:
 
 def test_initialize(hydra_restore_singletons: Any) -> None:
     assert not GlobalHydra().is_initialized()
-    initialize(config_path=None)
+    initialize(version_base=None)
     assert GlobalHydra().is_initialized()
 
 
@@ -610,7 +617,7 @@ def test_deprecated_compose() -> None:
     from hydra import initialize
     from hydra.experimental import compose as expr_compose
 
-    with initialize(config_path=None):
+    with initialize(version_base=None):
         with warns(
             expected_warning=UserWarning,
             match=re.escape(

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -881,15 +881,19 @@ def test_sys_exit(tmpdir: Path) -> None:
 @mark.parametrize(
     "task_config, overrides, expected_dir",
     [
-        ({"hydra": {"run": {"dir": "foo"}}}, [], "foo"),
-        ({}, ["hydra.run.dir=bar"], "bar"),
-        ({"hydra": {"run": {"dir": "foo"}}}, ["hydra.run.dir=boom"], "boom"),
+        ({"hydra": {"run": {"dir": "foo"}}}, ["hydra.job.chdir=True"], "foo"),
+        ({}, ["hydra.run.dir=bar", "hydra.job.chdir=True"], "bar"),
+        (
+            {"hydra": {"run": {"dir": "foo"}}},
+            ["hydra.run.dir=boom", "hydra.job.chdir=True"],
+            "boom",
+        ),
         (
             {
                 "hydra": {"run": {"dir": "foo-${hydra.job.override_dirname}"}},
                 "app": {"a": 1, "b": 2},
             },
-            ["app.a=20"],
+            ["app.a=20", "hydra.job.chdir=True"],
             "foo-app.a=20",
         ),
         (
@@ -897,7 +901,7 @@ def test_sys_exit(tmpdir: Path) -> None:
                 "hydra": {"run": {"dir": "foo-${hydra.job.override_dirname}"}},
                 "app": {"a": 1, "b": 2},
             },
-            ["app.b=10", "app.a=20"],
+            ["app.b=10", "app.a=20", "hydra.job.chdir=True"],
             "foo-app.a=20,app.b=10",
         ),
     ],

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -11,7 +11,7 @@ from typing import Any, List, Optional, Set
 from omegaconf import DictConfig, OmegaConf
 from pytest import mark, param, raises
 
-from hydra import MissingConfigException
+from hydra import MissingConfigException, version
 from hydra.test_utils.test_utils import (
     TSweepRunner,
     TTaskRunner,
@@ -1446,7 +1446,12 @@ def test_hydra_main_without_config_path(tmpdir: Path) -> None:
     _, err = run_python_script(cmd, allow_warnings=True)
 
     expected = dedent(
-        """
+        f"""
+        .*my_app.py:7: UserWarning:
+        The version_base parameter is not specified.
+        Please specify a compatability version level, or None.
+        Will assume defaults for version {version.__compat_version__}
+          @hydra.main()
         .*my_app.py:7: UserWarning:
         config_path is not specified in @hydra.main().
         See https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_hydra_main_config_path for more information.

--- a/tools/configen/configen/configen.py
+++ b/tools/configen/configen/configen.py
@@ -238,7 +238,7 @@ def generate_module(cfg: ConfigenConf, module: ModuleConf) -> str:
     )
 
 
-@hydra.main(config_path=None, config_name="configen_schema")
+@hydra.main(version_base=None, config_name="configen_schema")
 def main(cfg: Config):
     if cfg.init_config_dir is not None:
         init_config(cfg.init_config_dir)

--- a/tools/configen/example/my_app.py
+++ b/tools/configen/example/my_app.py
@@ -18,7 +18,7 @@ ConfigStore.instance().store(
 )
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     user: User = hydra.utils.instantiate(cfg.user)
     admin: Admin = hydra.utils.instantiate(cfg.admin)

--- a/tools/release/release.py
+++ b/tools/release/release.py
@@ -177,7 +177,7 @@ def bump_version(cfg: Config, package: Package, hydra_root: str) -> None:
 OmegaConf.register_new_resolver("parent_key", lambda _parent_: _parent_._key())
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def main(cfg: Config) -> None:
     hydra_root = find_parent_dir_containing(target="ATTRIBUTION")
     build_dir = f"{os.getcwd()}/{cfg.build_dir}"

--- a/website/docs/advanced/compose_api.md
+++ b/website/docs/advanced/compose_api.md
@@ -45,12 +45,12 @@ from omegaconf import OmegaConf
 
 if __name__ == "__main__":
     # context initialization
-    with initialize(config_path="conf", job_name="test_app"):
+    with initialize(version_base=None, config_path="conf", job_name="test_app"):
         cfg = compose(config_name="config", overrides=["db=mysql", "db.user=me"])
         print(OmegaConf.to_yaml(cfg))
 
     # global initialization
-    initialize(config_path="conf", job_name="test_app")
+    initialize(version_base=None, config_path="conf", job_name="test_app")
     cfg = compose(config_name="config", overrides=["db=mysql", "db.user=me"])
     print(OmegaConf.to_yaml(cfg))
 ```

--- a/website/docs/advanced/compose_api.md
+++ b/website/docs/advanced/compose_api.md
@@ -35,6 +35,8 @@ There are 3 initialization methods:
 All 3 can be used as methods or contexts.
 When used as methods, they are initializing Hydra globally and should only be called once.
 When used as contexts, they are initializing Hydra within the context can be used multiple times.
+Like <b>@hydra.main()</b> all three support the [version_base](../upgrades/version_base.md) parameter
+to define the compatability level to use.
 
 ### Code example
 ```python
@@ -71,6 +73,7 @@ def compose(
 
 ```python title="Relative initialization"
 def initialize(
+    version_base: Optional[str],
     config_path: Optional[str] = None,
     job_name: Optional[str] = "app",
     caller_stack_depth: int = 1,
@@ -85,6 +88,7 @@ def initialize(
     - Python modules
     - Unit tests
     - Jupyter notebooks.
+    :param version_base: compatability level to use.
     :param config_path: path relative to the parent of the caller
     :param job_name: the value for hydra.job.name (By default it is automatically detected based on the caller)
     :param caller_stack_depth: stack depth of the caller, defaults to 1 (direct caller).
@@ -92,21 +96,31 @@ def initialize(
 ```
 
 ```python title="Initialzing with config module"
-def initialize_config_module(config_module: str, job_name: str = "app") -> None:
+def initialize_config_module(
+    config_module: str,
+    version_base: Optional[str],
+    job_name: str = "app"
+) -> None:
     """
     Initializes Hydra and add the config_module to the config search path.
     The config module must be importable (an __init__.py must exist at its top level)
     :param config_module: absolute module name, for example "foo.bar.conf".
+    :param version_base: compatability level to use.
     :param job_name: the value for hydra.job.name (default is 'app')
     """
 ```
 ```python title="Initialzing with config directory"
-def initialize_config_dir(config_dir: str, job_name: str = "app") -> None:
+def initialize_config_dir(
+    config_dir: str,
+    version_base: Optional[str],
+    job_name: str = "app"
+) -> None:
     """
     Initializes Hydra and add an absolute config dir to the to the config search path.
     The config_dir is always a path on the file system and is must be an absolute path.
     Relative paths will result in an error.
     :param config_dir: absolute file system path
+    :param version_base: compatability level to use.
     :param job_name: the value for hydra.job.name (default is 'app')
     """
 ```

--- a/website/docs/advanced/instantiate_objects/config_files.md
+++ b/website/docs/advanced/instantiate_objects/config_files.md
@@ -83,7 +83,7 @@ defaults:
 
 With this, you can instantiate the object from the configuration with a single line of code:
 ```python
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg):
     connection = hydra.utils.instantiate(cfg.db)
     connection.connect()

--- a/website/docs/advanced/search_path.md
+++ b/website/docs/advanced/search_path.md
@@ -69,7 +69,7 @@ In this example, we add a second config directory - `additional_conf`, next to t
 
 ```python title="my_app.py"
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/website/docs/advanced/unit_testing.md
+++ b/website/docs/advanced/unit_testing.md
@@ -18,7 +18,7 @@ from hydra import initialize, compose
 #    it needs to have a __init__.py (can be empty).
 # 3. THe config path is relative to the file calling initialize (this file)
 def test_with_initialize() -> None:
-    with initialize(config_path="../hydra_app/conf"):
+    with initialize(version_base=None, config_path="../hydra_app/conf"):
         # config is relative to a module
         cfg = compose(config_name="config", overrides=["app.user=test_user"])
         assert cfg == {

--- a/website/docs/configure_hydra/job.md
+++ b/website/docs/configure_hydra/job.md
@@ -18,7 +18,6 @@ class JobConf:
     name: str = MISSING
 
     # Change current working dir to the output dir.
-    # Will default to False in Hydra 1.3
     chdir: bool = True
 
     # Concatenation of job overrides that can be used as a part

--- a/website/docs/experimental/callbacks.md
+++ b/website/docs/experimental/callbacks.md
@@ -88,7 +88,7 @@ class MyCallback(Callback):
         print(f"Job ended,uploading...")
         # uploading...
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -55,7 +55,7 @@ Application:
 import hydra
 from omegaconf import DictConfig, OmegaConf
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg : DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/website/docs/tutorials/basic/your_first_app/1_simple_cli.md
+++ b/website/docs/tutorials/basic/your_first_app/1_simple_cli.md
@@ -17,7 +17,7 @@ The examples in this tutorial are available <GithubLink to="examples/tutorials/b
 from omegaconf import DictConfig, OmegaConf
 import hydra
 
-@hydra.main(config_path=None)
+@hydra.main(version_base=None)
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 
@@ -37,7 +37,7 @@ db:
 ```
 
 :::info
-We will learn more about the `config_path` in the following pages. 
+See the [version_base page](../../../upgrades/version_base.md) for details on the version_base parameter.
 :::
 
 See [Hydra's command line flags](advanced/hydra-command-line-flags.md) and

--- a/website/docs/tutorials/basic/your_first_app/2_config_file.md
+++ b/website/docs/tutorials/basic/your_first_app/2_config_file.md
@@ -25,7 +25,7 @@ Hydra also needs to know where to find your config. Specify the directory contai
 from omegaconf import DictConfig, OmegaConf
 import hydra
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg):
     print(OmegaConf.to_yaml(cfg))
 

--- a/website/docs/tutorials/basic/your_first_app/3_using_config.md
+++ b/website/docs/tutorials/basic/your_first_app/3_using_config.md
@@ -21,7 +21,7 @@ node:                         # Config is hierarchical
 from omegaconf import DictConfig, OmegaConf
 import hydra
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig):
     assert cfg.node.loompa == 10          # attribute style access
     assert cfg["node"]["loompa"] == 10    # dictionary style access

--- a/website/docs/tutorials/basic/your_first_app/4_config_groups.md
+++ b/website/docs/tutorials/basic/your_first_app/4_config_groups.md
@@ -58,7 +58,7 @@ Since we moved all the configs into the `conf` directory, we need to tell Hydra 
 from omegaconf import DictConfig, OmegaConf
 import hydra
 
-@hydra.main(config_path="conf")
+@hydra.main(version_base=None, config_path="conf")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/website/docs/tutorials/basic/your_first_app/5_defaults.md
+++ b/website/docs/tutorials/basic/your_first_app/5_defaults.md
@@ -27,7 +27,7 @@ Remember to specify the `config_name`:
 from omegaconf import DictConfig, OmegaConf
 import hydra
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/website/docs/tutorials/structured_config/10_config_store.md
+++ b/website/docs/tutorials/structured_config/10_config_store.md
@@ -47,7 +47,7 @@ Say we have a simple application and a `db` config group with a `mysql` option:
 <div className="col col--5">
 
 ```python title="my_app.py"
-@hydra.main(config_path="conf")
+@hydra.main(version_base=None, config_path="conf")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 
@@ -99,7 +99,7 @@ cs = ConfigStore.instance()
 # Registering the Config class with the name `postgresql` with the config group `db`
 cs.store(name="postgresql", group="db", node=PostgresSQLConfig)
 
-@hydra.main(config_path="conf")
+@hydra.main(version_base=None, config_path="conf")
 def my_app(cfg: DictConfig) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/website/docs/tutorials/structured_config/1_minimal_example.md
+++ b/website/docs/tutorials/structured_config/1_minimal_example.md
@@ -30,7 +30,7 @@ cs = ConfigStore.instance()
 # Registering the Config class with the name 'config'.
 cs.store(name="config", node=MySQLConfig)
 
-@hydra.main(config_path=None, config_name="config")
+@hydra.main(version_base=None, config_name="config")
 def my_app(cfg: MySQLConfig) -> None:
     # pork should be port!
     if cfg.pork == 80:

--- a/website/docs/tutorials/structured_config/2_hierarchical_static_config.md
+++ b/website/docs/tutorials/structured_config/2_hierarchical_static_config.md
@@ -35,7 +35,7 @@ class MyConfig:
 cs = ConfigStore.instance()
 cs.store(name="config", node=MyConfig)
 
-@hydra.main(config_path=None, config_name="config")
+@hydra.main(version_base=None, config_name="config")
 def my_app(cfg: MyConfig) -> None:
     print(f"Title={cfg.ui.title}, size={cfg.ui.width}x{cfg.ui.height} pixels")
 

--- a/website/docs/tutorials/structured_config/3_config_groups.md
+++ b/website/docs/tutorials/structured_config/3_config_groups.md
@@ -40,7 +40,7 @@ cs.store(name="config", node=Config)
 cs.store(group="db", name="mysql", node=MySQLConfig)
 cs.store(group="db", name="postgresql", node=PostGreSQLConfig)
 
-@hydra.main(config_path=None, config_name="config")
+@hydra.main(version_base=None, config_name="config")
 def my_app(cfg: Config) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/website/docs/tutorials/structured_config/4_defaults.md
+++ b/website/docs/tutorials/structured_config/4_defaults.md
@@ -48,7 +48,7 @@ cs.store(group="db", name="postgresql", node=PostGreSQLConfig)
 cs.store(name="config", node=Config)
 
 
-@hydra.main(config_path=None, config_name="config")
+@hydra.main(version_base=None, config_name="config")
 def my_app(cfg: Config) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/website/docs/tutorials/structured_config/5_schema.md
+++ b/website/docs/tutorials/structured_config/5_schema.md
@@ -111,7 +111,7 @@ cs.store(name="base_config", node=Config)
 cs.store(group="db", name="base_mysql", node=MySQLConfig)
 cs.store(group="db", name="base_postgresql", node=PostGreSQLConfig)
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: Config) -> None:
     print(OmegaConf.to_yaml(cfg))
 

--- a/website/docs/upgrades/1.0_to_1.1/hydra_main_config_path.md
+++ b/website/docs/upgrades/1.0_to_1.1/hydra_main_config_path.md
@@ -23,7 +23,7 @@ hydra.initialize(config_path="conf")
 ### No config directory
 For applications that do not define config files next to the Python script (typically applications using only Structured Configs), it is recommended that
 you pass `None` as the config_path, indicating that no directory should be added to the config search path.
-This will become the default in Hydra 1.2.
+This will become the default with version_base >= "1.2"
 ```python
 @hydra.main(config_path=None)
 # or:

--- a/website/docs/upgrades/1.0_to_1.1/hydra_main_config_path.md
+++ b/website/docs/upgrades/1.0_to_1.1/hydra_main_config_path.md
@@ -23,7 +23,7 @@ hydra.initialize(config_path="conf")
 ### No config directory
 For applications that do not define config files next to the Python script (typically applications using only Structured Configs), it is recommended that
 you pass `None` as the config_path, indicating that no directory should be added to the config search path.
-This will become the default with version_base >= "1.2"
+This will become the default with [version_base](../version_base.md) >= "1.2"
 ```python
 @hydra.main(config_path=None)
 # or:

--- a/website/docs/upgrades/1.1_to_1.2/changes_to_job_working_dir.md
+++ b/website/docs/upgrades/1.1_to_1.2/changes_to_job_working_dir.md
@@ -5,11 +5,11 @@ hide_title: true
 ---
 
 Hydra 1.2 introduces `hydra.job.chdir`. This config allows users to specify whether Hydra should change the runtime working
-directory to the job's output directory. A warning will be issued if `hydra.job.chdir` is not set. 
-In Hydra 1.3, `hydra.job.chdir` will default to `False`.
+directory to the job's output directory.
+`hydra.job.chdir` will default to `False` if version_base is set to >= "1.2" (or None),
+or otherwise will use the old behavior and default to `True`, with a warning being issued if `hydra.job.chdir` is not set.
 
-If you want to keep the old Hydra behavior, please set `hydra.job.chdir=True` explicitly for you application so it will not
-be broken by future upgrades.
+If you want to keep the old Hydra behavior, please set `hydra.job.chdir=True` explicitly for your application.
 
 For more information about `hydra.job.chdir`,
 see [Output/Working directory](/tutorials/basic/running_your_app/3_working_directory.md#disable-changing-current-working-dir-to-jobs-output-dir)

--- a/website/docs/upgrades/1.1_to_1.2/hydra_main_config_path.md
+++ b/website/docs/upgrades/1.1_to_1.2/hydra_main_config_path.md
@@ -1,0 +1,8 @@
+---
+id: changes_to_hydra_main_config_path
+title: Changes to @hydra.main() and hydra.initialize()
+---
+
+Prior to Hydra 1.2, **@hydra.main()** and **hydra.initialize()** default `config path` was the directory containing the Python app (calling **@hydra.main()** or **hydra.initialize()**).
+Starting with Hydra 1.1 we give [control over the default config path](../1.0_to_1.1/hydra_main_config_path.md),
+and starting with Hydra 1.2, with version_base >= "1.2", we choose a default config_path=None, indicating that no directory should be added to the config search path.

--- a/website/docs/upgrades/1.1_to_1.2/hydra_main_config_path.md
+++ b/website/docs/upgrades/1.1_to_1.2/hydra_main_config_path.md
@@ -5,4 +5,4 @@ title: Changes to @hydra.main() and hydra.initialize()
 
 Prior to Hydra 1.2, **@hydra.main()** and **hydra.initialize()** default `config path` was the directory containing the Python app (calling **@hydra.main()** or **hydra.initialize()**).
 Starting with Hydra 1.1 we give [control over the default config path](../1.0_to_1.1/hydra_main_config_path.md),
-and starting with Hydra 1.2, with version_base >= "1.2", we choose a default config_path=None, indicating that no directory should be added to the config search path.
+and starting with Hydra 1.2, with [version_base](../version_base.md) >= "1.2", we choose a default config_path=None, indicating that no directory should be added to the config search path.

--- a/website/docs/upgrades/intro.md
+++ b/website/docs/upgrades/intro.md
@@ -5,7 +5,9 @@ sidebar_label: Introduction
 ---
 
 Upgrading to a new Hydra version is usually an easy process.
-
+Also since Hydra version 1.2, backwards compatibility is improved
+by giving the user more control over appropriate defaults
+through the use of the [version_base parameter](version_base.md).
 
 :::info NOTE
 Hydra versioning has only major versions and patch versions. A bump of the first two version digits is considered a major release.

--- a/website/docs/upgrades/version_base.md
+++ b/website/docs/upgrades/version_base.md
@@ -16,4 +16,4 @@ Also in this case, a warning is issued to indicate an explicit `version_base` is
 For example for Hydra 1.2, then would imply `config_path=None` and `hydra.job.chdir=False`.
 
 3. If the `version_base` parameter is an **explicit version string** like "1.1",
-then the default appropriate to that version are used.
+then the defaults appropriate to that version are used.

--- a/website/docs/upgrades/version_base.md
+++ b/website/docs/upgrades/version_base.md
@@ -1,0 +1,19 @@
+---
+id: version_base
+title: version_base
+---
+
+Hydra since version 1.2 supports backwards compatible upgrades by default
+through the use of the `version_base` parameter to **@hydra.main()** and **hydra.initialize()**.
+
+There are three classes of values that the `version_base` parameter supports,
+given new and existing users greater control of the default behaviors to use.
+
+1. If the `version_base` parameter is **not specified**, Hydra 1.x will use defaults compatible with version 1.1.
+Also in this case, a warning is issued to indicate an explicit `version_base` is preferred.
+
+2. If the `version_base` parameter is **None**, then the defaults are chosen for the current minor Hydra version.
+For example for Hydra 1.2, then would imply `config_path=None` and `hydra.job.chdir=False`.
+
+3. If the `version_base` parameter is an **explicit version string** like "1.1",
+then the default appropriate to that version are used.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -145,6 +145,7 @@ module.exports = {
 
         'Upgrade Guide': [
             'upgrades/intro',
+            'upgrades/version_base',
             {
                 type: 'category',
                 label: '1.1 to 1.2',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -149,6 +149,7 @@ module.exports = {
                 type: 'category',
                 label: '1.1 to 1.2',
                 items: [
+                    'upgrades/1.1_to_1.2/changes_to_hydra_main_config_path',
                     'upgrades/1.1_to_1.2/changes_to_job_working_dir',
                     'upgrades/1.1_to_1.2/changes_to_sweeper_config',
                 ],


### PR DESCRIPTION
Add the "version_base" parameter to hydra.main,
which acts as central way to select the defaults for that version.

Without a specified "version_base" the user will get a warning,
and we'll default to the currently supported minimum version defaults
(currently those of version 1.1).

Specifying a "version_base" will suffice to select appropriate defaults,
rather than requiring one explicitly set other config items like
config_path, or hydra.job.chdir.

New hydra uses should use version_base=None to get
the default set of the currently installed version.