### PR TITLE
remove support for legacy default list interpolation format

### DIFF
--- a/hydra/core/default_element.py
+++ b/hydra/core/default_element.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Pattern, Union
 from omegaconf import AnyNode, DictConfig, OmegaConf
 from omegaconf.errors import InterpolationResolutionError
 
+from hydra import version
 from hydra._internal.deprecation_warning import deprecation_warning
 from hydra.errors import ConfigCompositionException
 
@@ -537,16 +538,18 @@ class GroupDefault(InputDefault):
     def resolve_interpolation(self, known_choices: DictConfig) -> None:
         name = self.get_name()
         if name is not None:
-            # DEPRECATED: remove in 1.2
             if re.match(_legacy_interpolation_pattern, name) is not None:
                 msg = dedent(
                     f"""
 Defaults list element '{self.get_override_key()}={name}' is using a deprecated interpolation form.
 See http://hydra.cc/docs/next/upgrades/1.0_to_1.1/defaults_list_interpolation for migration information."""
                 )
-                deprecation_warning(
-                    message=msg,
-                )
+                if not version.base_at_least("1.2"):
+                    deprecation_warning(
+                        message=msg,
+                    )
+                else:
+                    raise ConfigCompositionException(msg)
 
             self.value = self._resolve_interpolation_impl(known_choices, name)
 

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -2019,13 +2019,23 @@ def test_legacy_interpolation(
     config_name: str,
     overrides: List[str],
     expected: DefaultsTreeNode,
+    hydra_restore_singletons: Any,
 ) -> None:
     msg = dedent(
         """
     Defaults list element '.*=.*' is using a deprecated interpolation form.
     See http://hydra.cc/docs/next/upgrades/1.0_to_1.1/defaults_list_interpolation for migration information."""
     )
+    version.setbase("1.1")
     with warns(expected_warning=UserWarning, match=msg):
+        _test_defaults_tree_impl(
+            config_name=config_name,
+            input_overrides=overrides,
+            expected=expected,
+        )
+
+    version.setbase("1.2")
+    with raises(ConfigCompositionException, match=msg):
         _test_defaults_tree_impl(
             config_name=config_name,
             input_overrides=overrides,


### PR DESCRIPTION
(when the version_base is >= 1.2).

The old ${defaults.N.name} format was deprecated,
and slated for removal in 1.2.

Follows on from the support of the newer format in PR #1044

Addresses issue #1891