### PR TITLE
version_base testing: use hydra_restore_singletons

### DIFF
--- a/tests/defaults_list/test_defaults_list.py
+++ b/tests/defaults_list/test_defaults_list.py
@@ -86,8 +86,8 @@ class TestDeprecatedOptional:
         self,
         config_path: str,
         expected_list: List[InputDefault],
+        hydra_restore_singletons: Any,
     ) -> None:
-        curr_base = version.getbase()
         version.setbase("1.1")
         repo = create_repo()
         warning = dedent(
@@ -103,7 +103,6 @@ class TestDeprecatedOptional:
             result = repo.load_config(config_path=config_path)
         assert result is not None
         assert result.defaults_list == expected_list
-        version.setbase(str(curr_base))
 
     @mark.parametrize("version_base", ["1.2", None])
     def test_version_base_1_2(
@@ -111,8 +110,8 @@ class TestDeprecatedOptional:
         config_path: str,
         expected_list: List[InputDefault],
         version_base: Optional[str],
+        hydra_restore_singletons: Any,
     ) -> None:
-        curr_base = version.getbase()
         version.setbase(version_base)
         repo = create_repo()
         err = "In optional_deprecated: Too many keys in default item {'group1': 'file1', 'optional': True}"
@@ -121,7 +120,6 @@ class TestDeprecatedOptional:
             match=re.escape(err),
         ):
             repo.load_config(config_path=config_path)
-        version.setbase(str(curr_base))
 
 
 def _test_defaults_list_impl(

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -742,7 +742,9 @@ def test_error_assigning_null_to_logging_config(
 @mark.parametrize(
     "strict", [param(True, id="strict=True"), param(False, id="strict=False")]
 )
-def test_deprecated_compose_strict_flag(strict: bool) -> None:
+def test_deprecated_compose_strict_flag(
+    strict: bool, hydra_restore_singletons: Any
+) -> None:
     msg = dedent(
         """\
 
@@ -751,7 +753,6 @@ def test_deprecated_compose_strict_flag(strict: bool) -> None:
         """
     )
 
-    curr_base = version.getbase()
     version.setbase("1.1")
 
     with warns(
@@ -759,8 +760,6 @@ def test_deprecated_compose_strict_flag(strict: bool) -> None:
         match=re.escape(msg),
     ):
         cfg = compose(overrides=[], strict=strict)
-
-    version.setbase(str(curr_base))
 
     assert cfg == {}
     assert OmegaConf.is_struct(cfg) is strict

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -186,11 +186,10 @@ class TestConfigLoader:
                 run_mode=RunMode.RUN,
             )
 
-    def test_load_yml_file(self, path: str) -> None:
+    def test_load_yml_file(self, path: str, hydra_restore_singletons: Any) -> None:
         config_loader = ConfigLoaderImpl(
             config_search_path=create_config_search_path(path)
         )
-        curr_base = version.getbase()
         version.setbase("1.1")
         with warns(
             UserWarning,
@@ -201,7 +200,6 @@ class TestConfigLoader:
                 overrides=[],
                 run_mode=RunMode.RUN,
             )
-        version.setbase(str(curr_base))
 
         with open_dict(cfg):
             del cfg["hydra"]


### PR DESCRIPTION
This PR makes use of the hydra_restore_singletons pytest fixture to restore version_base settings in the test suite.
