### PR TITLE
for forked PRs, run all nox sessions at once

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,9 +130,11 @@ jobs:
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
             conda activate hydra
             pip install nox dataclasses --progress-bar off
-            nox -s lint test_tools test_core test_jupyter_notebooks -ts
             if [ -n "$CIRCLE_PR_NUMBER" ]; then
-              SKIP_PLUGINS=hydra_ray_launcher nox -s lint_plugins test_plugins test_plugins_vs_core -ts
+              SKIP_PLUGINS=hydra_ray_launcher nox -s lint test_tools test_core \
+                test_jupyter_notebooks lint_plugins test_plugins test_plugins_vs_core -ts
+            else
+              nox -s lint test_tools test_core test_jupyter_notebooks -ts
             fi
   test_linux:
     parameters:
@@ -149,9 +151,11 @@ jobs:
             export PATH="$HOME/miniconda3/envs/hydra/bin:$PATH"
             export NOX_PYTHON_VERSIONS=<< parameters.py_version >>
             pip install nox dataclasses --progress-bar off
-            nox -s lint test_tools test_core test_jupyter_notebooks -ts
             if [ -n "$CIRCLE_PR_NUMBER" ]; then
-              SKIP_PLUGINS=hydra_ray_launcher nox -s lint_plugins test_plugins test_plugins_vs_core -ts
+              SKIP_PLUGINS=hydra_ray_launcher nox -s lint test_tools test_core \
+                test_jupyter_notebooks lint_plugins test_plugins test_plugins_vs_core -ts
+            else
+              nox -s lint test_tools test_core test_jupyter_notebooks -ts
             fi
   test_win:
     parameters:
@@ -169,8 +173,12 @@ jobs:
             $env:ConEmuDefaultCp=65001
             $env:PYTHONIOENCODING="utf_8"
             conda activate hydra
-            nox -s lint test_tools test_core test_jupyter_notebooks -ts
-            If ($env:CIRCLE_PR_NUMBER) {$env:SKIP_PLUGINS="hydra_ray_launcher"; nox -s lint_plugins test_plugins test_plugins_vs_core -ts}
+            If ($env:CIRCLE_PR_NUMBER) {
+              $env:SKIP_PLUGINS="hydra_ray_launcher"
+              nox -s lint test_tools test_core test_jupyter_notebooks lint_plugins test_plugins test_plugins_vs_core -ts
+            } else {
+              nox -s lint test_tools test_core test_jupyter_notebooks -ts
+            }
             exit $LASTEXITCODE
   trigger_plugin_pipelines:
     docker:


### PR DESCRIPTION
This diff updates our CI so that nox is only called once.

Instead of calling nox twice (once to run `lint`/`test_tools`/`test_core`/`test_jupyter_notebooks`, and once to run `lint_plugins`/`test_plugins`), all of these test sessions are run with a single nox invocation.

Motivation:
When using two calls to nox (as before this diff), a CI failure in the first nox call would cause the second nox call to be skipped. This means e.g. if the `lint` session from the first call fails, then we would not get signal from the `lint_plugins` or `test_plugins` sessions of the second call.