### PR TITLE
support absolute --config-path (#2368)

### DIFF
--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -123,7 +123,9 @@ def compute_search_path_dir(
     calling_module: Optional[str],
     config_path: Optional[str],
 ) -> Optional[str]:
-    if calling_file is not None:
+    if config_path is not None and os.path.isabs(config_path):
+        search_path_dir = config_path
+    elif calling_file is not None:
         abs_base_dir = realpath(dirname(calling_file))
 
         if config_path is not None:
@@ -554,7 +556,7 @@ def get_args_parser() -> argparse.ArgumentParser:
         "--config-path",
         "-cp",
         help="""Overrides the config_path specified in hydra.main().
-                    The config_path is relative to the Python file declaring @hydra.main()""",
+                    The config_path is absolute or relative to the Python file declaring @hydra.main()""",
     )
 
     parser.add_argument(

--- a/news/2368.feature
+++ b/news/2368.feature
@@ -1,0 +1,1 @@
+support specifying an absolute path with `--config-path`

--- a/tests/test_config_search_path.py
+++ b/tests/test_config_search_path.py
@@ -156,6 +156,7 @@ def test_prepend(
         ("foo/bar.py", None, None, None),
         ("foo/bar.py", None, "conf", realpath("foo/conf")),
         ("foo/bar.py", None, "../conf", realpath("conf")),
+        ("foo/bar.py", None, realpath("conf"), realpath("conf")),
         ("c:/foo/bar.py", None, "conf", realpath("c:/foo/conf")),
         ("c:/foo/bar.py", None, "../conf", realpath("c:/conf")),
         (None, "module", None, "pkg://"),
@@ -169,7 +170,7 @@ def test_prepend(
             "foo",
             "package1.rename_package_to.module",
             "../conf",
-            os.path.realpath(os.path.join(os.getcwd(), "../conf")),
+            realpath(os.path.join(os.getcwd(), "../conf")),
         ),
     ],
 )

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -761,7 +761,7 @@ for details.
                     eval "$(python {script} -sc uninstall=bash)"
 
                 --config-path,-cp : Overrides the config_path specified in hydra.main().
-                                    The config_path is relative to the Python file declaring @hydra.main()
+                                    The config_path is absolute or relative to the Python file declaring @hydra.main()
                 --config-name,-cn : Overrides the config_name specified in hydra.main()
                 --config-dir,-cd : Adds an additional config dir to the config search path
                 --experimental-rerun : Rerun a job from a previous config pickle
@@ -819,7 +819,7 @@ for details.
                     eval "$(python {script} -sc uninstall=bash)"
 
                 --config-path,-cp : Overrides the config_path specified in hydra.main().
-                                    The config_path is relative to the Python file declaring @hydra.main()
+                                    The config_path is absolute or relative to the Python file declaring @hydra.main()
                 --config-name,-cn : Overrides the config_name specified in hydra.main()
                 --config-dir,-cd : Adds an additional config dir to the config search path
                 --experimental-rerun : Rerun a job from a previous config pickle
@@ -1033,7 +1033,14 @@ def test_override_with_invalid_group_choice(
     assert re.search(msg, str(e.value)) is not None
 
 
-@mark.parametrize("config_path", ["dir1", "dir2"])
+@mark.parametrize(
+    "config_path",
+    [
+        "dir1",
+        "dir2",
+        os.path.abspath("tests/test_apps/app_with_multiple_config_dirs/dir2"),
+    ],
+)
 @mark.parametrize("config_name", ["cfg1", "cfg2"])
 def test_config_name_and_path_overrides(
     tmpdir: Path, config_path: str, config_name: str
@@ -1048,7 +1055,7 @@ def test_config_name_and_path_overrides(
     result, _err = run_python_script(cmd)
     # normalize newlines on Windows to make testing easier
     result = result.replace("\r\n", "\n")
-    assert result == f"{config_path}_{config_name}: true"
+    assert result == f"{os.path.basename(config_path)}_{config_name}: true"
 
 
 @mark.parametrize(

--- a/website/docs/advanced/hydra-command-line-flags.md
+++ b/website/docs/advanced/hydra-command-line-flags.md
@@ -27,7 +27,7 @@ Running Hydra applications:
 - **--run,-r**: Run is the default mode and is not normally needed.
 - **--multirun,-m**: Run multiple jobs with the configured launcher and sweeper. See [Multi-run](/tutorials/basic/running_your_app/2_multirun.md).
   <br/><br/>
-- **--config-path,-cp**: Overrides the `config_path` specified in `hydra.main()`. The `config_path` is relative to the Python file declaring `@hydra.main()`.
+- **--config-path,-cp**: Overrides the `config_path` specified in `hydra.main()`. The `config_path` is absolute or relative to the Python file declaring `@hydra.main()`.
 - **--config-name,-cn**: Overrides the `config_name` specified in `hydra.main()`.
 - **--config-dir,-cd**: Adds an additional config directory to the [config search path](search_path.md).   
 This is useful for installed apps that want to allow their users to provide additional configs.


### PR DESCRIPTION
This was actually already supported as
os.path.join("/blah", "/abs/config"), just returns "/abs/config", but we've made this explicit in code and docs now.