### PR TITLE
rm doc on instantiate _convert_ performance

### DIFF
--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -277,11 +277,6 @@ cfg_all = OmegaConf.create({..., "_convert_": "all"})
 obj_all = instantiate(cfg_all)
 ```
 
-If performance is a concern, note that the `_convert_="none"` strategy does the
-least work -- no conversion (from `DictConfig`/`ListConfig` to native python
-containers) is taking place. The `_convert_="partial"` strategy does more work,
-and `_convert_="all"` does more work yet.
-
 ### Partial Instantiation
 Sometimes you may not set all parameters needed to instantiate an object from the configuration, in this case you can set
 `_partial_` to be `True` to get a `functools.partial` wrapped object or method, then complete initializing the object in 

--- a/website/versioned_docs/version-1.1/advanced/instantiate_objects/overview.md
+++ b/website/versioned_docs/version-1.1/advanced/instantiate_objects/overview.md
@@ -275,11 +275,6 @@ cfg_all = OmegaConf.create({..., "_convert_": "all"})
 obj_all = instantiate(cfg_all)
 ```
 
-If performance is a concern, note that the `_convert_="none"` strategy does the
-least work -- no conversion (from `DictConfig`/`ListConfig` to native python
-containers) is taking place. The `_convert_="partial"` strategy does more work,
-and `_convert_="all"` does more work yet.
-
 ### Partial Instantiation (for Hydra version >= 1.1.2)
 Sometimes you may not set all parameters needed to instantiate an object from the configuration, in this case you can set
 `_partial_` to be `True` to get a `functools.partial` wrapped object or method, then complete initializing the object in 

--- a/website/versioned_docs/version-1.2/advanced/instantiate_objects/overview.md
+++ b/website/versioned_docs/version-1.2/advanced/instantiate_objects/overview.md
@@ -277,11 +277,6 @@ cfg_all = OmegaConf.create({..., "_convert_": "all"})
 obj_all = instantiate(cfg_all)
 ```
 
-If performance is a concern, note that the `_convert_="none"` strategy does the
-least work -- no conversion (from `DictConfig`/`ListConfig` to native python
-containers) is taking place. The `_convert_="partial"` strategy does more work,
-and `_convert_="all"` does more work yet.
-
 ### Partial Instantiation
 Sometimes you may not set all parameters needed to instantiate an object from the configuration, in this case you can set
 `_partial_` to be `True` to get a `functools.partial` wrapped object or method, then complete initializing the object in 


### PR DESCRIPTION
Remove the documentation paragraph about performance of `_convert_`
strategies for `instantiate`.

The paragraph made some incorrect claims, saying that `_convert_="none"`
would be the fastest strategy because no conversion takes place. The
reality is that the implementation of the `_convert_="none"` strategy
performs conversion from DictConfig to dict and then back to DictConfig,
so there will likely not be significant performance gains from using
`_convert_="none"`.

Benchmarking should be used to determine the best strategy for
performance-critical applications.