### PR TITLE
docs: Fix a few typos

### DIFF
--- a/website/docs/patterns/specializing_config.md
+++ b/website/docs/patterns/specializing_config.md
@@ -8,7 +8,7 @@ import {ExampleGithubLink} from "@site/src/components/GithubLink"
 <ExampleGithubLink text="Example application" to="examples/patterns/specializing_config"/>
 
 In some cases the desired configuration should depend on other configuration choices.
-For example, You may want to use only 5 layers in your Alexnet model if the dataset of choice is cifar10, and the dafault 7 otherwise.
+For example, You may want to use only 5 layers in your Alexnet model if the dataset of choice is cifar10, and the default 7 otherwise.
  
 We can start with a config that looks like this:
 ### initial config.yaml

--- a/website/versioned_docs/version-1.0/advanced/plugins.md
+++ b/website/versioned_docs/version-1.0/advanced/plugins.md
@@ -17,7 +17,7 @@ If you develop plugins, please join the <a href="https://hydra-framework.zulipch
 
 ## Plugin discovery
 The plugin discovery process runs whenever Hydra starts. During plugin discovery, Hydra scans for plugins in all the submodules of `hydra_plugins`. Hydra will import each module and look for plugins defined in that module.
-Any module under `hydra_plugins` that is slow to import will slow down the startup of _ALL_ Hydra applicaitons.
+Any module under `hydra_plugins` that is slow to import will slow down the startup of _ALL_ Hydra applications.
 Plugins with expensive imports can exclude individual files from this by prefixing them with `_` (but not `__`).
 For example, the file `_my_plugin_lib.py` would not be imported and scanned, while `my_plugin_lib.py` would be.
 

--- a/website/versioned_docs/version-1.0/patterns/specializing_config.md
+++ b/website/versioned_docs/version-1.0/patterns/specializing_config.md
@@ -5,7 +5,7 @@ title: Specializing configuration
 [![Example application](https://img.shields.io/badge/-Example%20application-informational)](https://github.com/facebookresearch/hydra/tree/1.0_branch/examples/patterns/specializing_config)
 
 In some cases the desired configuration should depend on other configuration choices.
-For example, You may want to use only 5 layers in your Alexnet model if the dataset of choice is cifar10, and the dafault 7 otherwise.
+For example, You may want to use only 5 layers in your Alexnet model if the dataset of choice is cifar10, and the default 7 otherwise.
  
 We can start with a config that looks like this:
 ### initial config.yaml

--- a/website/versioned_docs/version-1.1/advanced/plugins/develop.md
+++ b/website/versioned_docs/version-1.1/advanced/plugins/develop.md
@@ -18,7 +18,7 @@ When developing Hydra plugins, keep the following things in mind:
   
 ## Plugin discovery process
 The plugin discovery process runs whenever Hydra starts. During plugin discovery, Hydra scans for plugins in all the submodules of `hydra_plugins`. Hydra will import each module and look for plugins defined in that module.
-Any module under `hydra_plugins` that is slow to import will slow down the startup of __ALL__ Hydra applicaitons.
+Any module under `hydra_plugins` that is slow to import will slow down the startup of __ALL__ Hydra applications.
 Plugins with expensive imports can exclude individual files from Hydra's plugin discovery process by prefixing them with `_` (but not `__`).
 For example, the file `_my_plugin_lib.py` would not be imported and scanned, while `my_plugin_lib.py` would be.
 

--- a/website/versioned_docs/version-1.1/patterns/specializing_config.md
+++ b/website/versioned_docs/version-1.1/patterns/specializing_config.md
@@ -8,7 +8,7 @@ import {ExampleGithubLink} from "@site/src/components/GithubLink"
 <ExampleGithubLink text="Example application" to="examples/patterns/specializing_config"/>
 
 In some cases the desired configuration should depend on other configuration choices.
-For example, You may want to use only 5 layers in your Alexnet model if the dataset of choice is cifar10, and the dafault 7 otherwise.
+For example, You may want to use only 5 layers in your Alexnet model if the dataset of choice is cifar10, and the default 7 otherwise.
  
 We can start with a config that looks like this:
 ### initial config.yaml

--- a/website/versioned_docs/version-1.2/patterns/specializing_config.md
+++ b/website/versioned_docs/version-1.2/patterns/specializing_config.md
@@ -8,7 +8,7 @@ import {ExampleGithubLink} from "@site/src/components/GithubLink"
 <ExampleGithubLink text="Example application" to="examples/patterns/specializing_config"/>
 
 In some cases the desired configuration should depend on other configuration choices.
-For example, You may want to use only 5 layers in your Alexnet model if the dataset of choice is cifar10, and the dafault 7 otherwise.
+For example, You may want to use only 5 layers in your Alexnet model if the dataset of choice is cifar10, and the default 7 otherwise.
  
 We can start with a config that looks like this:
 ### initial config.yaml


### PR DESCRIPTION
There are small typos in:
- website/docs/patterns/specializing_config.md
- website/versioned_docs/version-1.0/advanced/plugins.md
- website/versioned_docs/version-1.0/patterns/specializing_config.md
- website/versioned_docs/version-1.1/advanced/plugins/develop.md
- website/versioned_docs/version-1.1/patterns/specializing_config.md
- website/versioned_docs/version-1.2/patterns/specializing_config.md

Fixes:
- Should read `default` rather than `dafault`.
- Should read `applications` rather than `applicaitons`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md