### PR TITLE
resolve ray init in ray launcher

### DIFF
--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_launcher_util.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_launcher_util.py
@@ -31,7 +31,7 @@ def start_ray(init_cfg: DictConfig) -> None:
     if not ray.is_initialized():
         log.info(f"Initializing ray with config: {init_cfg}")
         if init_cfg:
-            ray.init(**init_cfg)
+            ray.init(**OmegaConf.to_container(init_cfg, resolve=True))
         else:
             ray.init()
     else:


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Trying to use hydra and ray, when providing the init config it doesn't get resolved to primitive types and it fails when I set, for instance, `runtime_env`. It's solved easily by calling `OmegaConf.to_container` before passing the config to `ray.init` - (which I notice is already being done for the `ray.remote` config)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
