### PR TITLE
Bump version -> 1.3.0.dev2

### DIFF
--- a/hydra/__init__.py
+++ b/hydra/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 # Source of truth for Hydra's version
-__version__ = "1.3.0.dev1"
+__version__ = "1.3.0.dev2"
 from hydra import utils
 from hydra.errors import MissingConfigException
 from hydra.main import main


### PR DESCRIPTION
dev release 1.3.0.dev1 is now released to pypi:

https://pypi.org/project/hydra-core/1.3.0.dev1/

```
pip install hydra-core==1.3.0.dev1
```