### PR TITLE
Make tasks_per_node optional

### DIFF
--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
@@ -18,7 +18,7 @@ class BaseQueueConf:
     # number of gpus to use on each node
     gpus_per_node: Optional[int] = None
     # number of tasks to spawn on each node
-    tasks_per_node: int = 1
+    tasks_per_node: Optional[int] = None
     # memory to reserve for the job on each node (in GB)
     mem_gb: Optional[int] = None
     # number of nodes to use for the job

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
@@ -18,7 +18,7 @@ class BaseQueueConf:
     # number of gpus to use on each node
     gpus_per_node: Optional[int] = None
     # number of tasks to spawn on each node
-    tasks_per_node: Optional[int] = None
+    tasks_per_node: Optional[int] = 1
     # memory to reserve for the job on each node (in GB)
     mem_gb: Optional[int] = None
     # number of nodes to use for the job

--- a/plugins/hydra_submitit_launcher/news/2157.feature
+++ b/plugins/hydra_submitit_launcher/news/2157.feature
@@ -1,0 +1,1 @@
+Allow `tasks_per_node` to be omitted from Submitit Slurm submissions.

--- a/plugins/hydra_submitit_launcher/tests/test_submitit_launcher.py
+++ b/plugins/hydra_submitit_launcher/tests/test_submitit_launcher.py
@@ -94,6 +94,40 @@ def test_slurm_python_parameter(tmp_path: Path, python: Optional[str]) -> None:
     assert "slurm_python" not in executor.update_parameters.call_args.kwargs
 
 
+@mark.parametrize("tasks_per_node", [1, None])
+def test_slurm_tasks_per_node_is_optional_with_compatible_default(
+    tmp_path: Path, tasks_per_node: Optional[int]
+) -> None:
+    assert SlurmQueueConf().tasks_per_node == 1
+
+    executor = MagicMock()
+    executor.map_array.return_value = []
+    config = OmegaConf.create(
+        {
+            "hydra": {
+                "job": {"name": "test"},
+                "sweep": {"dir": str(tmp_path / "sweep")},
+                "launcher": OmegaConf.structured(SlurmQueueConf),
+            }
+        }
+    )
+    config.hydra.launcher.tasks_per_node = tasks_per_node
+    launcher = instantiate(
+        config.hydra.launcher,
+        _target_whitelist_=(
+            "hydra_plugins.hydra_submitit_launcher.submitit_launcher.SlurmLauncher"
+        ),
+    )
+    launcher.config = config
+
+    with patch.object(submitit, "AutoExecutor", return_value=executor):
+        assert launcher.launch([[]], initial_job_idx=0) == []
+
+    assert (
+        executor.update_parameters.call_args.kwargs["tasks_per_node"] == tasks_per_node
+    )
+
+
 def test_example(tmpdir: Path) -> None:
     run_python_script(
         [

--- a/website/docs/plugins/submitit_launcher.md
+++ b/website/docs/plugins/submitit_launcher.md
@@ -89,6 +89,9 @@ You can set all these parameters in your configuration file and/or override them
 ```text
 python foo.py --multirun hydra/launcher=submitit_slurm hydra.launcher.timeout_min=3
 ```
+Set `hydra.launcher.tasks_per_node=null` to omit `--ntasks-per-node` from the
+generated Slurm submission.
+
 Set `hydra.launcher.python` to use a Python executable other than the one
 running Hydra:
 


### PR DESCRIPTION
This pull request fixes https://github.com/facebookresearch/hydra/issues/1898
With the latest version of submitit, tasks_per_node became optional. see [here](https://github.com/facebookincubator/submitit/commit/208198eed20ca77d609bf96b0e89a75bc4ba43eb).
(need to change requirements.txt as well)