### PR TITLE
support Python3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
       - run:
           name: Preparing environment - Hydra
           command: |
-            conda create -n hydra python=<< parameters.py_version >> -yq
+            conda create -n hydra python=<< parameters.py_version >> -yqc conda-forge
             conda run -n hydra pip install nox --progress-bar off
       - save_cache:
           key: -<< pipeline.parameters.cache_key_version >>-macos-sys-{{ .Branch }}-<< parameters.py_version >>
@@ -84,7 +84,7 @@ commands:
           name: Preparing environment - Hydra
           command: |
             ~/miniconda3/bin/conda init bash
-            ~/miniconda3/bin/conda create -n hydra python=<< parameters.py_version >> -yq
+            ~/miniconda3/bin/conda create -n hydra python=<< parameters.py_version >> -yqc conda-forge
 
 
   win:
@@ -105,7 +105,7 @@ commands:
       - run:
           name: Preparing environment - Hydra
           command: |
-            conda create -n hydra python=<< parameters.py_version >> -qy
+            conda create -n hydra python=<< parameters.py_version >> -yqc conda-forge
             conda activate hydra
             pip install nox dataclasses --progress-bar off
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,19 +288,19 @@ workflows:
       - test_macos:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
       - test_linux:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
       - test_win:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
       - test_linux_omc_dev:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
 
   plugin_tests:
@@ -309,17 +309,17 @@ workflows:
       - test_plugin_linux:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
               test_plugin: [<< pipeline.parameters.test_plugins >>]
       - test_plugin_macos:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
               test_plugin: [<< pipeline.parameters.test_plugins >>]
       - test_plugin_win:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
               test_plugin: [<< pipeline.parameters.test_plugins >>]
 
 

--- a/examples/tutorials/structured_configs/2_static_complex/my_app.py
+++ b/examples/tutorials/structured_configs/2_static_complex/my_app.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import hydra
 from hydra.core.config_store import ConfigStore
@@ -20,8 +20,8 @@ class UserInterface:
 
 @dataclass
 class MyConfig:
-    db: MySQLConfig = MySQLConfig()
-    ui: UserInterface = UserInterface()
+    db: MySQLConfig = field(default_factory=MySQLConfig)
+    ui: UserInterface = field(default_factory=UserInterface)
 
 
 cs = ConfigStore.instance()

--- a/hydra/conf/__init__.py
+++ b/hydra/conf/__init__.py
@@ -81,9 +81,9 @@ class JobConf:
             item_sep: str = ","
             exclude_keys: List[str] = field(default_factory=list)
 
-        override_dirname: OverrideDirname = OverrideDirname()
+        override_dirname: OverrideDirname = field(default_factory=OverrideDirname)
 
-    config: JobConfig = JobConfig()
+    config: JobConfig = field(default_factory=JobConfig)
 
 
 @dataclass
@@ -129,9 +129,9 @@ class HydraConf:
     searchpath: List[str] = field(default_factory=list)
 
     # Normal run output configuration
-    run: RunDir = RunDir()
+    run: RunDir = field(default_factory=RunDir)
     # Multi-run output configuration
-    sweep: SweepDir = SweepDir()
+    sweep: SweepDir = field(default_factory=SweepDir)
     # Logging configuration for Hydra
     hydra_logging: Dict[str, Any] = MISSING
     # Logging configuration for the job
@@ -145,9 +145,9 @@ class HydraConf:
     callbacks: Dict[str, Any] = field(default_factory=dict)
 
     # Program Help template
-    help: HelpConf = HelpConf()
+    help: HelpConf = field(default_factory=HelpConf)
     # Hydra's Help template
-    hydra_help: HydraHelpConf = HydraHelpConf()
+    hydra_help: HydraHelpConf = field(default_factory=HydraHelpConf)
 
     # Output directory for produced configuration files and overrides.
     # E.g., hydra.yaml, overrides.yaml will go here. Useful for debugging
@@ -156,12 +156,12 @@ class HydraConf:
     output_subdir: Optional[str] = ".hydra"
 
     # Those lists will contain runtime overrides
-    overrides: OverridesConf = OverridesConf()
+    overrides: OverridesConf = field(default_factory=OverridesConf)
 
-    job: JobConf = JobConf()
+    job: JobConf = field(default_factory=JobConf)
 
     # populated at runtime
-    runtime: RuntimeConf = RuntimeConf()
+    runtime: RuntimeConf = field(default_factory=RuntimeConf)
 
     # Can be a boolean, string or a list of strings
     # If a boolean, setting to true will set the log level for the root logger to debug

--- a/news/2443.feature
+++ b/news/2443.feature
@@ -1,0 +1,1 @@
+Support python3.11

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,7 @@ from nox.logger import logger
 
 BASE = os.path.abspath(os.path.dirname(__file__))
 
-DEFAULT_PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
+DEFAULT_PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 DEFAULT_OS_NAMES = ["Linux", "MacOS", "Windows"]
 
 PYTHON_VERSIONS = os.environ.get(

--- a/noxfile.py
+++ b/noxfile.py
@@ -608,9 +608,7 @@ def test_jupyter_notebooks(session: Session) -> None:
 
     session.install("jupyter", "nbval", "pyzmq", "pytest")
     if platform.system() == "Windows":
-        # Newer versions of pywin32 are causing CI issues on Windows.
-        # see https://github.com/mhammond/pywin32/issues/1709
-        session.install("pywin32==225")
+        session.install("pywin32")
 
     install_hydra(session, ["pip", "install", "-e"])
     args = pytest_args(

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/config.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/config.py
@@ -46,9 +46,9 @@ class AxConfig:
 
     # max_trials is application-specific. Tune it for your use case
     max_trials: int = 10
-    early_stop: EarlyStopConfig = EarlyStopConfig()
-    experiment: ExperimentConfig = ExperimentConfig()
-    client: ClientConfig = ClientConfig()
+    early_stop: EarlyStopConfig = field(default_factory=EarlyStopConfig)
+    experiment: ExperimentConfig = field(default_factory=ExperimentConfig)
+    client: ClientConfig = field(default_factory=ClientConfig)
     params: Dict[str, Any] = field(default_factory=dict)
     # is_noisy = True indicates measurements have unknown uncertainty
     # is_noisy = False indicates measurements have an uncertainty of zero
@@ -60,7 +60,7 @@ class AxSweeperConf:
     _target_: str = "hydra_plugins.hydra_ax_sweeper.ax_sweeper.AxSweeper"
     # Maximum number of trials to run in parallel
     max_batch_size: Optional[int] = None
-    ax_config: AxConfig = AxConfig()
+    ax_config: AxConfig = field(default_factory=AxConfig)
 
 
 ConfigStore.instance().store(

--- a/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/config.py
+++ b/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/config.py
@@ -74,7 +74,7 @@ class NevergradSweeperConf:
     )
 
     # configuration of the optimizer
-    optim: OptimConf = OptimConf()
+    optim: OptimConf = field(default_factory=OptimConf)
 
     # default parametrization of the search space
     # can be specified:

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_config.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_config.py
@@ -19,7 +19,7 @@ class RayConf:
 @dataclass
 class RayLauncherConf:
     _target_: str = "hydra_plugins.hydra_ray_launcher.ray_launcher.RayLauncher"
-    ray: RayConf = RayConf()
+    ray: RayConf = field(default_factory=RayConf)
 
 
 def _pkg_version(mdl_name: str) -> Optional[str]:
@@ -251,9 +251,9 @@ class RayClusterConf:
     # If a node is idle for this many minutes, it will be removed.
     idle_timeout_minutes: int = 5
 
-    docker: RayDockerConf = RayDockerConf()
+    docker: RayDockerConf = field(default_factory=RayDockerConf)
 
-    provider: RayProviderConf = RayProviderConf()
+    provider: RayProviderConf = field(default_factory=RayProviderConf)
 
     # For additional options, check:
     # https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/aws/example-full.yaml
@@ -330,7 +330,7 @@ class RayClusterConf:
 
 @dataclass
 class RayAWSConf(RayConf):
-    cluster: RayClusterConf = RayClusterConf()
+    cluster: RayClusterConf = field(default_factory=RayClusterConf)
     run_env: RayRunEnv = RayRunEnv.auto
 
 
@@ -338,9 +338,9 @@ class RayAWSConf(RayConf):
 class RayAWSLauncherConf:
     _target_: str = "hydra_plugins.hydra_ray_launcher.ray_aws_launcher.RayAWSLauncher"
 
-    env_setup: EnvSetupConf = EnvSetupConf()
+    env_setup: EnvSetupConf = field(default_factory=EnvSetupConf)
 
-    ray: RayAWSConf = RayAWSConf()
+    ray: RayAWSConf = field(default_factory=RayAWSConf)
 
     # Stop Ray AWS cluster after jobs are finished.
     # (if False, cluster will remain provisioned and can be started with "ray up cluster.yaml").
@@ -350,21 +350,25 @@ class RayAWSLauncherConf:
     # This can be used for syncing up source code to remote cluster for execution.
     # You need to sync up if your code contains multiple modules.
     # source is local dir, target is remote dir
-    sync_up: RsyncConf = RsyncConf()
+    sync_up: RsyncConf = field(default_factory=RsyncConf)
 
     # sync_down is executed after jobs finishes on the cluster.
     # This can be used to download jobs output to local machine avoid the hassle to log on remote machine.
     # source is remote dir, target is local dir
-    sync_down: RsyncConf = RsyncConf()
+    sync_down: RsyncConf = field(default_factory=RsyncConf)
 
     # Ray sdk.configure_logging parameters: log_style, color_mode, verbosity
-    logging: RayLoggingConf = RayLoggingConf()
+    logging: RayLoggingConf = field(default_factory=RayLoggingConf)
 
     # Ray sdk.create_or_update_cluster parameters: no_restart, restart_only, no_config_cache
-    create_update_cluster: RayCreateOrUpdateClusterConf = RayCreateOrUpdateClusterConf()
+    create_update_cluster: RayCreateOrUpdateClusterConf = field(
+        default_factory=RayCreateOrUpdateClusterConf
+    )
 
     # Ray sdk.teardown parameters: workers_only, keep_min_workers
-    teardown_cluster: RayTeardownClusterConf = RayTeardownClusterConf()
+    teardown_cluster: RayTeardownClusterConf = field(
+        default_factory=RayTeardownClusterConf
+    )
 
 
 config_store = ConfigStore.instance()

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/config.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from hydra.core.config_store import ConfigStore
@@ -46,11 +46,11 @@ class EnqueueConf:
 class RQLauncherConf:
     _target_: str = "hydra_plugins.hydra_rq_launcher.rq_launcher.RQLauncher"
     # enqueue configuration
-    enqueue: EnqueueConf = EnqueueConf()
+    enqueue: EnqueueConf = field(default_factory=EnqueueConf)
     # queue name
     queue: str = "default"
     # redis configuration
-    redis: RedisConf = RedisConf()
+    redis: RedisConf = field(default_factory=RedisConf)
     # stop after enqueueing by raising custom exception
     stop_after_enqueue: bool = False
     # wait time in seconds when polling results

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ with open("README.md", "r") as fh:
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
             "Operating System :: POSIX :: Linux",
             "Operating System :: MacOS",
             "Operating System :: Microsoft :: Windows",

--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import collections
 import collections.abc
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial
 from typing import Any, Dict, List, NoReturn, Optional, Tuple
 
@@ -189,7 +189,7 @@ class Adam:
 
 @dataclass
 class NestingClass:
-    a: ASubclass = ASubclass(10)
+    a: ASubclass = field(default_factory=lambda: ASubclass(10))
 
 
 nesting = NestingClass()
@@ -412,8 +412,8 @@ class SimpleClassDefaultPrimitiveConf:
 @dataclass
 class NestedConf:
     _target_: str = "tests.instantiate.SimpleClass"
-    a: Any = User(name="a", age=1)
-    b: Any = User(name="b", age=2)
+    a: Any = field(default_factory=lambda: User(name="a", age=1))
+    b: Any = field(default_factory=lambda: User(name="b", age=2))
 
 
 def recisinstance(got: Any, expected: Any) -> bool:

--- a/tests/test_basic_sweeper.py
+++ b/tests/test_basic_sweeper.py
@@ -91,7 +91,8 @@ def test_partial_failure(
 
     expected_err_regex = dedent(
         r"""
-        Error executing job with overrides: \['\+divisor=0'\]
+        Error executing job with overrides: \['\+divisor=0'\](
+        )?
         Traceback \(most recent call last\):
           File ".*my_app\.py", line 9, in my_app
             val = 1 / cfg\.divisor(

--- a/tests/test_basic_sweeper.py
+++ b/tests/test_basic_sweeper.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import re
 import sys
 from textwrap import dedent
 from typing import Any, List, Optional
@@ -7,7 +8,7 @@ from pytest import mark, param
 
 from hydra._internal.core_plugins.basic_sweeper import BasicSweeper
 from hydra.core.override_parser.overrides_parser import OverridesParser
-from hydra.test_utils.test_utils import assert_regex_match, run_process
+from hydra.test_utils.test_utils import assert_multiline_regex_search, run_process
 
 
 @mark.parametrize(
@@ -75,36 +76,29 @@ def test_partial_failure(
     ]
     out, err = run_process(cmd=cmd, print_error=False, raise_exception=False)
 
-    expected_out = dedent(
-        """\
-        [HYDRA] Launching 2 jobs locally
-        [HYDRA] \t#0 : +divisor=1
-        val=1.0
-        [HYDRA] \t#1 : +divisor=0"""
+    expected_out_regex = re.escape(
+        dedent(
+            """
+            [HYDRA] Launching 2 jobs locally
+            [HYDRA] \t#0 : +divisor=1
+            val=1.0
+            [HYDRA] \t#1 : +divisor=0
+            """
+        ).strip()
     )
 
-    assert_regex_match(
-        from_line=expected_out,
-        to_line=out,
-        from_name="Expected output",
-        to_name="Actual output",
-    )
+    assert_multiline_regex_search(expected_out_regex, out)
 
-    expected_err = dedent(
-        """
-        Error executing job with overrides: ['+divisor=0']
-        Traceback (most recent call last):
-          File ".*my_app.py", line 9, in my_app
-            val = 1 / cfg.divisor
+    expected_err_regex = dedent(
+        r"""
+        Error executing job with overrides: \['\+divisor=0'\]
+        Traceback \(most recent call last\):
+          File ".*my_app\.py", line 9, in my_app
+            val = 1 / cfg\.divisor
         ZeroDivisionError: division by zero
 
-        Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
+        Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.
         """
-    )
+    ).strip()
 
-    assert_regex_match(
-        from_line=expected_err,
-        to_line=err,
-        from_name="Expected error",
-        to_name="Actual error",
-    )
+    assert_multiline_regex_search(expected_err_regex, err)

--- a/tests/test_basic_sweeper.py
+++ b/tests/test_basic_sweeper.py
@@ -94,7 +94,8 @@ def test_partial_failure(
         Error executing job with overrides: \['\+divisor=0'\]
         Traceback \(most recent call last\):
           File ".*my_app\.py", line 9, in my_app
-            val = 1 / cfg\.divisor
+            val = 1 / cfg\.divisor(
+                  ~~\^~~~~~~~~~~~~)?
         ZeroDivisionError: division by zero
 
         Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from textwrap import dedent
 from typing import Any, List
 
@@ -37,7 +37,7 @@ class MySQLConfig:
 @dataclass
 class TopLevelConfig:
     normal_yaml_config: bool = MISSING
-    db: MySQLConfig = MySQLConfig()
+    db: MySQLConfig = field(default_factory=MySQLConfig)
 
 
 @mark.parametrize(
@@ -541,7 +541,7 @@ class ConcretePlugin(Plugin):
     class FoobarParams:
         foo: int = 10
 
-    params: FoobarParams = FoobarParams()
+    params: FoobarParams = field(default_factory=FoobarParams)
 
 
 @dataclass
@@ -552,7 +552,7 @@ class InvalidPlugin:
 
 @dataclass
 class Config:
-    plugin: Plugin = Plugin()
+    plugin: Plugin = field(default_factory=Plugin)
 
 
 def test_overlapping_schemas(hydra_restore_singletons: Any) -> None:

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 import sys
+from dataclasses import dataclass
 from logging import getLogger
 from pathlib import Path
 from textwrap import dedent
@@ -1893,3 +1894,16 @@ def test_hydra_runtime_choice_1882(tmpdir: Path) -> None:
         from_name="Expected output",
         to_name="Actual output",
     )
+
+
+@mark.skipif(sys.version_info > (3, 11), reason="mutable defaults not allowed in 3.11")
+def test_dataclass_with_assigned_mutable_default():
+    @dataclass
+    class Y:
+        pass
+
+    @dataclass
+    class X:
+        y: Y = Y()
+
+    OmegaConf.create(X)

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1287,28 +1287,24 @@ def test_app_with_error_exception_sanitized(tmpdir: Any, monkeypatch: Any) -> No
         f"hydra.sweep.dir={tmpdir}",
         "hydra.job.chdir=True",
     ]
-    expected = dedent(
-        """\
-        Error executing job with overrides: []
-        Traceback (most recent call last):
-          File ".*my_app.py", line 13, in my_app
-            foo(cfg)
-          File ".*my_app.py", line 8, in foo
-            cfg.foo = "bar"  # does not exist in the config
-        omegaconf.errors.ConfigAttributeError: Key 'foo' is not in struct
+    expected_regex = dedent(
+        r"""
+        Error executing job with overrides: \[\]
+        Traceback \(most recent call last\):
+          File ".*my_app\.py", line 13, in my_app
+            foo\(cfg\)
+          File ".*my_app\.py", line 8, in foo
+            cfg\.foo = "bar"  # does not exist in the config
+        omegaconf\.errors\.ConfigAttributeError: Key 'foo' is not in struct
             full_key: foo
             object_type=dict
 
-        Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace."""
-    )
+        Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.
+        """
+    ).strip()
 
     ret = run_with_error(cmd)
-    assert_regex_match(
-        from_line=expected,
-        to_line=ret,
-        from_name="Expected output",
-        to_name="Actual output",
-    )
+    assert_multiline_regex_search(expected_regex, ret)
 
 
 def test_hydra_to_job_config_interpolation(tmpdir: Any) -> Any:
@@ -1394,25 +1390,24 @@ class TestTaskRunnerLogging:
 
 
 @mark.parametrize(
-    "expected",
+    "expected_regex",
     [
-        (
-            dedent(
-                """\
-                Error executing job with overrides: []
-                Traceback (most recent call last):
-                  File ".*my_app.py", line 9, in my_app
-                    1 / 0
-                ZeroDivisionError: division by zero
+        dedent(
+            r"""
+            Error executing job with overrides: \[\]
+            Traceback \(most recent call last\):
+              File ".*my_app\.py", line 9, in my_app
+                1 / 0
+            ZeroDivisionError: division by zero
 
-                Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace."""
-            )
-        ),
+            Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.
+            """
+        ).strip()
     ],
 )
 def test_job_exception(
     tmpdir: Any,
-    expected: str,
+    expected_regex: str,
 ) -> None:
     ret = run_with_error(
         [
@@ -1421,12 +1416,7 @@ def test_job_exception(
             "hydra.job.chdir=True",
         ]
     )
-    assert_regex_match(
-        from_line=expected,
-        to_line=ret,
-        from_name="Expected output",
-        to_name="Actual output",
-    )
+    assert_multiline_regex_search(expected_regex, ret)
 
 
 def test_job_exception_full_error(tmpdir: Any) -> None:

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1894,16 +1894,3 @@ def test_hydra_runtime_choice_1882(tmpdir: Path) -> None:
         from_name="Expected output",
         to_name="Actual output",
     )
-
-
-@mark.skipif(sys.version_info > (3, 11), reason="mutable defaults not allowed in 3.11")
-def test_dataclass_with_assigned_mutable_default():
-    @dataclass
-    class Y:
-        pass
-
-    @dataclass
-    class X:
-        y: Y = Y()
-
-    OmegaConf.create(X)

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1294,7 +1294,8 @@ def test_app_with_error_exception_sanitized(tmpdir: Any, monkeypatch: Any) -> No
           File ".*my_app\.py", line 13, in my_app
             foo\(cfg\)
           File ".*my_app\.py", line 8, in foo
-            cfg\.foo = "bar"  # does not exist in the config
+            cfg\.foo = "bar"  # does not exist in the config(
+            \^+)?
         omegaconf\.errors\.ConfigAttributeError: Key 'foo' is not in struct
             full_key: foo
             object_type=dict
@@ -1397,7 +1398,8 @@ class TestTaskRunnerLogging:
             Error executing job with overrides: \[\]
             Traceback \(most recent call last\):
               File ".*my_app\.py", line 9, in my_app
-                1 / 0
+                1 / 0(
+                ~~\^~~)?
             ZeroDivisionError: division by zero
 
             Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -3,7 +3,6 @@ import os
 import re
 import subprocess
 import sys
-from dataclasses import dataclass
 from logging import getLogger
 from pathlib import Path
 from textwrap import dedent

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,10 @@ from hydra._internal.utils import run_and_report
 from hydra.conf import HydraConf, RuntimeConf
 from hydra.core.hydra_config import HydraConfig
 from hydra.errors import HydraDeprecationError
-from hydra.test_utils.test_utils import assert_regex_match
+from hydra.test_utils.test_utils import (
+    assert_multiline_regex_search,
+    assert_regex_match,
+)
 
 
 def test_get_original_cwd(hydra_restore_singletons: Any) -> None:
@@ -168,42 +171,43 @@ class TestRunAndReport:
                 DemoFunctions.simple_error,
                 dedent(
                     r"""
-                    Traceback \(most recent call last\):$
-                      File "[^"]+", line \d+, in run_and_report$
-                        return func\(\)$
-                      File "[^"]+", line \d+, in simple_error$
-                        assert False, "simple_err_msg"$
-                    AssertionError: simple_err_msg$
-                    assert False$
+                    Traceback \(most recent call last\):
+                      File "[^"]+", line \d+, in run_and_report
+                        return func\(\)
+                      File "[^"]+", line \d+, in simple_error
+                        assert False, "simple_err_msg"
+                    AssertionError: simple_err_msg
+                    assert False
                     """
-                ),
+                ).strip(),
                 id="simple_failure_full_traceback",
             ),
             param(
                 DemoFunctions.run_job_wrapper,
                 dedent(
                     r"""
-                    Traceback \(most recent call last\):$
-                      File "[^"]+", line \d+, in nested_error$
-                        assert False, "nested_err"$
-                    AssertionError: nested_err$
-                    assert False$
-                    Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.$
+                    Traceback \(most recent call last\):
+                      File "[^"]+", line \d+, in nested_error
+                        assert False, "nested_err"
+                    AssertionError: nested_err
+                    assert False
+                    Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.
                     """
-                ),
+                ).strip(),
                 id="strip_run_job_from_top_of_stack",
             ),
             param(
                 DemoFunctions.omegaconf_job_wrapper,
                 dedent(
                     r"""
-                    Traceback \(most recent call last\):$
-                      File "[^"]+", line \d+, in job_calling_omconf$
-                        OmegaConf.resolve\(123\)  # type: ignore$
-                    ValueError: Invalid config type \(int\), expected an OmegaConf Container$
-                    Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.$
+                    Traceback \(most recent call last\):
+                      File "[^"]+", line \d+, in job_calling_omconf
+                        OmegaConf.resolve\(123\)  # type: ignore
+                    ValueError: Invalid config type \(int\), expected an OmegaConf Container
+
+                    Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.
                     """
-                ),
+                ).strip(),
                 id="strip_omegaconf_from_bottom_of_stack",
             ),
         ],
@@ -214,7 +218,7 @@ class TestRunAndReport:
             run_and_report(demo_func)
         mock_stderr.seek(0)
         stderr_output = mock_stderr.read()
-        assert_regex_match(expected_traceback_regex, stderr_output)
+        assert_multiline_regex_search(expected_traceback_regex, stderr_output)
 
     def test_simplified_traceback_with_no_module(self) -> None:
         """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -173,7 +173,8 @@ class TestRunAndReport:
                     r"""
                     Traceback \(most recent call last\):
                       File "[^"]+", line \d+, in run_and_report
-                        return func\(\)
+                        return func\(\)(
+                               \^+)?
                       File "[^"]+", line \d+, in simple_error
                         assert False, "simple_err_msg"
                     AssertionError: simple_err_msg
@@ -202,7 +203,8 @@ class TestRunAndReport:
                     r"""
                     Traceback \(most recent call last\):
                       File "[^"]+", line \d+, in job_calling_omconf
-                        OmegaConf.resolve\(123\)  # type: ignore
+                        OmegaConf.resolve\(123\)  # type: ignore(
+                        \^+)?
                     ValueError: Invalid config type \(int\), expected an OmegaConf Container
 
                     Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -192,6 +192,7 @@ class TestRunAndReport:
                         assert False, "nested_err"
                     AssertionError: nested_err
                     assert False
+
                     Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.
                     """
                 ).strip(),

--- a/tools/configen/configen/config.py
+++ b/tools/configen/configen/config.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional
 
 from hydra.core.config_store import ConfigStore
@@ -17,7 +17,7 @@ class Flags:
 class ModuleConf:
     name: str = MISSING
     classes: List[str] = MISSING
-    default_flags: Flags = Flags()
+    default_flags: Flags = field(default_factory=Flags)
 
 
 @dataclass
@@ -37,7 +37,7 @@ class ConfigenConf:
 @dataclass
 class Config:
     init_config_dir: Optional[str] = None
-    configen: ConfigenConf = ConfigenConf()
+    configen: ConfigenConf = field(default_factory=ConfigenConf)
 
 
 config_store = ConfigStore.instance()

--- a/tools/configen/tests/test_modules/__init__.py
+++ b/tools/configen/tests/test_modules/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -78,7 +78,7 @@ class WithLibraryClassArg:
 
 @dataclass
 class IncompatibleDataclass:
-    library: LibraryClass = LibraryClass()
+    library: LibraryClass = field(default_factory=LibraryClass)
 
     def __eq__(self, other):
         return isinstance(other, type(self)) and other.library == self.library

--- a/website/docs/configure_hydra/job.md
+++ b/website/docs/configure_hydra/job.md
@@ -49,9 +49,9 @@ class JobConf:
             item_sep: str = ","
             exclude_keys: List[str] = field(default_factory=list)
 
-        override_dirname: OverrideDirname = OverrideDirname()
+        override_dirname: OverrideDirname = field(default_factory=OverrideDirname)
 
-    config: JobConfig = JobConfig()
+    config: JobConfig = field(default_factory=JobConfig)
 ```
 </details>
 

--- a/website/docs/tutorials/structured_config/2_hierarchical_static_config.md
+++ b/website/docs/tutorials/structured_config/2_hierarchical_static_config.md
@@ -29,8 +29,8 @@ class UserInterface:
 
 @dataclass
 class MyConfig:
-    db: MySQLConfig = MySQLConfig()
-    ui: UserInterface = UserInterface()
+    db: MySQLConfig = field(default_factory=MySQLConfig)
+    ui: UserInterface = field(default_factory=UserInterface)
 
 cs = ConfigStore.instance()
 cs.store(name="config", node=MyConfig)

--- a/website/versioned_docs/version-1.0/configure_hydra/job.md
+++ b/website/versioned_docs/version-1.0/configure_hydra/job.md
@@ -46,9 +46,9 @@ class JobConf:
             item_sep: str = ","
             exclude_keys: List[str] = field(default_factory=list)
 
-        override_dirname: OverrideDirname = OverrideDirname()
+        override_dirname: OverrideDirname = field(default_factory=OverrideDirname)
 
-    config: JobConfig = JobConfig()
+    config: JobConfig = field(default_factory=JobConfig)
 ```
 </details>
 

--- a/website/versioned_docs/version-1.0/tutorials/structured_config/2_hierarchical_static_config.md
+++ b/website/versioned_docs/version-1.0/tutorials/structured_config/2_hierarchical_static_config.md
@@ -23,8 +23,8 @@ class UserInterface:
 
 @dataclass
 class MyConfig:
-    db: MySQLConfig = MySQLConfig()
-    ui: UserInterface = UserInterface()
+    db: MySQLConfig = field(default_factory=MySQLConfig)
+    ui: UserInterface = field(default_factory=UserInterface)
 
 cs = ConfigStore.instance()
 cs.store(name="config", node=MyConfig)

--- a/website/versioned_docs/version-1.1/configure_hydra/job.md
+++ b/website/versioned_docs/version-1.1/configure_hydra/job.md
@@ -46,9 +46,9 @@ class JobConf:
             item_sep: str = ","
             exclude_keys: List[str] = field(default_factory=list)
 
-        override_dirname: OverrideDirname = OverrideDirname()
+        override_dirname: OverrideDirname = field(default_factory=OverrideDirname)
 
-    config: JobConfig = JobConfig()
+    config: JobConfig = field(default_factory=JobConfig)
 ```
 </details>
 

--- a/website/versioned_docs/version-1.1/tutorials/structured_config/2_hierarchical_static_config.md
+++ b/website/versioned_docs/version-1.1/tutorials/structured_config/2_hierarchical_static_config.md
@@ -29,8 +29,8 @@ class UserInterface:
 
 @dataclass
 class MyConfig:
-    db: MySQLConfig = MySQLConfig()
-    ui: UserInterface = UserInterface()
+    db: MySQLConfig = field(default_factory=MySQLConfig)
+    ui: UserInterface = field(default_factory=UserInterface)
 
 cs = ConfigStore.instance()
 cs.store(name="config", node=MyConfig)

--- a/website/versioned_docs/version-1.2/configure_hydra/job.md
+++ b/website/versioned_docs/version-1.2/configure_hydra/job.md
@@ -49,9 +49,9 @@ class JobConf:
             item_sep: str = ","
             exclude_keys: List[str] = field(default_factory=list)
 
-        override_dirname: OverrideDirname = OverrideDirname()
+        override_dirname: OverrideDirname = field(default_factory=OverrideDirname)
 
-    config: JobConfig = JobConfig()
+    config: JobConfig = field(default_factory=JobConfig)
 ```
 </details>
 

--- a/website/versioned_docs/version-1.2/tutorials/structured_config/2_hierarchical_static_config.md
+++ b/website/versioned_docs/version-1.2/tutorials/structured_config/2_hierarchical_static_config.md
@@ -29,8 +29,8 @@ class UserInterface:
 
 @dataclass
 class MyConfig:
-    db: MySQLConfig = MySQLConfig()
-    ui: UserInterface = UserInterface()
+    db: MySQLConfig = field(default_factory=MySQLConfig)
+    ui: UserInterface = field(default_factory=UserInterface)
 
 cs = ConfigStore.instance()
 cs.store(name="config", node=MyConfig)


### PR DESCRIPTION
## Motivation

When trying to import hydra in Python 3.11, it throws following error:
```python
  File "/home/user/projects/iterative/hydra/hydra/conf/__init__.py", line 75, in JobConf
    @dataclass
     ^^^^^^^^^
  File "/home/user/.pyenv/versions/3.11-dev/lib/python3.11/dataclasses.py", line 1221, in dataclass
    return wrap(cls)
           ^^^^^^^^^
  File "/home/user/.pyenv/versions/3.11-dev/lib/python3.11/dataclasses.py", line 1211, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.pyenv/versions/3.11-dev/lib/python3.11/dataclasses.py", line 959, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.pyenv/versions/3.11-dev/lib/python3.11/dataclasses.py", line 816, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class 'hydra.conf.JobConf.JobConfig.OverrideDirname'> for field override_dirname is not allowed: use default_factory
```

This is due to a recent change in dataclasses in Python 3.11 that disallows mutable to be set as a default value. This is done via check for hashability.

See https://github.com/python/cpython/issues/88840. Note that I am trying to add support for Python 3.11 to hydra. This seems like a major blocker.

For reproducibility, I used the following command to search for these:
```console
rg ".*: .* = [A-Z].*\(.*\)"
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

If all tests pass, it should be good.

## Related Issues and PRs

