### PR TITLE
Add version constraint for Optuna

### DIFF
--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     install_requires=[
         "hydra-core>=1.1.0.dev7",
-        "optuna<3.0.0",
+        "optuna>=2.10.0,<3.0.0",
     ],
     include_package_data=True,
 )

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     install_requires=[
         "hydra-core>=1.1.0.dev7",
-        "optuna>=2.10.0",
+        "optuna<3.0.0",
     ],
     include_package_data=True,
 )


### PR DESCRIPTION
See https://github.com/facebookresearch/hydra/issues/2162 for more information.

## Motivation

This PR updates the version constraint of Optuna to avoid installing the next major version of Optuna.
See also 🔗 https://github.com/facebookresearch/hydra/issues/2162

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

https://github.com/facebookresearch/hydra/issues/2162
