### PR TITLE
setup.py: explicitly distribute hydra submodules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import pathlib
 
 import pkg_resources
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 from build_helpers.build_helpers import (
     ANTLRCommand,
@@ -41,7 +41,7 @@ with open("README.md", "r") as fh:
         long_description_content_type="text/markdown",
         url="https://github.com/facebookresearch/hydra",
         keywords="command-line configuration yaml tab-completion",
-        packages=find_packages(include=["hydra"]),
+        packages=find_namespace_packages(include=["hydra", "hydra.*"]),
         include_package_data=True,
         classifiers=[
             "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Resolves a setuptools deprecation warning that results when building
wheels. Closes https://github.com/facebookresearch/hydra/issues/2383 .