### PR TITLE
noxfile: always print installed OmegaConf version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -97,8 +97,7 @@ def install_hydra(session, cmd):
     if USE_OMEGACONF_DEV_VERSION:
         session.install("--pre", "omegaconf", silent=SILENT)
     session.run(*cmd, ".", silent=SILENT)
-    if USE_OMEGACONF_DEV_VERSION:
-        _print_installed_omegaconf_version(session)
+    _print_installed_omegaconf_version(session)
     if not SILENT:
         session.install("pipdeptree", silent=SILENT)
         session.run("pipdeptree", "-p", "hydra-core")


### PR DESCRIPTION
Previously the noxfile's `install_hydra` routine would print the installed OmegaConf
version only if an OmegaConf dev release was being used. With this change, the
nox tests should print the installed OmegaConf version under all circumstances.