### PR TITLE
requirements.txt: omegaconf~=2.1

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
-omegaconf==2.1.*
+omegaconf~=2.1
 antlr4-python3-runtime==4.8
 importlib-resources;python_version<'3.9'


### PR DESCRIPTION
Change the pin `omegaconf==2.1.*` to `omegaconf~=2.1`
to allow compatibility with omegaconf v2.2 dev release.
Related to https://github.com/facebookresearch/hydra/issues/2088