### PR TITLE
regression tests for config name collision with group name

### DIFF
--- a/tests/defaults_list/data/config_with_same_name_as_group.yaml
+++ b/tests/defaults_list/data/config_with_same_name_as_group.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - config_with_same_name_as_group: item

--- a/tests/defaults_list/data/include_group_with_same_name_as_config.yaml
+++ b/tests/defaults_list/data/include_group_with_same_name_as_config.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - config_with_same_name_as_group: item

--- a/tests/defaults_list/data/test_extend_from_config_with_same_name_as_group.yaml
+++ b/tests/defaults_list/data/test_extend_from_config_with_same_name_as_group.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - config_with_same_name_as_group

--- a/tests/defaults_list/data/test_extend_from_group_with_same_name_as_config.yaml
+++ b/tests/defaults_list/data/test_extend_from_group_with_same_name_as_config.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - config_with_same_name_as_group/item

--- a/tests/defaults_list/test_defaults_list.py
+++ b/tests/defaults_list/test_defaults_list.py
@@ -1669,6 +1669,105 @@ def test_duplicate_items(
     "config_name,overrides,expected",
     [
         param(
+            "config_with_same_name_as_group",
+            [],
+            [
+                ResultDefault(
+                    config_path="config_with_same_name_as_group/item",
+                    package="config_with_same_name_as_group",
+                    parent="config_with_same_name_as_group",
+                ),
+                ResultDefault(
+                    config_path="config_with_same_name_as_group",
+                    package="",
+                    is_self=True,
+                    primary=True,
+                ),
+            ],
+            id="config_with_same_name_as_group",
+        ),
+        param(
+            "include_group_with_same_name_as_config",
+            [],
+            [
+                ResultDefault(
+                    config_path="config_with_same_name_as_group/item",
+                    package="config_with_same_name_as_group",
+                    parent="include_group_with_same_name_as_config",
+                ),
+                ResultDefault(
+                    config_path="include_group_with_same_name_as_config",
+                    package="",
+                    is_self=True,
+                    primary=True,
+                ),
+            ],
+            id="include_group_with_same_name_as_config",
+        ),
+        param(
+            "test_extend_from_config_with_same_name_as_group",
+            [],
+            [
+                ResultDefault(
+                    config_path="config_with_same_name_as_group/item",
+                    package="config_with_same_name_as_group",
+                    parent="config_with_same_name_as_group",
+                ),
+                ResultDefault(
+                    config_path="config_with_same_name_as_group",
+                    package="",
+                    parent="test_extend_from_config_with_same_name_as_group",
+                    is_self=True,
+                ),
+                ResultDefault(
+                    config_path="test_extend_from_config_with_same_name_as_group",
+                    package="",
+                    is_self=True,
+                    primary=True,
+                ),
+            ],
+            id="test_extend_from_config_with_same_name_as_group",
+        ),
+        param(
+            "test_extend_from_group_with_same_name_as_config",
+            [],
+            [
+                ResultDefault(
+                    config_path="config_with_same_name_as_group/item",
+                    package="config_with_same_name_as_group",
+                    parent="test_extend_from_group_with_same_name_as_config",
+                ),
+                ResultDefault(
+                    config_path="test_extend_from_group_with_same_name_as_config",
+                    package="",
+                    is_self=True,
+                    primary=True,
+                ),
+            ],
+            id="test_extend_from_group_with_same_name_as_config",
+        ),
+    ],
+)
+@mark.parametrize("version_base", ["1.2", None])
+def test_name_collision(
+    config_name: str,
+    overrides: List[str],
+    expected: List[ResultDefault],
+    version_base: Optional[str],
+    hydra_restore_singletons: Any,
+) -> None:
+    version.setbase(version_base)
+    _test_defaults_list_impl(
+        config_name=config_name,
+        overrides=overrides,
+        expected=expected,
+    )
+
+
+@mark.parametrize(
+    "config_name,overrides,expected",
+    [
+        param(
             "group1/file_with_group_header",
             [],
             [

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -1488,6 +1488,89 @@ def test_extension_use_cases(
     "config_name,overrides,expected",
     [
         param(
+            "config_with_same_name_as_group",
+            [],
+            DefaultsTreeNode(
+                node=ConfigDefault(path="config_with_same_name_as_group"),
+                children=[
+                    GroupDefault(
+                        group="config_with_same_name_as_group",
+                        value="item",
+                    ),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="config_with_same_name_as_group",
+        ),
+        param(
+            "include_group_with_same_name_as_config",
+            [],
+            DefaultsTreeNode(
+                node=ConfigDefault(path="include_group_with_same_name_as_config"),
+                children=[
+                    GroupDefault(
+                        group="config_with_same_name_as_group",
+                        value="item",
+                    ),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="include_group_with_same_name_as_config",
+        ),
+        param(
+            "test_extend_from_config_with_same_name_as_group",
+            [],
+            DefaultsTreeNode(
+                node=ConfigDefault(
+                    path="test_extend_from_config_with_same_name_as_group"
+                ),
+                children=[
+                    DefaultsTreeNode(
+                        node=ConfigDefault(path="config_with_same_name_as_group"),
+                        children=[
+                            GroupDefault(
+                                group="config_with_same_name_as_group", value="item"
+                            ),
+                            ConfigDefault(path="_self_"),
+                        ],
+                    ),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="test_extend_from_config_with_same_name_as_group",
+        ),
+        param(
+            "test_extend_from_group_with_same_name_as_config",
+            [],
+            DefaultsTreeNode(
+                node=ConfigDefault(
+                    path="test_extend_from_group_with_same_name_as_config"
+                ),
+                children=[
+                    ConfigDefault(path="config_with_same_name_as_group/item"),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="test_extend_from_group_with_same_name_as_config",
+        ),
+    ],
+)
+def test_name_collision(
+    config_name: str,
+    overrides: List[str],
+    expected: DefaultsTreeNode,
+) -> None:
+    _test_defaults_tree_impl(
+        config_name=config_name,
+        input_overrides=overrides,
+        expected=expected,
+    )
+
+
+@mark.parametrize(
+    "config_name,overrides,expected",
+    [
+        param(
             "with_missing",
             [],
             raises(


### PR DESCRIPTION
This PR adds regression tests for the case where a config option (e.g. a yaml
file) as the same name as a config group (e.g. a folder containing other yaml
files).

In practice, here's how this situation would look:
```text
$ tree
.
├── my_cfg
│   └── sub_cfg.yaml
└── my_cfg.yaml

1 directory, 2 files
```

Hydra composes the config correctly even if there are name collisions.
