### PR TITLE
add task_function kwarg to on_job_start callback

### DIFF
--- a/hydra/_internal/callbacks.py
+++ b/hydra/_internal/callbacks.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from omegaconf import DictConfig, OmegaConf
 
+from hydra.types import TaskFunction
+
 if TYPE_CHECKING:
     from hydra.core.utils import JobReturn
 
@@ -41,8 +43,15 @@ class Callbacks:
             function_name="on_multirun_end", reverse=True, config=config, **kwargs
         )
 
-    def on_job_start(self, config: DictConfig, **kwargs: Any) -> None:
-        self._notify(function_name="on_job_start", config=config, **kwargs)
+    def on_job_start(
+        self, config: DictConfig, *, task_function: TaskFunction, **kwargs: Any
+    ) -> None:
+        self._notify(
+            function_name="on_job_start",
+            config=config,
+            task_function=task_function,
+            **kwargs,
+        )
 
     def on_job_end(
         self, config: DictConfig, job_return: "JobReturn", **kwargs: Any

--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -183,7 +183,7 @@ def run_job(
             _save_config(config.hydra.overrides.task, "overrides.yaml", hydra_output)
 
         with env_override(hydra_cfg.hydra.job.env_set):
-            callbacks.on_job_start(config=config)
+            callbacks.on_job_start(config=config, task_function=task_function)
             try:
                 ret.return_value = task_function(task_cfg)
                 ret.status = JobStatus.COMPLETED

--- a/hydra/experimental/callback.py
+++ b/hydra/experimental/callback.py
@@ -5,6 +5,7 @@ from typing import Any
 from omegaconf import DictConfig
 
 from hydra.core.utils import JobReturn
+from hydra.types import TaskFunction
 
 logger = logging.getLogger(__name__)
 
@@ -38,11 +39,14 @@ class Callback:
         """
         ...
 
-    def on_job_start(self, config: DictConfig, **kwargs: Any) -> None:
+    def on_job_start(
+        self, config: DictConfig, *, task_function: TaskFunction, **kwargs: Any
+    ) -> None:
         """
         Called in both RUN and MULTIRUN modes, once for each Hydra job (before running application code).
         This is called from within `hydra.core.utils.run_job`. In the case of remote launching, this will be executed
-        on the remote server along with your application code.
+        on the remote server along with your application code. The `task_function` argument is the function
+        decorated with `@hydra.main`.
         """
         ...
 

--- a/tests/test_apps/app_with_callbacks/on_job_start_accepts_task_function/__init__.py
+++ b/tests/test_apps/app_with_callbacks/on_job_start_accepts_task_function/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/tests/test_apps/app_with_callbacks/on_job_start_accepts_task_function/config.yaml
+++ b/tests/test_apps/app_with_callbacks/on_job_start_accepts_task_function/config.yaml
@@ -1,0 +1,4 @@
+hydra:
+  callbacks:
+    custom_callback:
+      _target_: my_app.OnJobStartCallback

--- a/tests/test_apps/app_with_callbacks/on_job_start_accepts_task_function/my_app.py
+++ b/tests/test_apps/app_with_callbacks/on_job_start_accepts_task_function/my_app.py
@@ -1,0 +1,29 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import logging
+from typing import Any
+
+from omegaconf import DictConfig
+
+import hydra
+from hydra.experimental.callback import Callback
+from hydra.types import TaskFunction
+
+log = logging.getLogger(__name__)
+
+
+class OnJobStartCallback(Callback):
+    def on_job_start(
+        self, config: DictConfig, *, task_function: TaskFunction, **kwargs: Any
+    ) -> None:
+        assert task_function(...) == "called my_app"
+        log.info(f"on_job_start task_function: {task_function}")
+
+
+@hydra.main(version_base=None, config_path=".", config_name="config")
+def my_app(cfg: DictConfig) -> Any:
+    return "called my_app"
+
+
+if __name__ == "__main__":
+    my_app()

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 from typing import Any, List
 
 from omegaconf import open_dict, read_write
-from pytest import mark
+from pytest import mark, param
 
 from hydra.core.utils import JobReturn, JobStatus
 from hydra.test_utils.test_utils import (
@@ -22,9 +22,10 @@ chdir_hydra_root()
 
 
 @mark.parametrize(
-    "args,expected",
+    "app_path,args,expected",
     [
-        (
+        param(
+            "tests/test_apps/app_with_callbacks/custom_callback/my_app.py",
             [],
             dedent(
                 """\
@@ -36,8 +37,10 @@ chdir_hydra_root()
                 [JOB] custom_callback on_job_end
                 [JOB] custom_callback on_run_end"""
             ),
+            id="custom_callback",
         ),
-        (
+        param(
+            "tests/test_apps/app_with_callbacks/custom_callback/my_app.py",
             [
                 "foo=bar",
                 "-m",
@@ -54,8 +57,10 @@ chdir_hydra_root()
                 [JOB] custom_callback on_job_end
                 [HYDRA] custom_callback on_multirun_end"""
             ),
+            id="custom_callback_multirun",
         ),
-        (
+        param(
+            "tests/test_apps/app_with_callbacks/custom_callback/my_app.py",
             [
                 "--config-name",
                 "config_with_two_callbacks",
@@ -75,16 +80,22 @@ chdir_hydra_root()
                 [JOB] callback_2 on_run_end
                 [JOB] callback_1 on_run_end"""
             ),
+            id="two_custom_callbacks",
+        ),
+        param(
+            "tests/test_apps/app_with_callbacks/on_job_start_accepts_task_function/my_app.py",
+            [],
+            r"\[JOB\] on_job_start task_function: <function my_app at 0x[0-9a-f]+>",
+            id="on_job_start_task_function",
         ),
     ],
 )
 def test_app_with_callbacks(
     tmpdir: Path,
+    app_path: str,
     args: List[str],
     expected: str,
 ) -> None:
-    app_path = "tests/test_apps/app_with_callbacks/custom_callback/my_app.py"
-
     cmd = [
         app_path,
         "hydra.run.dir=" + str(tmpdir),

--- a/website/docs/experimental/callbacks.md
+++ b/website/docs/experimental/callbacks.md
@@ -26,6 +26,8 @@ The full API exposed by the `hydra.experimental.callback.Callback` class is list
 <details><summary>Events supported (Click to expand)</summary>
 
 ```python
+from hydra.types import TaskFunction
+
 class Callback:
     def on_run_start(self, config: DictConfig, **kwargs: Any) -> None:
         """
@@ -55,11 +57,12 @@ class Callback:
         """
         ...
 
-    def on_job_start(self, config: DictConfig, **kwargs: Any) -> None:
+    def on_job_start(self, config: DictConfig, *, task_function: TaskFunction, **kwargs: Any) -> None:
         """
         Called in both RUN and MULTIRUN modes, once for each Hydra job (before running application code).
         This is called from within `hydra.core.utils.run_job`. In the case of remote launching, this will be executed
-        on the remote server along with your application code.
+        on the remote server along with your application code. The `task_function` argument is the function
+        decorated with `@hydra.main`.
         """
         ...
 


### PR DESCRIPTION
This PR closes feature request #2352 opened by @jgbos, adding a `task_function` keyword argument to the `on_job_start` callback.

TODO:
- [X] add test