### PR TITLE
remove support for strict flag from compose API

### DIFF
--- a/hydra/compose.py
+++ b/hydra/compose.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 from omegaconf import DictConfig, OmegaConf, open_dict
 
+from hydra import version
 from hydra.core.global_hydra import GlobalHydra
 from hydra.types import RunMode
 
@@ -45,15 +46,17 @@ def compose(
                 del cfg["hydra"]
 
     if strict is not None:
-        # DEPRECATED: remove in 1.2
-        deprecation_warning(
-            dedent(
-                """
-                The strict flag in the compose API is deprecated and will be removed in the next version of Hydra.
-                See https://hydra.cc/docs/upgrades/0.11_to_1.0/strict_mode_flag_deprecated for more info.
-                """
+        if version.base_at_least("1.2"):
+            raise TypeError("got an unexpected 'strict' argument")
+        else:
+            deprecation_warning(
+                dedent(
+                    """
+                    The strict flag in the compose API is deprecated.
+                    See https://hydra.cc/docs/upgrades/0.11_to_1.0/strict_mode_flag_deprecated for more info.
+                    """
+                )
             )
-        )
-        OmegaConf.set_struct(cfg, strict)
+            OmegaConf.set_struct(cfg, strict)
 
     return cfg

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -746,16 +746,22 @@ def test_deprecated_compose_strict_flag(strict: bool) -> None:
     msg = dedent(
         """\
 
-        The strict flag in the compose API is deprecated and will be removed in the next version of Hydra.
+        The strict flag in the compose API is deprecated.
         See https://hydra.cc/docs/upgrades/0.11_to_1.0/strict_mode_flag_deprecated for more info.
         """
     )
+
+    curr_base = version.getbase()
+    version.setbase("1.1")
 
     with warns(
         expected_warning=UserWarning,
         match=re.escape(msg),
     ):
         cfg = compose(overrides=[], strict=strict)
+
+    version.setbase(str(curr_base))
+
     assert cfg == {}
     assert OmegaConf.is_struct(cfg) is strict
 


### PR DESCRIPTION
Was deprecated, and slated for removal in 1.2
Addresses issue #1891
