### PR TITLE
test against omegaconf dev version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,23 @@ jobs:
               conda activate hydra
               nox -s lint_plugins test_plugins -ts
               exit $LASTEXITCODE
+  test_linux_omc_dev:
+    parameters:
+      py_version:
+        type: string
+    docker:
+      - image: cimg/base:stable-18.04
+    steps:
+      - linux:
+          py_version: << parameters.py_version >>
+      - run:
+          name: Testing Hydra
+          command: |
+            export PATH="$HOME/miniconda3/envs/hydra/bin:$PATH"
+            export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
+            export USE_OMEGACONF_DEV_VERSION=1
+            pip install nox dataclasses --progress-bar off
+            nox -s test_core -ts
   # Misc
   coverage:
     docker:
@@ -247,6 +264,10 @@ workflows:
             parameters:
               py_version: ["3.6", "3.7", "3.8", "3.9"]
       - test_win:
+          matrix:
+            parameters:
+              py_version: ["3.6", "3.7", "3.8", "3.9"]
+      - test_linux_omc_dev:
           matrix:
             parameters:
               py_version: ["3.6", "3.7", "3.8", "3.9"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,6 +31,7 @@ PLUGINS = os.environ.get("PLUGINS", "ALL").split(",")
 
 SKIP_CORE_TESTS = "0"
 SKIP_CORE_TESTS = os.environ.get("SKIP_CORE_TESTS", SKIP_CORE_TESTS) != "0"
+USE_OMEGACONF_DEV_VERSION = os.environ.get("USE_OMEGACONF_DEV_VERSION", "0") != "0"
 FIX = os.environ.get("FIX", "0") == "1"
 VERBOSE = os.environ.get("VERBOSE", "0")
 SILENT = VERBOSE == "0"
@@ -58,6 +59,7 @@ print(f"SKIP_CORE_TESTS\t\t:\t{SKIP_CORE_TESTS}")
 print(f"FIX\t\t\t:\t{FIX}")
 print(f"VERBOSE\t\t\t:\t{VERBOSE}")
 print(f"INSTALL_EDITABLE_MODE\t:\t{INSTALL_EDITABLE_MODE}")
+print(f"USE_OMEGACONF_DEV_VERSION\t:\t{USE_OMEGACONF_DEV_VERSION}")
 
 
 def _upgrade_basic(session):
@@ -80,12 +82,23 @@ def find_dirs(path: str):
             yield fullname
 
 
+def _print_installed_omegaconf_version(session):
+    pip_list: str = session.run("pip", "list", silent=True)
+    for line in pip_list.split("\n"):
+        if "omegaconf" in line:
+            print(f"Installed omegaconf version: {line}")
+
+
 def install_hydra(session, cmd):
     # needed for build
     session.install("read-version", silent=SILENT)
     # clean install hydra
     session.chdir(BASE)
+    if USE_OMEGACONF_DEV_VERSION:
+        session.install("--pre", "omegaconf", silent=SILENT)
     session.run(*cmd, ".", silent=SILENT)
+    if USE_OMEGACONF_DEV_VERSION:
+        _print_installed_omegaconf_version(session)
     if not SILENT:
         session.install("pipdeptree", silent=SILENT)
         session.run("pipdeptree", "-p", "hydra-core")

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-omegaconf==2.1.*
+omegaconf~=2.1
 antlr4-python3-runtime==4.8
 importlib-resources;python_version<'3.9'
 packaging

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -330,11 +330,11 @@ class TestConfigLoader:
         msg = dedent(
             """\
             In 'schema_validation_error': ValidationError raised while composing config:
-            Value 'not_an_int' could not be converted to Integer
+            Value 'not_an_int'( of type 'str')? could not be converted to Integer
                 full_key: port
                 object_type=MySQLConfig"""
         )
-        with raises(ConfigCompositionException, match=re.escape(msg)):
+        with raises(ConfigCompositionException, match=msg):
             config_loader.load_configuration(
                 config_name="schema_validation_error",
                 overrides=[],

--- a/tests/test_examples/test_structured_configs_tutorial.py
+++ b/tests/test_examples/test_structured_configs_tutorial.py
@@ -66,13 +66,13 @@ def test_1_basic_override_type_error(tmpdir: Path) -> None:
 
     expected = dedent(
         """\
-        Value 'foo' could not be converted to Integer
+        Value 'foo'( of type 'str')? could not be converted to Integer
             full_key: port
             object_type=MySQLConfig"""
     )
 
     err = run_with_error(cmd)
-    assert re.search(re.escape(expected), err) is not None
+    assert re.search(expected, err) is not None
 
 
 def test_2_static_complex(tmpdir: Path) -> None:

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1102,28 +1102,28 @@ def test_module_run(
             ["test.param=1,2"],
             True,
             dedent(
-                """\
-            Ambiguous value for argument 'test.param=1,2'
-            1. To use it as a list, use key=[value1,value2]
-            2. To use it as string, quote the value: key=\\'value1,value2\\'
-            3. To sweep over it, add --multirun to your command line
+                r"""
+                Ambiguous value for argument 'test\.param=1,2'
+                1\. To use it as a list, use key=\[value1,value2\]
+                2\. To use it as string, quote the value: key=\\'value1,value2\\'
+                3\. To sweep over it, add --multirun to your command line
 
-            Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace."""
-            ),
+                Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\."""
+            ).strip(),
             id="run:choice_sweep",
         ),
         param(
             ["test.param=[1,2]"],
             True,
             dedent(
-                """\
-                Error merging override test.param=[1,2]
-                Value '[1, 2]' could not be converted to Integer
-                    full_key: test.param
+                r"""
+                Error merging override test.param=\[1,2\]
+                Value '\[1, 2\]'( of type 'list')? could not be converted to Integer
+                    full_key: test\.param
                     object_type=TestConfig
 
-                Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace."""
-            ),
+                Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\."""
+            ).strip(),
             id="run:list_value",
         ),
         param(["test.param=1", "-m"], False, "1", id="multirun:value"),
@@ -1142,9 +1142,9 @@ def test_multirun_structured_conflict(
     if error:
         expected = normalize_newlines(expected)
         ret = run_with_error(cmd)
-        assert_regex_match(
-            from_line=expected,
-            to_line=ret,
+        assert_multiline_regex_search(
+            pattern=expected,
+            string=ret,
             from_name="Expected output",
             to_name="Actual output",
         )


### PR DESCRIPTION
This PR enables testing Hydra against the latest OmegaConf pre-release installed from pypi.

With the current setup:
- Testing against the OMC pre-release is enabled for linux but not for macos or windows
- Testing against the OMC pre-release only runs the nox `test_core` session; lints and plugin tests are skipped.