### PR TITLE
remove pathlib.Path use as a contextmanager

### DIFF
--- a/tests/standalone_apps/discovery_test_plugin/tests/test_discovery.py
+++ b/tests/standalone_apps/discovery_test_plugin/tests/test_discovery.py
@@ -13,9 +13,9 @@ def test_number_of_imports(tmpdir: Path) -> None:
         x.__name__ for x in Plugins.instance().discover(Plugin)
     ]
 
-    with Path(os.environ["TMP_FILE"]) as f:
-        txt = str(f.read_text())
-        assert txt.split("\n").count("imported") == 1
+    f = Path(os.environ["TMP_FILE"])
+    txt = str(f.read_text())
+    assert txt.split("\n").count("imported") == 1
 
 
 def test_skipped_imports(tmpdir: Path) -> None:


### PR DESCRIPTION
## Motivation

Path as a contextmanager is deprecated from 3.11 onwards and was a no-op since Python 3.11. Also, this functionality was never documented.

See [cpython/Lib/pathlib.py#L810-L816][1], python/cpython#83863 and, python/cpython#90714.

[1]: https://github.com/python/cpython/blob/120b4ab2b68aebf96ce0de243eab89a25fc2d282/Lib/pathlib.py#L810-L816

<!-- Thank you for sending a PR and taking the time to improve Hydra -->


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan


## Related Issues and PRs

