### PR TITLE
fix colorlog default log path

### DIFF
--- a/plugins/hydra_colorlog/hydra_plugins/hydra_colorlog/__init__.py
+++ b/plugins/hydra_colorlog/hydra_plugins/hydra_colorlog/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/plugins/hydra_colorlog/hydra_plugins/hydra_colorlog/conf/hydra/job_logging/colorlog.yaml
+++ b/plugins/hydra_colorlog/hydra_plugins/hydra_colorlog/conf/hydra/job_logging/colorlog.yaml
@@ -21,8 +21,8 @@ handlers:
   file:
     class: logging.FileHandler
     formatter: simple
-    # relative to the job log directory
-    filename: ${hydra.job.name}.log
+    # absolute file path
+    filename: ${hydra.runtime.output_dir}/${hydra.job.name}.log
 root:
   level: INFO
   handlers: [console, file]


### PR DESCRIPTION
closes #2241

tested by running an hydra app locally with `hydra.job.chdir=False` and verified the file got created in the output dir as expected. 