### PR TITLE
[hydra-submitit-launchers] prevent sacct provide old jobid info

### DIFF
--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import logging
+import time
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
@@ -143,6 +144,8 @@ class BaseSubmititLauncher(Launcher):
             )
 
         jobs = executor.map_array(self, *zip(*job_params))
+        # prevent sacct provide old jobid information
+        time.sleep(1)
         return [j.results()[0] for j in jobs]
 
 


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

After slurm restarting, sacct -j [jobid] can still provide previous run information.
https://github.com/facebookresearch/hydra/blob/5300a8632d9e5816863b37dbcf32a3fc5326a3c6/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py#L146
Jobs will fail at this line and trigger UncompletedJobError.
This is because InfoWatch obtain the previous wrong job states and the job status will be is_done. 
https://github.com/facebookincubator/submitit/blob/4cf1462d7216f9dcc530daeb703ce07c37cf9d72/submitit/core/core.py#L369-L384

Waiting sacct to update the information can prevent this issue.
Ideally, we should solve this issue in submitit Infowatch part, but I do not come up with a good way when we submit a bunch of array jobs.
This PR is a temporary patch to solve the issue.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

No, test plan. (or you can find a cluster free to restart slurm.)

## Related Issues and PRs

N/A
