### PR TITLE
enable python3.10 CI for Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,8 +289,7 @@ workflows:
       - test_win:
           matrix:
             parameters:
-              # skipping py3.10 for windows https://github.com/facebookresearch/hydra/issues/2209
-              py_version: ["3.6", "3.7", "3.8", "3.9"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
       - test_linux_omc_dev:
           matrix:
             parameters:
@@ -313,8 +312,7 @@ workflows:
       - test_plugin_win:
           matrix:
             parameters:
-              # skipping py3.10 for windows https://github.com/facebookresearch/hydra/issues/2209
-              py_version: ["3.6", "3.7", "3.8", "3.9"]
+              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
               test_plugin: [<< pipeline.parameters.test_plugins >>]
 
 


### PR DESCRIPTION
This PR enables Python3.10 CI on Windows.
Closes #2211.
