### PR TITLE
pin flake8<6

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@ bandit
 black>=22.1.0
 build
 coverage
-flake8
+flake8<6  # pinned due to https://github.com/savoirfairelinux/flake8-copyright/issues/19
 flake8-copyright
 isort==5.5.2
 mypy


### PR DESCRIPTION
pinned due to issue https://github.com/savoirfairelinux/flake8-copyright/issues/19
which affects the flake8-copyright flake8 plugin that we are using.

Here's an example of CI failure: https://app.circleci.com/pipelines/github/facebookresearch/hydra/15167/workflows/e14be3a7-ada4-4484-8f14-76322706c0f3/jobs/152877

```
Traceback (most recent call last):
  File "/home/circleci/project/.nox/lint_plugins-3-9/bin/flake8", line 8, in <module>
    sys.exit(main())
  File "/home/circleci/project/.nox/lint_plugins-3-9/lib/python3.9/site-packages/flake8/main/cli.py", line 23, in main
    app.run(argv)
  File "/home/circleci/project/.nox/lint_plugins-3-9/lib/python3.9/site-packages/flake8/main/application.py", line 198, in run
    self._run(argv)
  File "/home/circleci/project/.nox/lint_plugins-3-9/lib/python3.9/site-packages/flake8/main/application.py", line 186, in _run
    self.initialize(argv)
  File "/home/circleci/project/.nox/lint_plugins-3-9/lib/python3.9/site-packages/flake8/main/application.py", line 165, in initialize
    self.plugins, self.options = parse_args(argv)
  File "/home/circleci/project/.nox/lint_plugins-3-9/lib/python3.9/site-packages/flake8/options/parse_args.py", line 51, in parse_args
    option_manager.register_plugins(plugins)
  File "/home/circleci/project/.nox/lint_plugins-3-9/lib/python3.9/site-packages/flake8/options/manager.py", line 259, in register_plugins
    add_options(self)
  File "/home/circleci/project/.nox/lint_plugins-3-9/lib/python3.9/site-packages/flake8_copyright.py", line 56, in add_options
    register_opt(
  File "/home/circleci/project/.nox/lint_plugins-3-9/lib/python3.9/site-packages/flake8_copyright.py", line 30, in register_opt
    parser.add_option(*args, **kwargs)
  File "/home/circleci/project/.nox/lint_plugins-3-9/lib/python3.9/site-packages/flake8/options/manager.py", line 281, in add_option
    self._current_group.add_argument(*option_args, **option_kwargs)
  File "/home/circleci/miniconda3/envs/hydra/lib/python3.9/argparse.py", line 1428, in add_argument
    raise ValueError('%r is not callable' % (type_func,))
ValueError: 'int' is not callable
nox > [2022-11-26 00:27:44,422] Command flake8 --config .flake8 plugins failed with exit code 1
```
