### PR TITLE
fix hydra-ray-launcher dependency for python versions >= 3.8

### DIFF
--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core_aws.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core_aws.py
@@ -8,9 +8,9 @@ from typing import Any, Dict, List, Sequence
 
 import cloudpickle  # type: ignore
 
-if sys.version_info < (3, 8):
+try:
     import pickle5 as pickle  # type: ignore
-else:
+except ModuleNotFoundError:
     import pickle
 from hydra.core.singleton import Singleton
 from hydra.core.utils import JobReturn, configure_log, filter_overrides, setup_globals

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core_aws.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core_aws.py
@@ -2,7 +2,6 @@
 import logging
 import os
 import tempfile
-import sys
 from pathlib import Path
 from typing import Any, Dict, List, Sequence
 

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core_aws.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core_aws.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import tempfile
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Sequence
 

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core_aws.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core_aws.py
@@ -6,7 +6,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Sequence
 
 import cloudpickle  # type: ignore
-import pickle5 as pickle  # type: ignore
+if sys.version_info < (3, 8):
+    import pickle5 as pickle  # type: ignore
+else:
+    import pickle
 from hydra.core.singleton import Singleton
 from hydra.core.utils import JobReturn, configure_log, filter_overrides, setup_globals
 from omegaconf import OmegaConf, open_dict, read_write

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core_aws.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core_aws.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Sequence
 
 import cloudpickle  # type: ignore
+
 if sys.version_info < (3, 8):
     import pickle5 as pickle  # type: ignore
 else:

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_remote_invoke.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_remote_invoke.py
@@ -9,6 +9,7 @@ from typing import List
 from urllib.request import urlopen
 
 import cloudpickle  # type: ignore
+
 if sys.version_info < (3, 8):
     import pickle5 as pickle  # type: ignore
 else:

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_remote_invoke.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_remote_invoke.py
@@ -10,9 +10,9 @@ from urllib.request import urlopen
 
 import cloudpickle  # type: ignore
 
-if sys.version_info < (3, 8):
+try:
     import pickle5 as pickle  # type: ignore
-else:
+except ModuleNotFoundError:
     import pickle
 import ray
 from hydra.core.hydra_config import HydraConfig

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_remote_invoke.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_remote_invoke.py
@@ -9,7 +9,10 @@ from typing import List
 from urllib.request import urlopen
 
 import cloudpickle  # type: ignore
-import pickle5 as pickle  # type: ignore
+if sys.version_info < (3, 8):
+    import pickle5 as pickle  # type: ignore
+else:
+    import pickle
 import ray
 from hydra.core.hydra_config import HydraConfig
 from hydra.core.singleton import Singleton

--- a/plugins/hydra_ray_launcher/integration_test_tools/setup_integration_test_ami.py
+++ b/plugins/hydra_ray_launcher/integration_test_tools/setup_integration_test_ami.py
@@ -10,7 +10,7 @@ dependencies = [
     # https://github.com/aio-libs/aiohttp/issues/6203
     "aiohttp==3.8.1",
     "cloudpickle==2.0.0",
-    "pickle5==0.0.11",
+    "pickle5==0.0.11; python_version < '3.8.0'",
 ]
 
 

--- a/plugins/hydra_ray_launcher/setup.py
+++ b/plugins/hydra_ray_launcher/setup.py
@@ -29,7 +29,7 @@ setup(
         "ray[default]==1.12.0",
         "aiohttp==3.8.1",
         "cloudpickle==2.0.0",
-        "pickle5==0.0.11",
+        "pickle5==0.0.11; python_version < '3.8'",
     ],
     include_package_data=True,
 )


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

pickle5 does not support python versions >= 3.8. Thus, the default pickle library should be used for those versions.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Previous existing tests

## Related Issues and PRs

https://github.com/facebookresearch/hydra/issues/2318#issue-1319651414
https://github.com/facebookresearch/hydra/issues/2079#issue-1163741413