### PR TITLE
Support Python3.10 on main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,19 +271,19 @@ workflows:
       - test_macos:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
       - test_linux:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
       - test_win:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
       - test_linux_omc_dev:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
 
   plugin_tests:
@@ -292,17 +292,17 @@ workflows:
       - test_plugin_linux:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
               test_plugin: [<< pipeline.parameters.test_plugins >>]
       - test_plugin_macos:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
               test_plugin: [<< pipeline.parameters.test_plugins >>]
       - test_plugin_win:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
               test_plugin: [<< pipeline.parameters.test_plugins >>]
 
 

--- a/examples/plugins/example_configsource_plugin/setup.py
+++ b/examples/plugins/example_configsource_plugin/setup.py
@@ -23,6 +23,7 @@ with open("README.md", "r") as fh:
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "Operating System :: OS Independent",
         ],
         install_requires=[

--- a/examples/plugins/example_generic_plugin/setup.py
+++ b/examples/plugins/example_generic_plugin/setup.py
@@ -23,6 +23,7 @@ with open("README.md", "r") as fh:
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "Operating System :: OS Independent",
         ],
         install_requires=[

--- a/examples/plugins/example_launcher_plugin/setup.py
+++ b/examples/plugins/example_launcher_plugin/setup.py
@@ -23,6 +23,7 @@ with open("README.md", "r") as fh:
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "Operating System :: OS Independent",
         ],
         install_requires=[

--- a/examples/plugins/example_registered_plugin/setup.py
+++ b/examples/plugins/example_registered_plugin/setup.py
@@ -23,6 +23,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: OS Independent",
     ],
     install_requires=[

--- a/examples/plugins/example_searchpath_plugin/setup.py
+++ b/examples/plugins/example_searchpath_plugin/setup.py
@@ -25,6 +25,7 @@ with open("README.md", "r") as fh:
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "Operating System :: OS Independent",
         ],
         install_requires=[

--- a/examples/plugins/example_sweeper_plugin/setup.py
+++ b/examples/plugins/example_sweeper_plugin/setup.py
@@ -23,6 +23,7 @@ with open("README.md", "r") as fh:
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "Operating System :: OS Independent",
         ],
         install_requires=[

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -282,7 +282,7 @@ def run_and_report(func: Any) -> Any:
                         assert iter_tb.tb_next is not None
                         iter_tb = iter_tb.tb_next
 
-                    print_exception(etype=None, value=ex, tb=final_tb)  # type: ignore
+                    print_exception(None, value=ex, tb=final_tb)  # type: ignore
                 sys.stderr.write(
                     "\nSet the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.\n"
                 )

--- a/news/1856.feature
+++ b/news/1856.feature
@@ -1,0 +1,1 @@
+Support for Python 3.10

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,7 @@ from nox.logger import logger
 
 BASE = os.path.abspath(os.path.dirname(__file__))
 
-DEFAULT_PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9"]
+DEFAULT_PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
 DEFAULT_OS_NAMES = ["Linux", "MacOS", "Windows"]
 
 PYTHON_VERSIONS = os.environ.get(
@@ -546,6 +546,7 @@ def test_jupyter_notebooks(session):
     install_hydra(session, ["pip", "install", "-e"])
     args = pytest_args(
         "--nbval",
+        "-W ignore::DeprecationWarning",
         "-W ignore::ResourceWarning",
         "examples/jupyter_notebooks/compose_configs_in_notebook.ipynb",
     )
@@ -555,7 +556,12 @@ def test_jupyter_notebooks(session):
     for notebook in [
         file for file in notebooks_dir.iterdir() if str(file).endswith(".ipynb")
     ]:
-        args = pytest_args("--nbval", "-W ignore::ResourceWarning", str(notebook))
+        args = pytest_args(
+            "--nbval",
+            "-W ignore::DeprecationWarning",
+            "-W ignore::ResourceWarning",
+            str(notebook),
+        )
         args = [x for x in args if x != "-Werror"]
         session.run(*args, silent=SILENT)
 

--- a/plugins/hydra_ax_sweeper/news/1856.feature
+++ b/plugins/hydra_ax_sweeper/news/1856.feature
@@ -1,0 +1,1 @@
+Support for Python 3.10

--- a/plugins/hydra_ax_sweeper/setup.py
+++ b/plugins/hydra_ax_sweeper/setup.py
@@ -20,6 +20,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS",
         "Development Status :: 4 - Beta",

--- a/plugins/hydra_colorlog/news/1856.feature
+++ b/plugins/hydra_colorlog/news/1856.feature
@@ -1,0 +1,1 @@
+Support for Python 3.10

--- a/plugins/hydra_colorlog/setup.py
+++ b/plugins/hydra_colorlog/setup.py
@@ -21,6 +21,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: OS Independent",
     ],
     install_requires=["colorlog", "hydra-core>=1.0.0"],

--- a/plugins/hydra_joblib_launcher/news/1856.feature
+++ b/plugins/hydra_joblib_launcher/news/1856.feature
@@ -1,0 +1,1 @@
+Support for Python 3.10

--- a/plugins/hydra_joblib_launcher/setup.py
+++ b/plugins/hydra_joblib_launcher/setup.py
@@ -20,6 +20,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: MacOS",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX :: Linux",

--- a/plugins/hydra_nevergrad_sweeper/news/1856.feature
+++ b/plugins/hydra_nevergrad_sweeper/news/1856.feature
@@ -1,0 +1,1 @@
+Support for Python 3.10

--- a/plugins/hydra_nevergrad_sweeper/setup.py
+++ b/plugins/hydra_nevergrad_sweeper/setup.py
@@ -21,6 +21,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: OS Independent",
         "Development Status :: 4 - Beta",
     ],

--- a/plugins/hydra_optuna_sweeper/news/1856.feature
+++ b/plugins/hydra_optuna_sweeper/news/1856.feature
@@ -1,0 +1,1 @@
+Support for Python 3.10

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -21,6 +21,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS",
         "Development Status :: 4 - Beta",

--- a/plugins/hydra_rq_launcher/news/1856.feature
+++ b/plugins/hydra_rq_launcher/news/1856.feature
@@ -1,0 +1,1 @@
+Support for Python 3.10

--- a/plugins/hydra_rq_launcher/setup.py
+++ b/plugins/hydra_rq_launcher/setup.py
@@ -21,6 +21,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
     ],

--- a/plugins/hydra_submitit_launcher/news/1856.feature
+++ b/plugins/hydra_submitit_launcher/news/1856.feature
@@ -1,0 +1,1 @@
+Support for Python 3.10

--- a/plugins/hydra_submitit_launcher/setup.py
+++ b/plugins/hydra_submitit_launcher/setup.py
@@ -20,6 +20,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ with open("README.md", "r") as fh:
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "Operating System :: POSIX :: Linux",
             "Operating System :: MacOS",
             "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
- The most significant change is to `hydra/core/plugins.py`; the previous strategy used for importing plugins was causing a `DeprecationWarning` when I tested locally on Python3.10.
- Our ray launcher does not support python3.10 (as the ray library on which it depends only works with <= 3.9). The CI for ray+py3.10 is "passing" (i.e. it is green) but the ray tests are not actually running.