### PR TITLE
Make ax sweeper ci pass

### DIFF
--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/__init__.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.2.0"
+__version__ = "1.3.0.dev0"

--- a/plugins/hydra_ax_sweeper/setup.py
+++ b/plugins/hydra_ax_sweeper/setup.py
@@ -29,6 +29,7 @@ setup(
         "hydra-core>=1.1.0.dev7",
         "ax-platform>=0.1.20,<0.2.1",  # https://github.com/facebookresearch/hydra/issues/1767
         "torch",
+        "gpytorch<=1.8.1",  # avoid deprecation warnings. This can probably be removed when ax-platform is unpinned.
     ],
     include_package_data=True,
 )


### PR DESCRIPTION
We're getting some deprecation warnings from one of the ax sweeper's dependencies (e.g. see [this](https://app.circleci.com/pipelines/github/facebookresearch/hydra/14817/workflows/c2532f0b-3e59-49ab-a69d-4a936dc9c591/jobs/147395) example CI failure). This PR pins one of the dependencies of `hydra-ax-sweeper` as a stopgap for the deprecation warnings.