### PR TITLE
mypy: update python_version and type: ignore comments

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 mypy_path=.stubs
 exclude = (?x)(
     build/

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -290,7 +290,7 @@ class OptunaSweeperImpl(Sweeper):
 
         is_grid_sampler = (
             isinstance(self.sampler, functools.partial)
-            and self.sampler.func == optuna.samplers.GridSampler  # type: ignore
+            and self.sampler.func == optuna.samplers.GridSampler
         )
 
         (


### PR DESCRIPTION
Mypy no longer officially supports python3.6.
Updating the `python_version` setting in the mypy config
avoids some errors that were only showing up when mypy was
installed with python3.6.

This is a fix for the test failure [here](https://app.circleci.com/pipelines/github/facebookresearch/hydra/14936/workflows/6423d237-12b3-4a4b-bc85-d53885fde690/jobs/149281?invite=true#step-105-567).