### PR TITLE
fixup version_base stragglers

### DIFF
--- a/tests/test_apps/app_with_log_jobreturn_callback/my_app.py
+++ b/tests/test_apps/app_with_log_jobreturn_callback/my_app.py
@@ -4,7 +4,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     val = 1 / cfg.divisor
     print(f"val={val}")

--- a/website/docs/experimental/rerun.md
+++ b/website/docs/experimental/rerun.md
@@ -27,7 +27,7 @@ hydra:
 
 
 ```python title="Example function"
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     log.info(f"output_dir={HydraConfig.get().runtime.output_dir}")
     log.info(f"cfg.foo={cfg.foo}")
@@ -82,7 +82,7 @@ time_now: ${now:%H-%M-%S}
 <div className="col col--7">
 
 ```python title="Example function"
-@hydra.main(config_path=".", config_name="config")
+@hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     val = cfg.time_now
     # the rest of the application


### PR DESCRIPTION
This PR adds `version_base=None` to a few straggler calls to `@hydra.main`.
Based on Pádraig's commit message in [this commit](https://github.com/facebookresearch/hydra/pull/2065/commits/ebc1dbd374f98c26eaab8d6a3930a621c0beb1ab) from the original version_base PR :)
