### PR TITLE
remove support for _name_ and _group_ from package header

### DIFF
--- a/hydra/_internal/config_repository.py
+++ b/hydra/_internal/config_repository.py
@@ -250,8 +250,9 @@ class ConfigRepository(IConfigRepository):
                         options.append(vv)
                     config_value = options
 
-                if package is not None and "_name_" in package:
-                    issue_deprecated_name_warning()
+                if not version.base_at_least("1.2"):
+                    if package is not None and "_name_" in package:
+                        issue_deprecated_name_warning()
 
                 default = GroupDefault(
                     group=keywords.group,
@@ -263,8 +264,9 @@ class ConfigRepository(IConfigRepository):
 
             elif isinstance(item, str):
                 path, package, _package2 = self._split_group(item)
-                if package is not None and "_name_" in package:
-                    issue_deprecated_name_warning()
+                if not version.base_at_least("1.2"):
+                    if package is not None and "_name_" in package:
+                        issue_deprecated_name_warning()
 
                 default = ConfigDefault(path=path, package=package)
             else:

--- a/hydra/core/override_parser/types.py
+++ b/hydra/core/override_parser/types.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Union, ca
 from omegaconf import OmegaConf
 from omegaconf._utils import is_structured_config
 
+from hydra import version
 from hydra._internal.deprecation_warning import deprecation_warning
 from hydra._internal.grammar.utils import _ESC_QUOTED_STR, escape_special_characters
 from hydra.core.config_loader import ConfigLoader
@@ -482,13 +483,13 @@ class Override:
         )
 
     def validate(self) -> None:
-        if self.package is not None and "_name_" in self.package:
-            # DEPRECATED: remove in 1.2
-            url = "https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_package_header"
-            deprecation_warning(
-                message=dedent(
-                    f"""\
-                    In override {self.input_line}: _name_ keyword is deprecated in packages, see {url}
-                    """
-                ),
-            )
+        if not version.base_at_least("1.2"):
+            if self.package is not None and "_name_" in self.package:
+                url = "https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_package_header"
+                deprecation_warning(
+                    message=dedent(
+                        f"""\
+                        In override {self.input_line}: _name_ keyword is deprecated in packages, see {url}
+                        """
+                    ),
+                )

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -2824,12 +2824,16 @@ def test_deprecated_package_header_keywords(
     overrides: List[str],
     package_header: str,
     expected: DefaultsTreeNode,
+    hydra_restore_singletons: Any,
 ) -> None:
     msg = dedent(
         f"""\
         In '{config_name}': Usage of deprecated keyword in package header '# @package {package_header}'.
         See https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_package_header for more information"""
     )
+
+    version.setbase("1.1")
+
     with warns(UserWarning, match=re.escape(msg)):
         _test_defaults_tree_impl(
             config_name=config_name,

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Union
 from _pytest.python_api import RaisesContext
 from pytest import mark, param, raises, warns
 
+from hydra import version
 from hydra._internal.grammar.functions import Functions
 from hydra._internal.grammar.utils import escape_special_characters
 from hydra.core.override_parser.overrides_parser import (
@@ -991,11 +992,14 @@ def test_override(
     assert ret == expected
 
 
-def test_deprecated_name_package() -> None:
+def test_deprecated_name_package(hydra_restore_singletons: Any) -> None:
     msg = (
         "In override key@_name_=value: _name_ keyword is deprecated in packages, "
         "see https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_package_header"
     )
+
+    version.setbase("1.1")
+
     with warns(
         UserWarning,
         match=re.escape(msg),


### PR DESCRIPTION
(when version_base >= 1.2)

Was deprecated, and slated for removal in 1.2.

Addresses issue #1891
