### PR TITLE
Add srun_args parameter to submitit launcher

### DIFF
--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
@@ -73,6 +73,8 @@ class SlurmQueueConf(BaseQueueConf):
     array_parallelism: int = 256
     # A list of commands to run in sbatch befure running srun
     setup: Optional[List[str]] = None
+    # Any additional arguments that should be passed to srun
+    srun_args: Optional[List[str]] = None
 
 
 @dataclass

--- a/plugins/hydra_submitit_launcher/news/2429.feature
+++ b/plugins/hydra_submitit_launcher/news/2429.feature
@@ -1,0 +1,1 @@
+Add support to Hydra's slurm launcher config for submitit's `srun_args` parameter.

--- a/website/docs/plugins/submitit_launcher.md
+++ b/website/docs/plugins/submitit_launcher.md
@@ -61,6 +61,7 @@ max_num_timeout: 0
 additional_parameters: {}
 array_parallelism: 256
 setup: null
+srun_args: null
 ```
 </details>
 <details><summary>Discover the Local Launcher parameters <b>(Expand)</b></summary>


### PR DESCRIPTION
## Motivation

I needed to pass some extra parameters to `srun`, submitit can do this but the argument wasn't exposed by the hydra launcher

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Verified on a live slurm cluster

## Related Issues and PRs

#2429 
