### PR TITLE
include version number in stable docs urls

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -131,6 +131,7 @@ module.exports = {
                     showLastUpdateAuthor: true,
                     showLastUpdateTime: true,
                     editUrl: 'https://github.com/facebookresearch/hydra/edit/main/website/',
+                    lastVersion: 'current',
                 },
                 theme: {
                     customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Before this PR:
- https://hydra.cc/docs/next/intro/ -> "Next" version
- https://hydra.cc/docs/intro/ -> v1.2
- https://hydra.cc/docs/1.2/intro/ -> page crashes
- https://hydra.cc/docs/1.1/intro/ -> v1.1
- https://hydra.cc/docs/1.0/intro/ -> v1.0

After this PR:
- https://hydra.cc/docs/next/intro/ -> page crashes
- https://hydra.cc/docs/intro/ -> "Next" version
- https://hydra.cc/docs/1.2/intro/ -> v1.2
- https://hydra.cc/docs/1.1/intro/ -> v1.1
- https://hydra.cc/docs/1.0/intro/ -> v1.0

Closes #1871.