### PR TITLE
MANIFEST: add requirements.txt and build_helpers

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 include hydra/py.typed
+include requirements/requirements.txt
 global-exclude *.pyc
 global-exclude __pycache__
 recursive-include hydra/* *
+recursive-include build_helpers *.py *.jar


### PR DESCRIPTION
This PR modifies Hydra's `MANIFEST.in` file to include the `build_helpers` package and a `requirements.txt` file.

#### Motivation:
Hydra's [Release Process](https://hydra.cc/docs/development/release/) involves creating a wheel using `python -m build`.
Before this diff, I'm getting a `ModuleNotFoundError` when I run `python -m build` (see my [my comment here](https://github.com/facebookresearch/hydra/issues/2024#issuecomment-1262734666)).
This diff adds to `MANIFEST.in`, bring hydra's `MANIFEST.in` file closer in sync with OmegaConf's [`MANIFEST.in`](https://github.com/omry/omegaconf/blob/e4eb15a7e5a00134544e837819bd2954f622d7d5/MANIFEST.in).

Closes #2024.