### PR TITLE
fixup for PR #2361: accommodate windows in regex

### DIFF
--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -85,7 +85,7 @@ chdir_hydra_root()
         param(
             "tests/test_apps/app_with_callbacks/on_job_start_accepts_task_function/my_app.py",
             [],
-            r"\[JOB\] on_job_start task_function: <function my_app at 0x[0-9a-f]+>",
+            r"\[JOB\] on_job_start task_function: <function my_app at 0x[0-9a-fA-F]+>",
             id="on_job_start_task_function",
         ),
     ],


### PR DESCRIPTION
This PR follows up on #2361 by expanding a regular expression that was causing Windows CI failure.
Windows uses uppercase letters for string representations of object addresses in memory, while linux/mac use lowercase letters:
- `'<function foo at 0x1114d2cb0>'` (linux/mac)
- `'<function foo at 0x1114D2CB0>'` (windows)