### PR TITLE
Copy entire `master_config` cache to `sweep_config`.

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -4,9 +4,8 @@ import os
 import re
 import sys
 import warnings
-from collections import defaultdict
 from textwrap import dedent
-from typing import Any, Dict, List, MutableSequence, Optional
+from typing import Any, List, MutableSequence, Optional
 
 from omegaconf import Container, DictConfig, OmegaConf, flag_override, open_dict
 from omegaconf.errors import (

--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -311,13 +311,10 @@ class ConfigLoaderImpl(ConfigLoader):
             run_mode=RunMode.RUN,
         )
 
-        # Partial copy of master config cache, to ensure we get the same resolved values for timestamps
-        cache: Dict[str, Any] = defaultdict(dict, {})
-        cache_master_config = OmegaConf.get_cache(master_config)
-        for k in ["now"]:
-            if k in cache_master_config:
-                cache[k] = cache_master_config[k]
-        OmegaConf.set_cache(sweep_config, cache)
+        # Copy old config cache to ensure we get the same resolved values (for things
+        # like timestamps etc). Since `oc.env` does not cache environment variables
+        # (but the deprecated `env` resolver did), the entire config should be copied
+        OmegaConf.copy_cache(from_config=master_config, to_config=sweep_config)
 
         return sweep_config
 

--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -59,7 +59,8 @@ class ConfigLoaderImpl(ConfigLoader):
                 if run_mode == RunMode.MULTIRUN:
                     if x.is_hydra_override():
                         raise ConfigCompositionException(
-                            f"Sweeping over Hydra's configuration is not supported : '{x.input_line}'"
+                            "Sweeping over Hydra's configuration is not supported :"
+                            f" '{x.input_line}'"
                         )
                 elif run_mode == RunMode.RUN:
                     if x.value_type == ValueType.SIMPLE_CHOICE_SWEEP:
@@ -111,18 +112,19 @@ class ConfigLoaderImpl(ConfigLoader):
                     if source.scheme() == "pkg":
                         if source.path == "":
                             msg = (
-                                "Primary config module is empty."
-                                "\nPython requires resources to be in a module with an __init__.py file"
+                                "Primary config module is empty.\nPython requires"
+                                " resources to be in a module with an __init__.py file"
                             )
                         else:
                             msg = (
-                                f"Primary config module '{source.path}' not found."
-                                f"\nCheck that it's correct and contains an __init__.py file"
+                                f"Primary config module '{source.path}' not"
+                                " found.\nCheck that it's correct and contains an"
+                                " __init__.py file"
                             )
                     else:
                         msg = (
-                            f"Primary config directory not found."
-                            f"\nCheck that the config directory '{source.path}' exists and readable"
+                            "Primary config directory not found.\nCheck that the"
+                            f" config directory '{source.path}' exists and readable"
                         )
 
                     self._missing_config_error(
@@ -166,7 +168,8 @@ class ConfigLoaderImpl(ConfigLoader):
 
         if not OmegaConf.is_dict(primary_config):
             raise ConfigCompositionException(
-                f"primary config '{config_name}' must be a DictConfig, got {type(primary_config).__name__}"
+                f"primary config '{config_name}' must be a DictConfig, got"
+                f" {type(primary_config).__name__}"
             )
 
         def is_searchpath_override(v: Override) -> bool:
@@ -213,7 +216,10 @@ class ConfigLoaderImpl(ConfigLoader):
             if not source.available():
                 warnings.warn(
                     category=UserWarning,
-                    message=f"provider={source.provider}, path={source.path} is not available.",
+                    message=(
+                        f"provider={source.provider}, path={source.path} is not"
+                        " available."
+                    ),
                 )
 
     def _load_configuration_impl(
@@ -326,8 +332,9 @@ class ConfigLoaderImpl(ConfigLoader):
         for override in overrides:
             if override.package is not None:
                 raise ConfigCompositionException(
-                    f"Override {override.input_line} looks like a config group override, "
-                    f"but config group '{override.key_or_group}' does not exist."
+                    f"Override {override.input_line} looks like a config group"
+                    f" override, but config group '{override.key_or_group}' does not"
+                    " exist."
                 )
 
             key = override.key_or_group
@@ -337,12 +344,14 @@ class ConfigLoaderImpl(ConfigLoader):
                     config_val = OmegaConf.select(cfg, key, throw_on_missing=False)
                     if config_val is None:
                         raise ConfigCompositionException(
-                            f"Could not delete from config. '{override.key_or_group}' does not exist."
+                            f"Could not delete from config. '{override.key_or_group}'"
+                            " does not exist."
                         )
                     elif value is not None and value != config_val:
                         raise ConfigCompositionException(
-                            f"Could not delete from config."
-                            f" The value of '{override.key_or_group}' is {config_val} and not {value}."
+                            "Could not delete from config. The value of"
+                            f" '{override.key_or_group}' is {config_val} and not"
+                            f" {value}."
                         )
 
                     last_dot = key.rfind(".")
@@ -395,7 +404,8 @@ class ConfigLoaderImpl(ConfigLoader):
 
         if not OmegaConf.is_config(ret.config):
             raise ValueError(
-                f"Config {config_path} must be an OmegaConf config, got {type(ret.config).__name__}"
+                f"Config {config_path} must be an OmegaConf config, got"
+                f" {type(ret.config).__name__}"
             )
 
         if not ret.is_schema_source:
@@ -473,7 +483,8 @@ class ConfigLoaderImpl(ConfigLoader):
             and OmegaConf.select(res.config, "hydra.searchpath") is not None
         ):
             raise ConfigCompositionException(
-                f"In '{config_path}': Overriding hydra.searchpath is only supported from the primary config"
+                f"In '{config_path}': Overriding hydra.searchpath is only supported"
+                " from the primary config"
             )
 
         return res
@@ -517,7 +528,8 @@ class ConfigLoaderImpl(ConfigLoader):
                     cfg.merge_with(loaded.config)
                 except OmegaConfBaseException as e:
                     raise ConfigCompositionException(
-                        f"In '{default.config_path}': {type(e).__name__} raised while composing config:\n{e}"
+                        f"In '{default.config_path}': {type(e).__name__} raised while"
+                        f" composing config:\n{e}"
                     ).with_traceback(sys.exc_info()[2])
 
         # # remove remaining defaults lists from all nodes.

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -193,7 +193,10 @@ class TestConfigLoader:
         version.setbase("1.1")
         with warns(
             UserWarning,
-            match="Support for .yml files is deprecated. Use .yaml extension for Hydra config files",
+            match=(
+                "Support for .yml files is deprecated. Use .yaml extension for Hydra"
+                " config files"
+            ),
         ):
             cfg = config_loader.load_configuration(
                 config_name="config.yml",
@@ -235,7 +238,6 @@ class TestConfigLoader:
     def test_load_config_with_schema(
         self, hydra_restore_singletons: Any, path: str
     ) -> None:
-
         ConfigStore.instance().store(
             name="config_with_schema", node=TopLevelConfig, provider="this_test"
         )
@@ -279,7 +281,6 @@ class TestConfigLoader:
     def test_load_config_file_with_schema_validation(
         self, hydra_restore_singletons: Any, path: str
     ) -> None:
-
         with ConfigStoreWithProvider("this_test") as cs:
             cs.store(name="config", node=TopLevelConfig)
             cs.store(group="db", name="mysql", node=MySQLConfig, package="db")
@@ -317,7 +318,6 @@ class TestConfigLoader:
     def test_load_config_with_validation_error(
         self, hydra_restore_singletons: Any, path: str
     ) -> None:
-
         ConfigStore.instance().store(
             name="base_mysql", node=MySQLConfig, provider="this_test"
         )
@@ -342,7 +342,6 @@ class TestConfigLoader:
     def test_load_config_with_key_error(
         self, hydra_restore_singletons: Any, path: str
     ) -> None:
-
         ConfigStore.instance().store(
             name="base_mysql", node=MySQLConfig, provider="this_test"
         )
@@ -383,16 +382,10 @@ class TestConfigLoader:
         # pseudorandom resolvers with/without value caching
         pseudorandom_values = iter(["1st", "2nd", "3rd", "4th"])
         OmegaConf.register_new_resolver(
-            "cached",
-            lambda: next(pseudorandom_values),
-            use_cache=True,
-            replace=True
+            "cached", lambda: next(pseudorandom_values), use_cache=True, replace=True
         )
         OmegaConf.register_new_resolver(
-            "uncached",
-            lambda: next(pseudorandom_values),
-            use_cache=False,
-            replace=True
+            "uncached", lambda: next(pseudorandom_values), use_cache=False, replace=True
         )
 
         monkeypatch.setenv("TEST_ENV", "test_env")
@@ -563,7 +556,6 @@ class Config:
 
 
 def test_overlapping_schemas(hydra_restore_singletons: Any) -> None:
-
     cs = ConfigStore.instance()
     cs.store(name="config", node=Config)
     cs.store(group="plugin", name="concrete", node=ConcretePlugin)
@@ -766,7 +758,8 @@ def test_complex_defaults(overrides: Any, expected: Any) -> None:
             raises(
                 HydraException,
                 match=re.escape(
-                    "Override foo@bar=10 looks like a config group override, but config group 'foo' does not exist."
+                    "Override foo@bar=10 looks like a config group override, but config"
+                    " group 'foo' does not exist."
                 ),
             ),
             id="config_group_missing",


### PR DESCRIPTION
Partially reverts the intention of #749 (to not copy cached `env` resolver values), as that pull request was made redundant by #1653 (on account of `env` being deprecated, and replaced by the non-caching `oc.env` resolver). Expanded tests to check behaviour of arbitrarily named resolvers (and not just the "special" `now` and `oc.env` resolvers) with/without value caching.

<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

I wanted to create randomly (but memorably) named output directories (say, using the `coolname` python package), instead of using `${now:}` time-stamped directories. Unfortunately, as only the values cached by the `now` resolver are copied from the `master_config` to the `sweep_config` this is impossible (or at least very, very difficult?). Without copying the cache (and the accompanying "random directory name" generated by the `master_config`), every `sweep_config` job is written into a differently named output directory. 

I initially tried using a `hydra.experimental.callback.Callback` to pass "cached" values between the launcher and sweeper configs. I used `on_run_start`/`on_multirun_start` to record the output directory name generated by the launcher, but unfortunately the `on_job_start` method is called too late (that is, just after the sweep directory is created) for me to copy the callback's "cached" value...

This pull request reverts the behaviour of #749, which I argue was a little too strict - instead it (or this pull request) could have copied the entire `master_config` cache to the `sweep_config` EXCEPT for any `"env"` values. Since the `env` resolver has been deprecated (and replaced with the non-caching `oc.env` resolver), I decided not to introduce an `if k == "env":` loop/branch (to filter our `"env"` values), and instead simply copied across the entire cache.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

I've updated the test to additionally check the behaviour of arbitrarily named resolvers (and not just `hydra`'s/`omegaconf`'s "special" `now` and `oc.env` resolvers) with/without value caching. Arguably the `now` and `oc.env` present in `test_sweep_config_cache` already provide sufficient coverage by themselves though.

## Related Issues and PRs

Partially reverts #749. Motivated by #1653
