### PR TITLE
update hydra.runtime.choices during multirun

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -311,9 +311,6 @@ class ConfigLoaderImpl(ConfigLoader):
             run_mode=RunMode.RUN,
         )
 
-        with open_dict(sweep_config):
-            sweep_config.hydra.runtime.merge_with(master_config.hydra.runtime)
-
         # Partial copy of master config cache, to ensure we get the same resolved values for timestamps
         cache: Dict[str, Any] = defaultdict(dict, {})
         cache_master_config = OmegaConf.get_cache(master_config)

--- a/news/1882.bugfix
+++ b/news/1882.bugfix
@@ -1,0 +1,1 @@
+`hydra.runtime.choices` updated correctly during multi-run

--- a/tests/test_apps/app_with_cfg_groups/conf/config_with_runtime_option.yaml
+++ b/tests/test_apps/app_with_cfg_groups/conf/config_with_runtime_option.yaml
@@ -1,0 +1,5 @@
+defaults:
+  - optimizer: nesterov
+  - _self_
+
+optimizer_option: ${hydra:runtime.choices.optimizer}

--- a/tests/test_apps/app_with_cfg_groups/my_app_with_runtime_choices_print.py
+++ b/tests/test_apps/app_with_cfg_groups/my_app_with_runtime_choices_print.py
@@ -1,0 +1,17 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from typing import Any
+
+from omegaconf import DictConfig
+
+import hydra
+
+
+@hydra.main(
+    version_base=None, config_path="conf", config_name="config_with_runtime_option"
+)
+def my_app(cfg: DictConfig) -> Any:
+    print(cfg.optimizer_option)
+
+
+if __name__ == "__main__":
+    my_app()

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1832,3 +1832,31 @@ def test_hydra_mode(
             from_name="Expected output",
             to_name="Actual output",
         )
+
+
+def test_hydra_runtime_choice_1882(tmpdir: Path) -> None:
+    cmd = [
+        "tests/test_apps/app_with_cfg_groups/my_app_with_runtime_choices_print.py",
+        "--multirun",
+        f"hydra.sweep.dir={tmpdir}",
+        "hydra.hydra_logging.formatters.simple.format='[HYDRA] %(message)s'",
+        "hydra.job_logging.formatters.simple.format='[JOB] %(message)s'",
+        "hydra.job.chdir=False",
+        "optimizer=adam,nesterov",
+    ]
+    expected_output = dedent(
+        """
+                [HYDRA] Launching 2 jobs locally
+                [HYDRA] \t#0 : optimizer=adam
+                adam
+                [HYDRA] \t#1 : optimizer=nesterov
+                nesterov"""
+    )
+
+    out, _ = run_python_script(cmd)
+    assert_regex_match(
+        from_line=expected_output,
+        to_line=out,
+        from_name="Expected output",
+        to_name="Actual output",
+    )


### PR DESCRIPTION
closes #1882 

The particular line of code deleted in this PR is redundant and actually override the correct value to an outdated one. 