### PR TITLE
remove support for hydra.experimental.{compose,initialize}

### DIFF
--- a/hydra/experimental/compose.py
+++ b/hydra/experimental/compose.py
@@ -1,9 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-# DEPRECATED: remove in 1.2
 from typing import List, Optional
 
 from omegaconf import DictConfig
 
+from hydra import version
 from hydra._internal.deprecation_warning import deprecation_warning
 
 
@@ -15,10 +15,14 @@ def compose(
 ) -> DictConfig:
     from hydra import compose as real_compose
 
-    deprecation_warning(
-        message="hydra.experimental.compose() is no longer experimental."
-        " Use hydra.compose()",
+    message = (
+        "hydra.experimental.compose() is no longer experimental. Use hydra.compose()"
     )
+
+    if version.base_at_least("1.2"):
+        raise ImportError(message)
+
+    deprecation_warning(message=message)
     return real_compose(
         config_name=config_name,
         overrides=overrides,

--- a/hydra/experimental/initialize.py
+++ b/hydra/experimental/initialize.py
@@ -1,8 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-# DEPRECATED: remove in 1.2
 import copy
 from typing import Any, Optional
 
+from hydra import version
 from hydra._internal.deprecation_warning import deprecation_warning
 from hydra.core.global_hydra import GlobalHydra
 from hydra.core.singleton import Singleton
@@ -32,10 +32,15 @@ class initialize:
     ) -> None:
         from hydra import initialize as real_initialize
 
-        deprecation_warning(
-            message="hydra.experimental.initialize() is no longer experimental."
-            " Use hydra.initialize()",
+        message = (
+            "hydra.experimental.initialize() is no longer experimental. "
+            "Use hydra.initialize()"
         )
+
+        if version.base_at_least("1.2"):
+            raise ImportError(message)
+
+        deprecation_warning(message=message)
 
         self.delegate = real_initialize(
             config_path=config_path,
@@ -64,10 +69,15 @@ class initialize_config_module:
     def __init__(self, config_module: str, job_name: str = "app") -> None:
         from hydra import initialize_config_module as real_initialize_config_module
 
-        deprecation_warning(
-            message="hydra.experimental.initialize_config_module() is no longer experimental."
-            " Use hydra.initialize_config_module().",
+        message = (
+            "hydra.experimental.initialize_config_module() is no longer experimental. "
+            "Use hydra.initialize_config_module()."
         )
+
+        if version.base_at_least("1.2"):
+            raise ImportError(message)
+
+        deprecation_warning(message=message)
 
         self.delegate = real_initialize_config_module(
             config_module=config_module, job_name=job_name
@@ -95,10 +105,15 @@ class initialize_config_dir:
     def __init__(self, config_dir: str, job_name: str = "app") -> None:
         from hydra import initialize_config_dir as real_initialize_config_dir
 
-        deprecation_warning(
-            message="hydra.experimental.initialize_config_dir() is no longer experimental."
-            " Use hydra.initialize_config_dir().",
+        message = (
+            "hydra.experimental.initialize_config_dir() is no longer experimental. "
+            "Use hydra.initialize_config_dir()."
         )
+
+        if version.base_at_least("1.2"):
+            raise ImportError(message)
+
+        deprecation_warning(message=message)
 
         self.delegate = real_initialize_config_dir(
             config_dir=config_dir, job_name=job_name

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -638,41 +638,62 @@ class TestConfigSearchPathOverride:
             compose(config_name=config_name, overrides=[override])
 
 
-def test_deprecated_compose() -> None:
+def test_deprecated_compose(hydra_restore_singletons: Any) -> None:
     from hydra import initialize
     from hydra.experimental import compose as expr_compose
 
-    with initialize(version_base=None):
+    msg = "hydra.experimental.compose() is no longer experimental. Use hydra.compose()"
+
+    with initialize(version_base="1.1"):
         with warns(
             expected_warning=UserWarning,
-            match=re.escape(
-                "hydra.experimental.compose() is no longer experimental. Use hydra.compose()"
-            ),
+            match=re.escape(msg),
+        ):
+            assert expr_compose() == {}
+
+    with initialize(version_base="1.2"):
+        with raises(
+            ImportError,
+            match=re.escape(msg),
         ):
             assert expr_compose() == {}
 
 
-def test_deprecated_initialize() -> None:
+def test_deprecated_initialize(hydra_restore_singletons: Any) -> None:
     from hydra.experimental import initialize as expr_initialize
 
-    with warns(
-        expected_warning=UserWarning,
-        match=re.escape(
-            "hydra.experimental.initialize() is no longer experimental. Use hydra.initialize()"
-        ),
-    ):
+    msg = "hydra.experimental.initialize() is no longer experimental. Use hydra.initialize()"
+
+    version.setbase("1.1")
+    with warns(expected_warning=UserWarning, match=re.escape(msg)):
+        with expr_initialize():
+            assert compose() == {}
+
+    version.setbase("1.2")
+    with raises(ImportError, match=re.escape(msg)):
         with expr_initialize():
             assert compose() == {}
 
 
-def test_deprecated_initialize_config_dir() -> None:
+def test_deprecated_initialize_config_dir(hydra_restore_singletons: Any) -> None:
     from hydra.experimental import initialize_config_dir as expr_initialize_config_dir
 
+    msg = "hydra.experimental.initialize_config_dir() is no longer experimental. Use hydra.initialize_config_dir()"
+
+    version.setbase("1.1")
     with warns(
         expected_warning=UserWarning,
-        match=re.escape(
-            "hydra.experimental.initialize_config_dir() is no longer experimental. Use hydra.initialize_config_dir()"
-        ),
+        match=re.escape(msg),
+    ):
+        with expr_initialize_config_dir(
+            config_dir=str(Path(".").absolute()),
+        ):
+            assert compose() == {}
+
+    version.setbase("1.2")
+    with raises(
+        ImportError,
+        match=re.escape(msg),
     ):
         with expr_initialize_config_dir(
             config_dir=str(Path(".").absolute()),
@@ -680,18 +701,25 @@ def test_deprecated_initialize_config_dir() -> None:
             assert compose() == {}
 
 
-def test_deprecated_initialize_config_module() -> None:
+def test_deprecated_initialize_config_module(hydra_restore_singletons: Any) -> None:
     from hydra.experimental import (
         initialize_config_module as expr_initialize_config_module,
     )
 
-    with warns(
-        expected_warning=UserWarning,
-        match=re.escape(
-            "hydra.experimental.initialize_config_module() is no longer experimental."
-            " Use hydra.initialize_config_module()"
-        ),
-    ):
+    msg = (
+        "hydra.experimental.initialize_config_module() is no longer experimental."
+        " Use hydra.initialize_config_module()"
+    )
+
+    version.setbase("1.1")
+    with warns(expected_warning=UserWarning, match=re.escape(msg)):
+        with expr_initialize_config_module(
+            config_module="examples.jupyter_notebooks.cloud_app.conf",
+        ):
+            assert compose() == {}
+
+    version.setbase("1.2")
+    with raises(ImportError, match=re.escape(msg)):
         with expr_initialize_config_module(
             config_module="examples.jupyter_notebooks.cloud_app.conf",
         ):


### PR DESCRIPTION
(when the version_base is >= 1.2).

This was deprecated, and slated for removal in 1.2.

Addresses issue #1891
