### PR TITLE
Support `config_path=pathlib.Path(...)`

### DIFF
--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -5,6 +5,7 @@ import string
 import sys
 from argparse import ArgumentParser
 from collections import defaultdict
+from pathlib import Path
 from typing import Any, Callable, DefaultDict, List, Optional, Sequence, Type, Union
 
 from omegaconf import Container, DictConfig, OmegaConf, flag_override
@@ -43,7 +44,7 @@ class Hydra:
         cls: Type["Hydra"],
         calling_file: Optional[str],
         calling_module: Optional[str],
-        config_path: Optional[str],
+        config_path: Optional[Union[str, Path]],
         job_name: str,
     ) -> "Hydra":
         config_search_path = create_automatic_config_search_path(

--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -275,7 +275,7 @@ class JobRuntime(metaclass=Singleton):
         self.conf[key] = value
 
 
-def validate_config_path(config_path: Optional[str]) -> None:
+def validate_config_path(config_path: Optional[Union[str, Path]]) -> None:
     if config_path is not None:
         split_file = splitext(config_path)
         if split_file[1] in (".yaml", ".yml"):

--- a/hydra/initialize.py
+++ b/hydra/initialize.py
@@ -1,8 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import copy
 import os
+from pathlib import Path
 from textwrap import dedent
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from hydra._internal.deprecation_warning import deprecation_warning
 from hydra._internal.hydra import Hydra
@@ -51,7 +52,7 @@ class initialize:
 
     def __init__(
         self,
-        config_path: Optional[str] = _UNSPECIFIED_,
+        config_path: Optional[Union[str, Path]] = _UNSPECIFIED_,
         job_name: Optional[str] = None,
         caller_stack_depth: int = 1,
     ) -> None:
@@ -135,7 +136,7 @@ class initialize_config_dir:
     :param job_name: the value for hydra.job.name (default is 'app')
     """
 
-    def __init__(self, config_dir: str, job_name: str = "app") -> None:
+    def __init__(self, config_dir: Union[str, Path], job_name: str = "app") -> None:
         self._gh_backup = get_gh_backup()
         # Relative here would be interpreted as relative to cwd, which - depending on when it run
         # may have unexpected meaning. best to force an absolute path to avoid confusion.

--- a/hydra/main.py
+++ b/hydra/main.py
@@ -1,7 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import functools
+from pathlib import Path
 from textwrap import dedent
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Union
 
 from omegaconf import DictConfig
 
@@ -13,7 +14,7 @@ _UNSPECIFIED_: Any = object()
 
 
 def main(
-    config_path: Optional[str] = _UNSPECIFIED_,
+    config_path: Optional[Union[str, Path]] = _UNSPECIFIED_,
     config_name: Optional[str] = None,
 ) -> Callable[[TaskFunction], Any]:
     """

--- a/news/2067.feature
+++ b/news/2067.feature
@@ -1,0 +1,1 @@
+Allow passing `pathlib.Path` instances as the `config_path`/`config_dir` argument to `hydra.main`, `hydra.initialize`, and `hydra.initialize_config_dir`.

--- a/tests/test_config_search_path.py
+++ b/tests/test_config_search_path.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import os
 from os.path import realpath
+from pathlib import Path
 from typing import List, Optional, Tuple
 
 from pytest import mark
@@ -155,20 +156,38 @@ def test_prepend(
         ("foo.py", None, None, None),
         ("foo/bar.py", None, None, None),
         ("foo/bar.py", None, "conf", realpath("foo/conf")),
+        ("foo/bar.py", None, Path("conf"), realpath("foo/conf")),
         ("foo/bar.py", None, "../conf", realpath("conf")),
+        ("foo/bar.py", None, Path("../conf"), realpath("conf")),
         ("c:/foo/bar.py", None, "conf", realpath("c:/foo/conf")),
+        ("c:/foo/bar.py", None, Path("conf"), realpath("c:/foo/conf")),
         ("c:/foo/bar.py", None, "../conf", realpath("c:/conf")),
+        ("c:/foo/bar.py", None, Path("../conf"), realpath("c:/conf")),
         (None, "module", None, "pkg://"),
         (None, "package.module", None, "pkg://package"),
         (None, "package.module", "conf", "pkg://package/conf"),
+        (None, "package.module", Path("conf"), "pkg://package/conf"),
         # This is an unusual one. this behavior is intentional.
         (None, "package.module", "../conf", "pkg://conf"),
+        (None, "package.module", Path("../conf"), "pkg://conf"),
         (None, "package1.rename_package_to.module", "../conf", "pkg://package1/conf"),
+        (
+            None,
+            "package1.rename_package_to.module",
+            Path("../conf"),
+            "pkg://package1/conf",
+        ),
         # prefer directory
         (
             "foo",
             "package1.rename_package_to.module",
             "../conf",
+            os.path.realpath(os.path.join(os.getcwd(), "../conf")),
+        ),
+        (
+            "foo",
+            "package1.rename_package_to.module",
+            Path("../conf"),
             os.path.realpath(os.path.join(os.getcwd(), "../conf")),
         ),
     ],


### PR DESCRIPTION
This PR implements support for passing instances of `pathlib.Path` as the `config_path` or `config_dir` arguments to the functions `hydra.main`/`hydra.initialize`/`hydra.initialize_config_dir`.
Previously, `str` was supported but `Path` was not.

Closes #2067.
