### PR TITLE
Replace deprecated distutils.spawn.find_executable() in test_completion.py

### DIFF
--- a/build_helpers/__init__.py
+++ b/build_helpers/__init__.py
@@ -1,3 +1,2 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import setuptools  # isort:skip # noqa
-import distutils  # isort:skip # noqa

--- a/build_helpers/build_helpers.py
+++ b/build_helpers/build_helpers.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import codecs
-import distutils.log
 import errno
+import logging
 import os
 import re
 import shutil
@@ -11,6 +11,8 @@ from typing import List, Optional
 
 from setuptools import Command
 from setuptools.command import build_py, develop, sdist
+
+log = logging.getLogger(__name__)
 
 
 def find_version(*file_paths: str) -> str:
@@ -131,13 +133,13 @@ class CleanCommand(Command):  # type: ignore
 
 def run_antlr(cmd: Command) -> None:
     try:
-        cmd.announce("Generating parsers with antlr4", level=distutils.log.INFO)
+        log.info("Generating parsers with antlr4")
         cmd.run_command("antlr")
     except OSError as e:
         if e.errno == errno.ENOENT:
             msg = f"| Unable to generate parsers: {e} |"
             msg = "=" * len(msg) + "\n" + msg + "\n" + "=" * len(msg)
-            cmd.announce(f"{msg}", level=distutils.log.FATAL)
+            log.critical(f"{msg}")
             exit(1)
         else:
             raise
@@ -192,9 +194,7 @@ class ANTLRCommand(Command):  # type: ignore
                 join(project_root, grammar),
             ]
 
-            self.announce(
-                f"Generating parser for Python3: {command}", level=distutils.log.INFO
-            )
+            log.info(f"Generating parser for Python3: {command}")
 
             subprocess.check_call(command)
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import distutils.spawn
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -20,11 +20,11 @@ chdir_hydra_root()
 
 
 def is_expect_exists() -> bool:
-    return distutils.spawn.find_executable("expect") is not None
+    return shutil.which("expect") is not None
 
 
 def is_fish_supported() -> bool:
-    if distutils.spawn.find_executable("fish") is None:
+    if shutil.which("fish") is None:
         return False
 
     proc = subprocess.run(
@@ -46,7 +46,7 @@ def is_fish_supported() -> bool:
 
 
 def is_zsh_supported() -> bool:
-    if distutils.spawn.find_executable("zsh") is None:
+    if shutil.which("zsh") is None:
         return False
 
     proc = subprocess.run(


### PR DESCRIPTION
`shutil.which()` is available since Python 3.3 and is equivalent to
`find_executable()` here.
See https://peps.python.org/pep-0632/

Fixes #2276

What I don't understand yet is why Hydra's own CircleCI core tests already pass on Python 3.10 already although I can't find an option that lets those warnings be ignored.

<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

`distutils` is deprecated and causes test failures on Python 3.10 due to a new `DeprecationWarning`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

No changes necessary.

## Related Issues and PRs

- #2276
- https://github.com/conda-forge/hydra-core-feedstock/pull/19