### PR TITLE
fix CI: follow up to #1909 and temporarily pin omegaconf=2.1

### DIFF
--- a/plugins/hydra_optuna_sweeper/example/custom-search-space/config.yaml
+++ b/plugins/hydra_optuna_sweeper/example/custom-search-space/config.yaml
@@ -16,7 +16,7 @@ hydra:
       y: choice(-5, 0, 5)
     # `custom_search_space` should be a dotpath pointing to a
     # callable that provides search-space configuration logic:
-    custom_search_space: .custom-search-space-objective.configure
+    custom_search_space: custom-search-space-objective.configure
 
 x: 1
 y: 1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-omegaconf~=2.1
+omegaconf==2.1.*
 antlr4-python3-runtime==4.8
 importlib-resources;python_version<'3.9'
 packaging


### PR DESCRIPTION
CI is failing on the `main` branch.

Edit:
- The first commit https://github.com/facebookresearch/hydra/pull/2145/commits/eeef282c9b4db6df7763495c8314d69bc5616e97 is a follow-up to #1909.
- The second commit https://github.com/facebookresearch/hydra/pull/2145/commits/c77f218b0ad761974f0655670961a317b1726919 is a temporary pin on the `omegaconf` version. I've accidentally release OmegaConf version v2.2.0 prematurely (I was supposed to release only OmegaConf v2.1.2). Running Hydra `main` branch CI against the OmgeaConf2.2.0 version from pypi is causing test failures, hence the pin `omegaconf==2.1.*`.