### PR TITLE
fix intro.md references in versioned_docs

### DIFF
--- a/website/versioned_docs/version-1.2/intro.md
+++ b/website/versioned_docs/version-1.2/intro.md
@@ -27,7 +27,8 @@ Use the version switcher in the top bar to switch between documentation versions
  
 |        |          Version          |  Release notes                                                                      | Python Versions    |
 | -------|---------------------------|-------------------------------------------------------------------------------------| -------------------|
-| &#9658;| 1.1 (Stable)              | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/v1.1.1)      | **3.6 - 3.9**      |
+| &#9658;| 1.2 (Stable)              | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/v1.2.0)      | **3.6 - 3.10**     |
+|        | 1.1                       | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/v1.1.1)      | **3.6 - 3.9**      |
 |        | 1.0                       | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/v1.0.7)      | **3.6 - 3.8**      |
 |        | 0.11                      | [Release notes](https://github.com/facebookresearch/hydra/releases/tag/v0.11.3)     | **2.7, 3.5 - 3.8** |
 


### PR DESCRIPTION
The new docusaurus version should have been generated
_after_ the update to the source intro.md
So manually correct this here.
