### PR TITLE
hydra_ax_sweeper support for when evaluation function returns a dict

### DIFF
--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
@@ -221,8 +221,11 @@ class CoreAxSweeper(Sweeper):
             for idx in range(len(batch)):
                 val: Any = rets[idx].return_value
                 # Ax expects a measured value (int or float), which can optionally
-                # be given in a tuple along with the error of that measurement
-                assert isinstance(val, (int, float, tuple))
+                # be given in a tuple along with the error of that measurement.
+                # Alternatively, the task function can return a dict whose values
+                # represent multiple metrics, where each key is the name of the metric
+                # and the item can be an int, float or tuple.
+                assert isinstance(val, (int, float, tuple, dict))
                 # is_noisy specifies how Ax should behave when not given an error value.
                 # if true (default), the error of each measurement is inferred by Ax.
                 # if false, the error of each measurement is set to 0.

--- a/plugins/hydra_ax_sweeper/news/2330.feature
+++ b/plugins/hydra_ax_sweeper/news/2330.feature
@@ -1,0 +1,1 @@
+Support returning a dict (rather than just a scalar value) from the `@hydra.main`-decorated task function

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_constraint.py
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_constraint.py
@@ -1,0 +1,24 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from typing import Any
+
+import hydra
+from omegaconf import DictConfig
+
+
+@hydra.main(
+    version_base=None, config_path=".", config_name="polynomial_with_constraint"
+)
+def polynomial(cfg: DictConfig) -> Any:
+    x = cfg.polynomial.x
+    y = cfg.polynomial.y
+    z = cfg.polynomial.x
+    a = 100
+    b = 10
+    c = 1
+    result = a * (x**2) + b * y + c * z
+    constraint_metric = y * x
+    return {"result": result, "constraint_metric": constraint_metric}
+
+
+if __name__ == "__main__":
+    polynomial()

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_constraint.yaml
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_constraint.yaml
@@ -1,0 +1,25 @@
+defaults:
+  - override hydra/sweeper: ax
+
+polynomial:
+  x: ???
+  y: ???
+  z: ???
+
+hydra:
+  sweeper:
+    ax_config:
+      max_trials: 10
+
+      experiment:
+        minimize: true
+        objective_name: result
+        outcome_constraints: ['constraint_metric >= 2.1']  # Optional.
+
+      early_stop:
+        max_epochs_without_improvement: 2
+
+      params:
+        polynomial.x:
+          type: range
+          bounds: [-1, 1]

--- a/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
+++ b/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
@@ -247,6 +247,27 @@ def test_search_space_exhausted_exception(tmpdir: Path, cmd_args: List[str]) -> 
 
 
 @mark.parametrize(
+    "cmd_args",
+    [
+        ["polynomial.y=choice(-1, 0, 1)", "polynomial.x=range(2,4)"],
+        ["polynomial.y=1", "polynomial.x=range(2,4)"],
+    ],
+)
+def test_search_space_with_constraint_metric(tmpdir: Path, cmd_args: List[str]) -> None:
+    # test that outcome_constraints experiment parameter `outcome_constraints`
+    # works correctly, and that the ax_sweeper supports outputting a dictionary
+    # from the evaluation function so that multiple metrics can be supported.
+    cmd = [
+        "tests/apps/polynomial_with_constraint.py",
+        "-m",
+        "hydra.run.dir=" + str(tmpdir),
+        "hydra.job.chdir=True",
+        "hydra.sweeper.ax_config.max_trials=2",
+    ] + cmd_args
+    results, _ = run_python_script(cmd)
+
+
+@mark.parametrize(
     "cmd_arg, serialized_encoding, best_coefficients, best_value",
     [
         (


### PR DESCRIPTION
## Motivation

ax supports optimisation using multiple metrics. One use case is that we may have an experiment which optimises based on one metric (`experiment.objective_name`), but than we can define additional constraints and these can be based on other metrics (`experiments.outcome_constraints`).  Multiple metric outputs are supported by returning a dictionary from the evaluation function. Currently ax-sweeper does not support this as it does not allow a dict as the `raw_data` input to `ax_client.complete_trial()`:

see _core.py line 228:
```
                assert isinstance(val, (int, float, tuple))
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

I have added a new test that tests that when the evaluation function returns a dict of metrics, and that the sweeper runs and the `experiment.objective_name` and `experiments.outcome_constraints` experimental parameters are interpreted by ax.