### PR TITLE
Add Callback for saving pickled job info

### DIFF
--- a/hydra/experimental/pickle_job_info_callback.py
+++ b/hydra/experimental/pickle_job_info_callback.py
@@ -22,17 +22,17 @@ class PickleJobInfoCallback(Callback):
         )
         filename = "config.pickle"
         self._save_pickle(obj=config, filename=filename, output_dir=self.output_dir)
-        log.info(f"Saving job configs in {str(self.output_dir / filename)}")
+        log.info(f"Saving job configs in {self.output_dir / filename}")
 
     def on_job_end(
         self, config: DictConfig, job_return: JobReturn, **kwargs: Any
     ) -> None:
         filename = "job_return.pickle"
         self._save_pickle(obj=job_return, filename=filename, output_dir=self.output_dir)
-        log.info(f"Saving job_return in {str(self.output_dir / filename)}")
+        log.info(f"Saving job_return in {self.output_dir / filename}")
 
     def _save_pickle(self, obj: Any, filename: str, output_dir: Path) -> None:
         output_dir.mkdir(parents=True, exist_ok=True)
         assert output_dir is not None
         with open(str(output_dir / filename), "wb") as file:
-            pickle.dump(obj, file)
+            pickle.dump(obj, file, protocol=pickle.HIGHEST_PROTOCOL)

--- a/hydra/experimental/pickle_job_info_callback.py
+++ b/hydra/experimental/pickle_job_info_callback.py
@@ -35,4 +35,4 @@ class PickleJobInfoCallback(Callback):
         output_dir.mkdir(parents=True, exist_ok=True)
         assert output_dir is not None
         with open(str(output_dir / filename), "wb") as file:
-            pickle.dump(obj, file, protocol=pickle.HIGHEST_PROTOCOL)
+            pickle.dump(obj, file, protocol=4)

--- a/hydra/experimental/pikcle_job_info_callback.py
+++ b/hydra/experimental/pikcle_job_info_callback.py
@@ -1,0 +1,38 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import logging
+import pickle
+from pathlib import Path
+from typing import Any
+
+from omegaconf import DictConfig
+
+from hydra.core.utils import JobReturn
+from hydra.experimental.callback import Callback
+
+log = logging.getLogger(__name__)
+
+
+class PickleJobInfoCallback(Callback):
+    output_dir: Path
+
+    def on_job_start(self, config: DictConfig, **kwargs: Any) -> None:
+        self.output_dir = Path(config.hydra.runtime.output_dir) / Path(
+            config.hydra.output_subdir
+        )
+        filename = "config.pickle"
+        self._save_pickle(obj=config, filename=filename, output_dir=self.output_dir)
+        log.info(f"Saving job configs in {str(self.output_dir / filename)}")
+
+    def on_job_end(
+        self, config: DictConfig, job_return: JobReturn, **kwargs: Any
+    ) -> None:
+        filename = "job_return.pickle"
+        self._save_pickle(obj=job_return, filename=filename, output_dir=self.output_dir)
+        log.info(f"Saving job_return in {str(self.output_dir / filename)}")
+
+    def _save_pickle(self, obj: Any, filename: str, output_dir: Path) -> None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        assert output_dir is not None
+        with open(str(output_dir / filename), "wb") as file:
+            pickle.dump(obj, file)

--- a/news/2092.feature
+++ b/news/2092.feature
@@ -1,0 +1,1 @@
+Add experimental Callback for pickling job info.

--- a/tests/test_apps/app_with_pickle_job_info_callback/__init__.py
+++ b/tests/test_apps/app_with_pickle_job_info_callback/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/tests/test_apps/app_with_pickle_job_info_callback/config.yaml
+++ b/tests/test_apps/app_with_pickle_job_info_callback/config.yaml
@@ -1,0 +1,6 @@
+foo: bar
+
+hydra:
+  callbacks:
+    save_job_info:
+      _target_: hydra.experimental.pikcle_job_info_callback.PickleJobInfoCallback

--- a/tests/test_apps/app_with_pickle_job_info_callback/config.yaml
+++ b/tests/test_apps/app_with_pickle_job_info_callback/config.yaml
@@ -3,4 +3,4 @@ foo: bar
 hydra:
   callbacks:
     save_job_info:
-      _target_: hydra.experimental.pikcle_job_info_callback.PickleJobInfoCallback
+      _target_: hydra.experimental.pickle_job_info_callback.PickleJobInfoCallback

--- a/tests/test_apps/app_with_pickle_job_info_callback/my_app.py
+++ b/tests/test_apps/app_with_pickle_job_info_callback/my_app.py
@@ -1,0 +1,31 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import logging
+import pickle
+from pathlib import Path
+from typing import Any
+
+from omegaconf import DictConfig
+
+import hydra
+from hydra.core.hydra_config import HydraConfig
+
+log = logging.getLogger(__name__)
+
+
+@hydra.main(config_path=".", config_name="config")
+def my_app(cfg: DictConfig) -> str:
+    def pickle_cfg(path: Path, obj: Any) -> Any:
+        with open(str(path), "wb") as file:
+            pickle.dump(obj, file)
+
+    hydra_cfg = HydraConfig.get()
+    output_dir = Path(hydra_cfg.runtime.output_dir)
+    pickle_cfg(Path(output_dir) / "task_cfg.pickle", cfg)
+    pickle_cfg(Path(output_dir) / "hydra_cfg.pickle", hydra_cfg)
+
+    return "hello world"
+
+
+if __name__ == "__main__":
+    my_app()


### PR DESCRIPTION
Add an experimental Callback for pickling job info. Having this as a Callback enables users to opt-in this behavior. 

The doc updates will come after all of #1805 is completed. 