### PR TITLE
remove support for "*.yml" extensions

### DIFF
--- a/hydra/plugins/config_source.py
+++ b/hydra/plugins/config_source.py
@@ -1,16 +1,16 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import re
-
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
 
-from hydra.core.default_element import InputDefault
-from hydra.errors import HydraException
 from omegaconf import Container
 
-from hydra.core.object_type import ObjectType
+from hydra import version
 from hydra._internal.deprecation_warning import deprecation_warning
+from hydra.core.default_element import InputDefault
+from hydra.core.object_type import ObjectType
+from hydra.errors import HydraException
 from hydra.plugins.plugin import Plugin
 
 
@@ -117,12 +117,14 @@ class ConfigSource(Plugin):
 
     @staticmethod
     def _normalize_file_name(filename: str) -> str:
-        if filename.endswith(".yml"):
-            # DEPRECATED: remove in 1.2
-            deprecation_warning(
-                "Support for .yml files is deprecated. Use .yaml extension for Hydra config files"
-            )
-        if not any(filename.endswith(ext) for ext in [".yaml", ".yml"]):
+        supported_extensions = [".yaml"]
+        if not version.base_at_least("1.2"):
+            supported_extensions.append(".yml")
+            if filename.endswith(".yml"):
+                deprecation_warning(
+                    "Support for .yml files is deprecated. Use .yaml extension for Hydra config files"
+                )
+        if not any(filename.endswith(ext) for ext in supported_extensions):
             filename += ".yaml"
         return filename
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -7,6 +7,7 @@ from typing import Any, List
 from omegaconf import MISSING, OmegaConf, ValidationError, open_dict
 from pytest import mark, param, raises, warns
 
+from hydra import version
 from hydra._internal.config_loader_impl import ConfigLoaderImpl
 from hydra._internal.utils import create_config_search_path
 from hydra.core.config_store import ConfigStore, ConfigStoreWithProvider
@@ -189,6 +190,8 @@ class TestConfigLoader:
         config_loader = ConfigLoaderImpl(
             config_search_path=create_config_search_path(path)
         )
+        curr_base = version.getbase()
+        version.setbase("1.1")
         with warns(
             UserWarning,
             match="Support for .yml files is deprecated. Use .yaml extension for Hydra config files",
@@ -198,6 +201,7 @@ class TestConfigLoader:
                 overrides=[],
                 run_mode=RunMode.RUN,
             )
+        version.setbase(str(curr_base))
 
         with open_dict(cfg):
             del cfg["hydra"]


### PR DESCRIPTION
Was deprecated, and slated for removal in 1.2
Addresses issue #1891 
