### PR TITLE
Fix CI

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -336,7 +336,8 @@ def instantiate_node(
         else:
             # If ALL or PARTIAL non structured, instantiate in dict and resolve interpolations eagerly.
             if convert == ConvertMode.ALL or (
-                convert == ConvertMode.PARTIAL and node._metadata.object_type is None
+                convert == ConvertMode.PARTIAL
+                and node._metadata.object_type in (None, dict)
             ):
                 dict_items = {}
                 for key, value in node.items():


### PR DESCRIPTION
CI is failing on the `main` branch.

This is due to a change in OmegaConf 2.2.0.dev2 (vs previous OmegaConf verisons):
- previously non-structured DictConfig instances had `_metadata.object_type is None`
- as of OMC 2.2.0.dev2, non-structured DictConfig instances have `_metadata.object_type == dict`
