### PR TITLE
Optuna Sweeper dev release

### DIFF
--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/__init__.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.2.0"
+__version__ = "1.3.0.dev0"


### PR DESCRIPTION
Bump the hydra-optuna-sweeper version `1.2.0` -> `1.3.0.dev0`.
This is motivated by the [recent comments](https://github.com/facebookresearch/hydra/pull/2215#issuecomment-1239270848) on PR #2215; I plan to push a dev release of hydra-optuna-sweeper to Pypi shortly.