### PR TITLE
Add Hydra Ecosystem section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,8 @@ Hydra is licensed under [MIT License](LICENSE).
 
 #### Check out these third-party libraries that build on Hydra's functionality:
 * [hydra-zen](https://github.com/mit-ll-responsible-ai/hydra-zen): Pythonic utilities for working with Hydra. Dynamic config generation capabilities, enhanced config store features, a Python API for launching Hydra jobs, and more.
-* [hydra-torch](https://github.com/pytorch/hydra-torch): ...
-* [lightning-hydra-template](https://github.com/ashleve/lightning-hydra-template): ...
-* [configen](https://github.com/facebookresearch/hydra/tree/main/tools/configen): Automatically generates Structured Configs that can be used with `hydra.utils.instantiate()`
+* [lightning-hydra-template](https://github.com/ashleve/lightning-hydra-template): user-friendly template combining Hydra with [Pytorch-Lightning](https://github.com/Lightning-AI/lightning) for ML experimentation
+* [hydra-torch](https://github.com/pytorch/hydra-torch): [configen](https://github.com/facebookresearch/hydra/tree/main/tools/configen)-generated configuration classes enabling type-safe PyTorch configuration for Hydra apps.
 
 #### Ask questions in Github Discussions or StackOverflow (Use the tag #fb-hydra or #omegaconf):
 * [Github Discussions](https://github.com/facebookresearch/hydra/discussions)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Hydra is licensed under [MIT License](LICENSE).
 * [hydra-zen](https://github.com/mit-ll-responsible-ai/hydra-zen): Pythonic utilities for working with Hydra. Dynamic config generation capabilities, enhanced config store features, a Python API for launching Hydra jobs, and more.
 * [hydra-torch](https://github.com/pytorch/hydra-torch): ...
 * [lightning-hydra-template](https://github.com/ashleve/lightning-hydra-template): ...
+* [configen](https://github.com/facebookresearch/hydra/tree/main/tools/configen): Automatically generates Structured Configs that can be used with `hydra.utils.instantiate()`
 
 #### Ask questions in Github Discussions or StackOverflow (Use the tag #fb-hydra or #omegaconf):
 * [Github Discussions](https://github.com/facebookresearch/hydra/discussions)

--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ Hydra is licensed under [MIT License](LICENSE).
 * [StackOverflow](https://stackexchange.com/filters/391828/hydra-questions)
 * [Twitter](https://twitter.com/Hydra_Framework)
 
-## Hydra
-
 ### Citing Hydra
 If you use Hydra in your research please use the following BibTeX entry:
 ```BibTeX

--- a/README.md
+++ b/README.md
@@ -54,13 +54,19 @@
 ### License
 Hydra is licensed under [MIT License](LICENSE).
 
-## Community
+## Hydra Ecosystem
 
-Ask questions in Github Discussions or StackOverflow (Use the tag #fb-hydra or #omegaconf):
+#### Check out these third-party libraries that build on Hydra's functionality:
+* [hydra-zen](https://github.com/mit-ll-responsible-ai/hydra-zen): Configurable, reproducible, and scalable Python programs, via Hydra
+* [hydra-torch](https://github.com/pytorch/hydra-torch): ...
+* [lightning-hydra-template](https://github.com/ashleve/lightning-hydra-template): ...
+
+#### Ask questions in Github Discussions or StackOverflow (Use the tag #fb-hydra or #omegaconf):
 * [Github Discussions](https://github.com/facebookresearch/hydra/discussions)
 * [StackOverflow](https://stackexchange.com/filters/391828/hydra-questions)
 * [Twitter](https://twitter.com/Hydra_Framework)
 
+## Hydra
 
 ### Citing Hydra
 If you use Hydra in your research please use the following BibTeX entry:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Hydra is licensed under [MIT License](LICENSE).
 
 #### Check out these third-party libraries that build on Hydra's functionality:
 * [hydra-zen](https://github.com/mit-ll-responsible-ai/hydra-zen): Pythonic utilities for working with Hydra. Dynamic config generation capabilities, enhanced config store features, a Python API for launching Hydra jobs, and more.
-* [lightning-hydra-template](https://github.com/ashleve/lightning-hydra-template): user-friendly template combining Hydra with [Pytorch-Lightning](https://github.com/Lightning-AI/lightning) for ML experimentation
+* [lightning-hydra-template](https://github.com/ashleve/lightning-hydra-template): user-friendly template combining Hydra with [Pytorch-Lightning](https://github.com/Lightning-AI/lightning) for ML experimentation.
 * [hydra-torch](https://github.com/pytorch/hydra-torch): [configen](https://github.com/facebookresearch/hydra/tree/main/tools/configen)-generated configuration classes enabling type-safe PyTorch configuration for Hydra apps.
 
 #### Ask questions in Github Discussions or StackOverflow (Use the tag #fb-hydra or #omegaconf):

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Hydra is licensed under [MIT License](LICENSE).
 ## Hydra Ecosystem
 
 #### Check out these third-party libraries that build on Hydra's functionality:
-* [hydra-zen](https://github.com/mit-ll-responsible-ai/hydra-zen): Configurable, reproducible, and scalable Python programs, via Hydra
+* [hydra-zen](https://github.com/mit-ll-responsible-ai/hydra-zen): Pythonic utilities for working with Hydra. Dynamic config generation capabilities, enhanced config store features, a Python API for launching Hydra jobs, and more.
 * [hydra-torch](https://github.com/pytorch/hydra-torch): ...
 * [lightning-hydra-template](https://github.com/ashleve/lightning-hydra-template): ...
 


### PR DESCRIPTION
Adds a section to the README featuring third-party frameworks, libraries, and extensions to Hydra. Based on discussion with @rsokl.