### PR TITLE
Instantiate cherry pick

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -2,7 +2,6 @@
 
 import copy
 import functools
-import sys
 from enum import Enum
 from textwrap import dedent
 from typing import Any, Callable, Dict, List, Sequence, Tuple, Union

--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -4,6 +4,7 @@ import copy
 import functools
 import sys
 from enum import Enum
+from textwrap import dedent
 from typing import Any, Callable, Dict, List, Sequence, Tuple, Union
 
 from omegaconf import OmegaConf, SCMode
@@ -32,7 +33,7 @@ def _is_target(x: Any) -> bool:
     return False
 
 
-def _extract_pos_args(*input_args: Any, **kwargs: Any) -> Tuple[Any, Any]:
+def _extract_pos_args(input_args: Any, kwargs: Any) -> Tuple[Any, Any]:
     config_args = kwargs.pop(_Keys.ARGS, ())
     output_args = config_args
 
@@ -41,16 +42,16 @@ def _extract_pos_args(*input_args: Any, **kwargs: Any) -> Tuple[Any, Any]:
             output_args = input_args
     else:
         raise InstantiationException(
-            f"Unsupported _args_ type: {type(config_args).__name__}. value: {config_args}"
+            f"Unsupported _args_ type: '{type(config_args).__name__}'. value: '{config_args}'"
         )
 
     return output_args, kwargs
 
 
-def _call_target(_target_: Callable, _partial_: bool, *args, **kwargs) -> Any:  # type: ignore
+def _call_target(_target_: Callable, _partial_: bool, args, kwargs, full_key) -> Any:  # type: ignore
     """Call target (type) with args and kwargs."""
     try:
-        args, kwargs = _extract_pos_args(*args, **kwargs)
+        args, kwargs = _extract_pos_args(args, kwargs)
         # detaching configs from parent.
         # At this time, everything is resolved and the parent link can cause
         # issues when serializing objects in some scenarios.
@@ -60,13 +61,35 @@ def _call_target(_target_: Callable, _partial_: bool, *args, **kwargs) -> Any:  
         for v in kwargs.values():
             if OmegaConf.is_config(v):
                 v._set_parent(None)
-        if _partial_:
-            return functools.partial(_target_, *args, **kwargs)
-        return _target_(*args, **kwargs)
     except Exception as e:
-        raise type(e)(
-            f"Error instantiating '{_convert_target_to_string(_target_)}' : {e}"
-        ).with_traceback(sys.exc_info()[2])
+        msg = (
+            f"Error in collecting args and kwargs for '{_convert_target_to_string(_target_)}':"
+            + f"\n{repr(e)}"
+        )
+        if full_key:
+            msg += f"\nfull_key: {full_key}"
+
+        raise InstantiationException(msg) from e
+
+    if _partial_:
+        try:
+            return functools.partial(_target_, *args, **kwargs)
+        except Exception as e:
+            msg = (
+                f"Error in creating partial({_convert_target_to_string(_target_)}, ...) object:"
+                + f"\n{repr(e)}"
+            )
+            if full_key:
+                msg += f"\nfull_key: {full_key}"
+            raise InstantiationException(msg) from e
+    else:
+        try:
+            return _target_(*args, **kwargs)
+        except Exception as e:
+            msg = f"Error in call to target '{_convert_target_to_string(_target_)}':\n{repr(e)}"
+            if full_key:
+                msg += f"\nfull_key: {full_key}"
+            raise InstantiationException(msg) from e
 
 
 def _convert_target_to_string(t: Any) -> Any:
@@ -100,18 +123,23 @@ def _prepare_input_dict_or_list(d: Union[Dict[Any, Any], List[Any]]) -> Any:
 
 
 def _resolve_target(
-    target: Union[str, type, Callable[..., Any]]
+    target: Union[str, type, Callable[..., Any]], full_key: str
 ) -> Union[type, Callable[..., Any]]:
     """Resolve target string, type or callable into type or callable."""
     if isinstance(target, str):
-        return _locate(target)
-    if isinstance(target, type):
-        return target
-    if callable(target):
-        return target
-    raise InstantiationException(
-        f"Unsupported target type: {type(target).__name__}. value: {target}"
-    )
+        try:
+            target = _locate(target)
+        except Exception as e:
+            msg = f"Error locating target '{target}', see chained exception above."
+            if full_key:
+                msg += f"\nfull_key: {full_key}"
+            raise InstantiationException(msg) from e
+    if not callable(target):
+        msg = f"Expected a callable target, got '{target}' of type '{type(target).__name__}'"
+        if full_key:
+            msg += f"\nfull_key: {full_key}"
+        raise InstantiationException(msg)
+    return target
 
 
 def instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
@@ -151,9 +179,15 @@ def instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
     if isinstance(config, TargetConf) and config._target_ == "???":
         # Specific check to give a good warning about failure to annotate _target_ as a string.
         raise InstantiationException(
-            f"Missing value for {type(config).__name__}._target_. Check that it's properly annotated and overridden."
-            f"\nA common problem is forgetting to annotate _target_ as a string : '_target_: str = ...'"
+            dedent(
+                f"""\
+                Config has missing value for key `_target_`, cannot instantiate.
+                Config type: {type(config).__name__}
+                Check that the `_target_` key in your dataclass is properly annotated and overridden.
+                A common problem is forgetting to annotate _target_ as a string : '_target_: str = ...'"""
+            )
         )
+        # TODO: print full key
 
     if isinstance(config, (dict, list)):
         config = _prepare_input_dict_or_list(config)
@@ -210,8 +244,12 @@ def instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
         )
     else:
         raise InstantiationException(
-            "Top level config has to be OmegaConf DictConfig/ListConfig, "
-            + "plain dict/list, or a Structured Config class or instance."
+            dedent(
+                f"""\
+                Cannot instantiate config of type {type(config).__name__}.
+                Top level config must be an OmegaConf DictConfig/ListConfig object,
+                a plain dict/list, or a Structured Config class or instance."""
+            )
         )
 
 
@@ -248,11 +286,19 @@ def instantiate_node(
         recursive = node[_Keys.RECURSIVE] if _Keys.RECURSIVE in node else recursive
         partial = node[_Keys.PARTIAL] if _Keys.PARTIAL in node else partial
 
+    full_key = node._get_full_key(None)
+
     if not isinstance(recursive, bool):
-        raise TypeError(f"_recursive_ flag must be a bool, got {type(recursive)}")
+        msg = f"Instantiation: _recursive_ flag must be a bool, got {type(recursive)}"
+        if full_key:
+            msg += f"\nfull_key: {full_key}"
+        raise TypeError(msg)
 
     if not isinstance(partial, bool):
-        raise TypeError(f"_partial_ flag must be a bool, got {type( partial )}")
+        msg = f"Instantiation: _partial_ flag must be a bool, got {type( partial )}"
+        if node and full_key:
+            msg += f"\nfull_key: {full_key}"
+        raise TypeError(msg)
 
     # If OmegaConf list, create new list of instances if recursive
     if OmegaConf.is_list(node):
@@ -273,7 +319,7 @@ def instantiate_node(
     elif OmegaConf.is_dict(node):
         exclude_keys = set({"_target_", "_convert_", "_recursive_", "_partial_"})
         if _is_target(node):
-            _target_ = _resolve_target(node.get(_Keys.TARGET))
+            _target_ = _resolve_target(node.get(_Keys.TARGET), full_key)
             kwargs = {}
             for key, value in node.items():
                 if key not in exclude_keys:
@@ -283,7 +329,7 @@ def instantiate_node(
                         )
                     kwargs[key] = _convert_node(value, convert)
 
-            return _call_target(_target_, partial, *args, **kwargs)
+            return _call_target(_target_, partial, args, kwargs, full_key)
         else:
             # If ALL or PARTIAL non structured, instantiate in dict and resolve interpolations eagerly.
             if convert == ConvertMode.ALL or (

--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -4,7 +4,7 @@ import copy
 import functools
 import sys
 from enum import Enum
-from typing import Any, Callable, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Sequence, Tuple, Union
 
 from omegaconf import OmegaConf, SCMode
 from omegaconf._utils import is_structured_config
@@ -78,7 +78,7 @@ def _convert_target_to_string(t: Any) -> Any:
         return t
 
 
-def _prepare_input_dict(d: Any) -> Any:
+def _prepare_input_dict_or_list(d: Union[Dict[Any, Any], List[Any]]) -> Any:
     res: Any
     if isinstance(d, dict):
         res = {}
@@ -86,13 +86,13 @@ def _prepare_input_dict(d: Any) -> Any:
             if k == "_target_":
                 v = _convert_target_to_string(d["_target_"])
             elif isinstance(v, (dict, list)):
-                v = _prepare_input_dict(v)
+                v = _prepare_input_dict_or_list(v)
             res[k] = v
     elif isinstance(d, list):
         res = []
         for v in d:
             if isinstance(v, (list, dict)):
-                v = _prepare_input_dict(v)
+                v = _prepare_input_dict_or_list(v)
             res.append(v)
     else:
         assert False
@@ -155,13 +155,13 @@ def instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
             f"\nA common problem is forgetting to annotate _target_ as a string : '_target_: str = ...'"
         )
 
-    if isinstance(config, dict):
-        config = _prepare_input_dict(config)
+    if isinstance(config, (dict, list)):
+        config = _prepare_input_dict_or_list(config)
 
-    kwargs = _prepare_input_dict(kwargs)
+    kwargs = _prepare_input_dict_or_list(kwargs)
 
     # Structured Config always converted first to OmegaConf
-    if is_structured_config(config) or isinstance(config, dict):
+    if is_structured_config(config) or isinstance(config, (dict, list)):
         config = OmegaConf.structured(config, flags={"allow_objects": True})
 
     if OmegaConf.is_dict(config):
@@ -185,9 +185,33 @@ def instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
         return instantiate_node(
             config, *args, recursive=_recursive_, convert=_convert_, partial=_partial_
         )
+    elif OmegaConf.is_list(config):
+        # Finalize config (convert targets to strings, merge with kwargs)
+        config_copy = copy.deepcopy(config)
+        config_copy._set_flag(
+            flags=["allow_objects", "struct", "readonly"], values=[True, False, False]
+        )
+        config_copy._set_parent(config._get_parent())
+        config = config_copy
+
+        OmegaConf.resolve(config)
+
+        _recursive_ = kwargs.pop(_Keys.RECURSIVE, True)
+        _convert_ = kwargs.pop(_Keys.CONVERT, ConvertMode.NONE)
+        _partial_ = kwargs.pop(_Keys.PARTIAL, False)
+
+        if _partial_:
+            raise InstantiationException(
+                "The _partial_ keyword is not compatible with top-level list instantiation"
+            )
+
+        return instantiate_node(
+            config, *args, recursive=_recursive_, convert=_convert_, partial=_partial_
+        )
     else:
         raise InstantiationException(
-            "Top level config has to be OmegaConf DictConfig, plain dict, or a Structured Config class or instance"
+            "Top level config has to be OmegaConf DictConfig/ListConfig, "
+            + "plain dict/list, or a Structured Config class or instance."
         )
 
 

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -7,8 +7,8 @@ import sys
 from dataclasses import dataclass
 from os.path import dirname, join, normpath, realpath
 from traceback import print_exc, print_exception
-from types import FrameType, TracebackType
-from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
+from types import FrameType, ModuleType, TracebackType
+from typing import Any, List, Optional, Sequence, Tuple
 
 from omegaconf.errors import OmegaConfBaseException
 

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -559,7 +559,6 @@ def _locate(path: str) -> Any:
     """
     if path == "":
         raise ImportError("Empty path")
-    import builtins
     from importlib import import_module
 
     parts = [part for part in path.split(".")]

--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -34,12 +34,13 @@ def get_class(path: str) -> type:
 
 def get_method(path: str) -> Callable[..., Any]:
     try:
-        cl = _locate(path)
-        if not callable(cl):
+        obj = _locate(path)
+        if not callable(obj):
             raise ValueError(
-                f"Located non-callable of type '{type(cl).__name__}'"
+                f"Located non-callable of type '{type(obj).__name__}'"
                 + f" while loading '{path}'"
             )
+        cl: Callable[..., Any] = obj
         return cl
     except Exception as e:
         log.error(f"Error getting callable at {path} : {e}")

--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -22,10 +22,13 @@ def get_class(path: str) -> type:
     try:
         cls = _locate(path)
         if not isinstance(cls, type):
-            raise ValueError(f"Located non-class in {path} : {type(cls).__name__}")
+            raise ValueError(
+                f"Located non-class of type '{type(cls).__name__}'"
+                + f" while loading '{path}'"
+            )
         return cls
     except Exception as e:
-        log.error(f"Error initializing class at {path} : {e}")
+        log.error(f"Error initializing class at {path}: {e}")
         raise e
 
 
@@ -33,7 +36,10 @@ def get_method(path: str) -> Callable[..., Any]:
     try:
         cl = _locate(path)
         if not callable(cl):
-            raise ValueError(f"Non callable object located : {type(cl).__name__}")
+            raise ValueError(
+                f"Located non-callable of type '{type(cl).__name__}'"
+                + f" while loading '{path}'"
+            )
         return cl
     except Exception as e:
         log.error(f"Error getting callable at {path} : {e}")

--- a/news/1950.feature
+++ b/news/1950.feature
@@ -1,0 +1,1 @@
+The `instantiate` API now accepts `ListConfig`/`list`-type config as top-level input.

--- a/news/2099.feature
+++ b/news/2099.feature
@@ -1,0 +1,1 @@
+Improve error messages raised in case of instantiation failure.

--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -3,11 +3,14 @@ import collections
 import collections.abc
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NoReturn, Optional, Tuple
 
 from omegaconf import MISSING, DictConfig, ListConfig
 
 from hydra.types import TargetConf
+from tests.instantiate.module_shadowed_by_function import a_function
+
+module_shadowed_by_function = a_function
 
 
 def _convert_type(obj: Any) -> Any:
@@ -70,6 +73,16 @@ def add_values(a: int, b: int) -> int:
 
 def module_function(x: int) -> int:
     return x
+
+
+class ExceptionTakingNoArgument(Exception):
+    def __init__(self) -> None:
+        """Init method taking only one argument (self)"""
+        super().__init__("Err message")
+
+
+def raise_exception_taking_no_argument() -> NoReturn:
+    raise ExceptionTakingNoArgument()
 
 
 @dataclass

--- a/tests/instantiate/import_error.py
+++ b/tests/instantiate/import_error.py
@@ -1,0 +1,2 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+assert False

--- a/tests/instantiate/module_shadowed_by_function.py
+++ b/tests/instantiate/module_shadowed_by_function.py
@@ -1,0 +1,3 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+def a_function() -> None:
+    pass

--- a/tests/instantiate/test_helpers.py
+++ b/tests/instantiate/test_helpers.py
@@ -1,12 +1,14 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import datetime
 import re
+from textwrap import dedent
 from typing import Any
 
 from _pytest.python_api import RaisesContext, raises
-from pytest import mark
+from pytest import mark, param
 
 from hydra._internal.utils import _locate
-from hydra.utils import get_class
+from hydra.utils import get_class, get_method
 from tests.instantiate import (
     AClass,
     Adam,
@@ -15,6 +17,8 @@ from tests.instantiate import (
     NestingClass,
     Parameters,
 )
+
+from .module_shadowed_by_function import a_function
 
 
 @mark.parametrize(
@@ -27,14 +31,120 @@ from tests.instantiate import (
         ("tests.instantiate.NestingClass", NestingClass),
         ("tests.instantiate.AnotherClass", AnotherClass),
         ("", raises(ImportError, match=re.escape("Empty path"))),
-        [
+        (
             "not_found",
-            raises(ImportError, match=re.escape("Error loading module 'not_found'")),
-        ],
+            raises(ImportError, match=re.escape("Error loading 'not_found'")),
+        ),
         (
             "tests.instantiate.b.c.Door",
             raises(
                 ImportError, match=re.escape("No module named 'tests.instantiate.b'")
+            ),
+        ),
+        param(
+            "int",
+            raises(
+                ImportError,
+                match=dedent(
+                    r"""
+                    Error loading 'int':
+                    ModuleNotFoundError\("No module named 'int'",?\)
+                    Are you sure that module 'int' is installed\?
+                    """
+                ).strip(),
+            ),
+            id="int",
+        ),
+        param("builtins.int", int, id="builtins_explicit"),
+        param("builtins.int.from_bytes", int.from_bytes, id="method_of_builtin"),
+        param(
+            "builtins.int.not_found",
+            raises(
+                ImportError,
+                match=dedent(
+                    r"""
+                    Error loading 'builtins\.int\.not_found':
+                    AttributeError\("type object 'int' has no attribute 'not_found'",?\)
+                    Are you sure that 'not_found' is an attribute of 'builtins\.int'\?
+                    """
+                ).strip(),
+            ),
+            id="builtin_attribute_error",
+        ),
+        param(
+            "datetime",
+            datetime,
+            id="top_level_module",
+        ),
+        ("tests.instantiate.Adam", Adam),
+        ("tests.instantiate.Parameters", Parameters),
+        ("tests.instantiate.AClass", AClass),
+        param(
+            "tests.instantiate.AClass.static_method",
+            AClass.static_method,
+            id="staticmethod",
+        ),
+        param(
+            "tests.instantiate.AClass.not_found",
+            raises(
+                ImportError,
+                match=dedent(
+                    r"""
+                    Error loading 'tests\.instantiate\.AClass\.not_found':
+                    AttributeError\("type object 'AClass' has no attribute 'not_found'",?\)
+                    Are you sure that 'not_found' is an attribute of 'tests\.instantiate\.AClass'\?
+                    """
+                ).strip(),
+            ),
+            id="class_attribute_error",
+        ),
+        ("tests.instantiate.ASubclass", ASubclass),
+        ("tests.instantiate.NestingClass", NestingClass),
+        ("tests.instantiate.AnotherClass", AnotherClass),
+        ("tests.instantiate.module_shadowed_by_function", a_function),
+        param(
+            "",
+            raises(ImportError, match=("Empty path")),
+            id="invalid-path-empty",
+        ),
+        param(
+            "toplevel_not_found",
+            raises(
+                ImportError,
+                match=dedent(
+                    r"""
+                    Error loading 'toplevel_not_found':
+                    ModuleNotFoundError\("No module named 'toplevel_not_found'",?\)
+                    Are you sure that module 'toplevel_not_found' is installed\?
+                    """
+                ).strip(),
+            ),
+            id="toplevel_not_found",
+        ),
+        param(
+            "tests.instantiate.b.c.Door",
+            raises(
+                ImportError,
+                match=dedent(
+                    r"""
+                    Error loading 'tests\.instantiate\.b\.c\.Door':
+                    ModuleNotFoundError\("No module named 'tests\.instantiate\.b'",?\)
+                    Are you sure that 'b' is importable from module 'tests\.instantiate'\?"""
+                ).strip(),
+            ),
+            id="nested_not_found",
+        ),
+        param(
+            "tests.instantiate.import_error",
+            raises(
+                ImportError,
+                match=re.escape(
+                    dedent(
+                        """\
+                        Error loading 'tests.instantiate.import_error':
+                        AssertionError()"""
+                    )
+                ),
             ),
         ),
     ],
@@ -47,6 +157,75 @@ def test_locate(name: str, expected: Any) -> None:
         assert _locate(name) == expected
 
 
-@mark.parametrize("path,expected_type", [("tests.instantiate.AClass", AClass)])
-def test_get_class(path: str, expected_type: type) -> None:
-    assert get_class(path) == expected_type
+@mark.parametrize(
+    "name",
+    [
+        param(".", id="invalid-path-period"),
+        param("..", id="invalid-path-period2"),
+        param(".mod", id="invalid-path-relative"),
+        param("..mod", id="invalid-path-relative2"),
+        param("mod.", id="invalid-path-trailing-dot"),
+        param("mod..another", id="invalid-path-two-dots"),
+    ],
+)
+def test_locate_relative_import_fails(name: str) -> None:
+    with raises(
+        ValueError,
+        match=r"Error loading '.*': invalid dotstring\."
+        + re.escape("\nRelative imports are not supported."),
+    ):
+        _locate(name)
+
+
+@mark.parametrize(
+    "path,expected",
+    [
+        param("tests.instantiate.AClass", AClass, id="class"),
+        param("builtins.print", print, id="callable"),
+        param(
+            "datetime",
+            raises(
+                ValueError,
+                match="Located non-callable of type 'module' while loading 'datetime'",
+            ),
+            id="module-error",
+        ),
+    ],
+)
+def test_get_method(path: str, expected: Any) -> None:
+    if isinstance(expected, RaisesContext):
+        with expected:
+            get_method(path)
+    else:
+        assert get_method(path) == expected
+
+
+@mark.parametrize(
+    "path,expected",
+    [
+        param("tests.instantiate.AClass", AClass, id="class"),
+        param(
+            "builtins.print",
+            raises(
+                ValueError,
+                match="Located non-class of type 'builtin_function_or_method'"
+                + " while loading 'builtins.print'",
+            ),
+            id="callable-error",
+        ),
+        param(
+            "datetime",
+            raises(
+                ValueError,
+                match="Located non-class of type 'module' while loading 'datetime'",
+            ),
+            id="module-error",
+        ),
+    ],
+)
+def test_get_class(path: str, expected: Any) -> None:
+    if isinstance(expected, RaisesContext):
+        with expected:
+            get_class(path)
+    else:
+        assert get_class(path) == expected

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -5,7 +5,7 @@ import re
 from dataclasses import dataclass
 from functools import partial
 from textwrap import dedent
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
 from pytest import fixture, mark, param, raises, warns


### PR DESCRIPTION
This PR cherry picks changes to `hydra.instantiate` from `main` branch to `1.1_branch`.
Most of the changes come from these three PRs:
- [  allow list as toplevel instantiate input #2014 ](https://github.com/facebookresearch/hydra/pull/2014)
- [ prefer getattr in _locate logic #2062 ](https://github.com/facebookresearch/hydra/pull/2062)
- [ Improve error messages for instantiate #2110 ](https://github.com/facebookresearch/hydra/pull/2110)