### PR TITLE
Mypy: use builtins.str to avoid variable shadowing

### DIFF
--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import builtins
 import math
 import re
 from builtins import isinstance
@@ -1433,7 +1434,7 @@ class CastResults:
     ]
 
     @staticmethod
-    def error(msg: str) -> Any:
+    def error(msg: builtins.str) -> Any:
         return raises(HydraException, match=f"^{re.escape(msg)}")
 
 


### PR DESCRIPTION
The CI seems to be failing.