### PR TITLE
nevergrad sweeper: unpin numpy

### DIFF
--- a/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/__init__.py
+++ b/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.2.0"
+__version__ = "1.3.0.dev0"

--- a/plugins/hydra_nevergrad_sweeper/setup.py
+++ b/plugins/hydra_nevergrad_sweeper/setup.py
@@ -27,8 +27,6 @@ setup(
     install_requires=[
         "hydra-core>=1.1.0.dev7",
         "nevergrad>=0.4.3.post9",
-        "cma==3.0.3",  # https://github.com/facebookresearch/hydra/issues/1684
-        "numpy<1.20.0",  # remove once nevergrad is upgraded to support numpy 1.20
     ],
     include_package_data=True,
 )

--- a/plugins/hydra_nevergrad_sweeper/setup.py
+++ b/plugins/hydra_nevergrad_sweeper/setup.py
@@ -21,6 +21,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: OS Independent",
         "Development Status :: 4 - Beta",
     ],

--- a/plugins/hydra_nevergrad_sweeper/tests/test_nevergrad_sweeper_plugin.py
+++ b/plugins/hydra_nevergrad_sweeper/tests/test_nevergrad_sweeper_plugin.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import sys
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -123,8 +124,17 @@ def test_launched_jobs(hydra_sweep_runner: TSweepRunner) -> None:
             "bar=4:8",
         ],
     )
-    with sweep:
-        assert sweep.returns is None
+    with warnings.catch_warnings():  # ignore specific warnings raised by sweep:
+        warnings.filterwarnings(
+            "ignore", category=ng.common.errors.InefficientSettingsWarning
+        )
+        warnings.filterwarnings(
+            "ignore",
+            category=UserWarning,
+            message=r"Could not import matplotlib\.pyplot",
+        )
+        with sweep:
+            assert sweep.returns is None
 
 
 @mark.parametrize("with_commandline", (True, False))


### PR DESCRIPTION
This PR closes issue #2362 by removing the nevergrad sweeper's pin on `numpy`.

Three Commits:
- Bump hydra-nevergrad-sweeper dev version 1.2.0 -> 1.3.0.dev0
- nevergrad-sweeper: remove pins on numpy and cma
- nevergrad-sweeper: support python3.10

I'll confirm that the nevergrad CI passes before merging.

Todo after merge:
- [ ] publish dev release of `hydra-negergrad-sweeper` to Pypi