### PR TITLE
Add job return logging

### DIFF
--- a/hydra/experimental/log_job_return_callback.py
+++ b/hydra/experimental/log_job_return_callback.py
@@ -1,0 +1,23 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import logging
+from typing import Any
+
+from omegaconf import DictConfig
+
+from hydra.core.utils import JobReturn, JobStatus
+from hydra.experimental.callback import Callback
+
+log = logging.getLogger(__name__)
+
+
+class LogJobReturnCallback(Callback):
+    def on_job_end(
+        self, config: DictConfig, job_return: JobReturn, **kwargs: Any
+    ) -> None:
+        if job_return.status == JobStatus.COMPLETED:
+            log.info(f"Succeeded with return value: {job_return.return_value}")
+        elif job_return.status == JobStatus.FAILED:
+            log.error("", exc_info=job_return._return_value)
+        else:
+            log.error("Status unknown. This should never happen.")

--- a/news/2100.feature
+++ b/news/2100.feature
@@ -1,0 +1,1 @@
+Add callback for logging JobReturn.

--- a/tests/test_apps/app_with_log_jobreturn_callback/__init__.py
+++ b/tests/test_apps/app_with_log_jobreturn_callback/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/tests/test_apps/app_with_log_jobreturn_callback/config.yaml
+++ b/tests/test_apps/app_with_log_jobreturn_callback/config.yaml
@@ -1,0 +1,6 @@
+foo: bar
+
+hydra:
+  callbacks:
+    log_job_return:
+      _target_: hydra.experimental.log_job_return_callback.LogJobReturnCallback

--- a/tests/test_apps/app_with_log_jobreturn_callback/my_app.py
+++ b/tests/test_apps/app_with_log_jobreturn_callback/my_app.py
@@ -1,0 +1,14 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from omegaconf import DictConfig
+
+import hydra
+
+
+@hydra.main(config_path=".", config_name="config")
+def my_app(cfg: DictConfig) -> None:
+    val = 1 / cfg.divisor
+    print(f"val={val}")
+
+
+if __name__ == "__main__":
+    my_app()

--- a/website/docs/experimental/callbacks.md
+++ b/website/docs/experimental/callbacks.md
@@ -5,9 +5,6 @@ sidebar_label: Callbacks
 ---
 
 import GithubLink from "@site/src/components/GithubLink"
-import {ExampleGithubLink} from "@site/src/components/GithubLink"
-
-<ExampleGithubLink text="Examples" to="hydra/experimental"/>
 
 The <GithubLink to="hydra/experimental/callback.py">Callback interface</GithubLink> enables custom
 code to be triggered by various Hydra events.

--- a/website/docs/experimental/callbacks.md
+++ b/website/docs/experimental/callbacks.md
@@ -5,7 +5,9 @@ sidebar_label: Callbacks
 ---
 
 import GithubLink from "@site/src/components/GithubLink"
+import {ExampleGithubLink} from "@site/src/components/GithubLink"
 
+<ExampleGithubLink text="Examples" to="hydra/experimental"/>
 
 The <GithubLink to="hydra/experimental/callback.py">Callback interface</GithubLink> enables custom
 code to be triggered by various Hydra events.


### PR DESCRIPTION
I tried a fews ways to add the logging in hydra core without a callback. However didn't find a clean way to add the logging in both RUN and MULTIRUN mode without adding much more noise to the console. 

Add logging as a callback means: 1) job return will be logged together with the rest of the application log, 2) users can opt in.

related to #2100 