### PR TITLE
Add '-' char in ID.

### DIFF
--- a/hydra/grammar/OverrideLexer.g4
+++ b/hydra/grammar/OverrideLexer.g4
@@ -25,7 +25,7 @@ COLON: ':';
 SLASH: '/';
 
 KEY_ID: ID -> type(ID);
-KEY_SPECIAL: (CHAR|'_'|'$') (CHAR|DIGIT|'_'|'$')*;  // same as ID but allowing $
+KEY_SPECIAL: (CHAR|'_'|'$') (CHAR|DIGIT|'_'|'-'|'$')*;  // same as ID but allowing $
 DOT_PATH: (KEY_SPECIAL | INT_UNSIGNED) ('.' (KEY_SPECIAL | INT_UNSIGNED))+;
 
 ////////////////
@@ -60,7 +60,7 @@ BOOL:
 NULL: [Nn][Uu][Ll][Ll];
 
 UNQUOTED_CHAR: [/\-\\+.$%*@?|];  // other characters allowed in unquoted strings
-ID: (CHAR|'_') (CHAR|DIGIT|'_')*;
+ID: (CHAR|'_') (CHAR|DIGIT|'_'|'-')*;
 // Note: when adding more characters to the ESC rule below, also add them to
 // the `_ESC` string in `_internal/grammar/utils.py`.
 ESC: (ESC_BACKSLASH | '\\(' | '\\)' | '\\[' | '\\]' | '\\{' | '\\}' |

--- a/hydra/grammar/OverrideParser.g4
+++ b/hydra/grammar/OverrideParser.g4
@@ -53,7 +53,7 @@ dictKeyValuePair: dictKey COLON element;
 
 primitive:
       QUOTED_VALUE                               // 'hello world', "hello world"
-    | (   ID                                     // foo_10
+    | (   ID                                     // foo-bar_10
         | NULL                                   // null, NULL
         | INT                                    // 0, 10, -20, 1_000_000
         | FLOAT                                  // 3.14, -20.0, 1e-1, -10e3
@@ -67,7 +67,7 @@ primitive:
 
 // Same as `primitive` except that `COLON` and `INTERPOLATION` are not allowed.
 dictKey:
-    (   ID                                     // foo_10
+    (   ID                                     // foo-bar_10
       | NULL                                   // null, NULL
       | INT                                    // 0, 10, -20, 1_000_000
       | FLOAT                                  // 3.14, -20.0, 1e-1, -10e3

--- a/news/2363.feature
+++ b/news/2363.feature
@@ -1,0 +1,1 @@
+Allow for non-leading dashes in override keys

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -536,6 +536,7 @@ def test_parse_errors(rule: str, value: str, expected: Any) -> None:
         param("abc.cde", "abc.cde", id="package"),
         param("$foo", "$foo", id="package_dollar"),
         param("$foo.bar$.x$z", "$foo.bar$.x$z", id="package_dollar_dotpath"),
+        param("ab-c", "ab-c", id="package"),
     ],
 )
 def test_package(value: str, expected: Any) -> None:
@@ -551,6 +552,8 @@ def test_package(value: str, expected: Any) -> None:
         param("$foo", "$foo", id="package_dollar"),
         param("$foo.bar$.x$z", "$foo.bar$.x$z", id="package_dollar_dotpath"),
         param("a/b/c", "a/b/c", id="group"),
+        param("a-b/c", "a-b/c", id="group"),
+        param("a-b", "a-b", id="package"),
     ],
 )
 def test_package_or_group(value: str, expected: Any) -> None:
@@ -564,6 +567,8 @@ def test_package_or_group(value: str, expected: Any) -> None:
         param("abc", Key(key_or_group="abc"), id="abc"),
         param("abc/cde", Key(key_or_group="abc/cde"), id="abc/cde"),
         param("abc.cde", Key(key_or_group="abc.cde"), id="abc.cde"),
+        param("ab-c/d-ef", Key(key_or_group="ab-c/d-ef"), id="ab-c/d-ef"),
+        param("ab-c.d-ef", Key(key_or_group="ab-c.d-ef"), id="ab-c.d-ef"),
         param("$foo", Key(key_or_group="$foo"), id="dollar"),
         param("$foo.bar$.x$z", Key(key_or_group="$foo.bar$.x$z"), id="dollar_dotpath"),
         param("list.0", Key(key_or_group="list.0"), id="list.0"),

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -552,8 +552,8 @@ def test_package(value: str, expected: Any) -> None:
         param("$foo", "$foo", id="package_dollar"),
         param("$foo.bar$.x$z", "$foo.bar$.x$z", id="package_dollar_dotpath"),
         param("a/b/c", "a/b/c", id="group"),
-        param("a-b/c", "a-b/c", id="group"),
-        param("a-b", "a-b", id="package"),
+        param("a-b/c", "a-b/c", id="group_with_dash"),
+        param("a-b", "a-b", id="package_with_dash"),
     ],
 )
 def test_package_or_group(value: str, expected: Any) -> None:

--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -78,7 +78,7 @@ dictKeyValuePair: dictKey COLON element;
 
 primitive:
       QUOTED_VALUE                               // 'hello world', "hello world"
-    | (   ID                                     // foo_10
+    | (   ID                                     // foo-bar_10
         | NULL                                   // null, NULL
         | INT                                    // 0, 10, -20, 1_000_000
         | FLOAT                                  // 3.14, -20.0, 1e-1, -10e3
@@ -92,7 +92,7 @@ primitive:
 
 // Same as `primitive` except that `COLON` and `INTERPOLATION` are not allowed.
 dictKey:
-    (   ID                                     // foo_10
+    (   ID                                     // foo-bar_10
       | NULL                                   // null, NULL
       | INT                                    // 0, 10, -20, 1_000_000
       | FLOAT                                  // 3.14, -20.0, 1e-1, -10e3


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

The override grammar doesn't handle the `'-'` character in the ID of groups even though the yaml file does not have this issue.
For example, this is perfectly acceptable in the yaml file :
```yaml
defaults:
  - /models/classifier-heads@head: old_name
```
but the override parameter `'models/classifier-heads@head=new_name'` throws an error indicating the group ID is incorrect.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

* Ran `python setup.py antlr`.
* Ran `pytest` (python 3.8).
* Replaced my `hydra/grammar/gen` folder by newly generated one and tested on my setup similar to the example described above.

## Related Issues and PRs

N/A