### PR TITLE
python3.11 support for plugins

### DIFF
--- a/examples/plugins/example_configsource_plugin/setup.py
+++ b/examples/plugins/example_configsource_plugin/setup.py
@@ -24,6 +24,7 @@ with open("README.md", "r") as fh:
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
             "Operating System :: OS Independent",
         ],
         install_requires=[

--- a/examples/plugins/example_generic_plugin/setup.py
+++ b/examples/plugins/example_generic_plugin/setup.py
@@ -24,6 +24,7 @@ with open("README.md", "r") as fh:
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
             "Operating System :: OS Independent",
         ],
         install_requires=[

--- a/examples/plugins/example_launcher_plugin/setup.py
+++ b/examples/plugins/example_launcher_plugin/setup.py
@@ -24,6 +24,7 @@ with open("README.md", "r") as fh:
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
             "Operating System :: OS Independent",
         ],
         install_requires=[

--- a/examples/plugins/example_registered_plugin/setup.py
+++ b/examples/plugins/example_registered_plugin/setup.py
@@ -24,6 +24,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: OS Independent",
     ],
     install_requires=[

--- a/examples/plugins/example_searchpath_plugin/setup.py
+++ b/examples/plugins/example_searchpath_plugin/setup.py
@@ -26,6 +26,7 @@ with open("README.md", "r") as fh:
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
             "Operating System :: OS Independent",
         ],
         install_requires=[

--- a/examples/plugins/example_sweeper_plugin/setup.py
+++ b/examples/plugins/example_sweeper_plugin/setup.py
@@ -24,6 +24,7 @@ with open("README.md", "r") as fh:
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
             "Operating System :: OS Independent",
         ],
         install_requires=[

--- a/plugins/hydra_colorlog/hydra_plugins/hydra_colorlog/__init__.py
+++ b/plugins/hydra_colorlog/hydra_plugins/hydra_colorlog/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.2.0"
+__version__ = "1.3.0.dev0"

--- a/plugins/hydra_colorlog/news/2443.feature
+++ b/plugins/hydra_colorlog/news/2443.feature
@@ -1,0 +1,1 @@
+Support python3.11

--- a/plugins/hydra_colorlog/setup.py
+++ b/plugins/hydra_colorlog/setup.py
@@ -22,6 +22,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: OS Independent",
     ],
     install_requires=["colorlog", "hydra-core>=1.0.0"],

--- a/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/__init__.py
+++ b/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.2.0"
+__version__ = "1.3.0.dev0"

--- a/plugins/hydra_joblib_launcher/news/2443.feature
+++ b/plugins/hydra_joblib_launcher/news/2443.feature
@@ -1,0 +1,1 @@
+Support python3.11

--- a/plugins/hydra_joblib_launcher/setup.py
+++ b/plugins/hydra_joblib_launcher/setup.py
@@ -21,6 +21,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: MacOS",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX :: Linux",

--- a/plugins/hydra_nevergrad_sweeper/news/2443.feature
+++ b/plugins/hydra_nevergrad_sweeper/news/2443.feature
@@ -1,0 +1,1 @@
+Support python3.11

--- a/plugins/hydra_nevergrad_sweeper/setup.py
+++ b/plugins/hydra_nevergrad_sweeper/setup.py
@@ -22,6 +22,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: OS Independent",
         "Development Status :: 4 - Beta",
     ],

--- a/plugins/hydra_optuna_sweeper/news/2443.feature
+++ b/plugins/hydra_optuna_sweeper/news/2443.feature
@@ -1,0 +1,1 @@
+Support python3.11

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -22,6 +22,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS",
         "Development Status :: 4 - Beta",

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/__init__.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.2.0"
+__version__ = "1.3.0.dev0"

--- a/plugins/hydra_rq_launcher/news/2443.feature
+++ b/plugins/hydra_rq_launcher/news/2443.feature
@@ -1,0 +1,1 @@
+Support python3.11

--- a/plugins/hydra_rq_launcher/setup.py
+++ b/plugins/hydra_rq_launcher/setup.py
@@ -22,6 +22,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
     ],

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/__init__.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.2.0"
+__version__ = "1.3.0.dev0"

--- a/plugins/hydra_submitit_launcher/news/2443.feature
+++ b/plugins/hydra_submitit_launcher/news/2443.feature
@@ -1,0 +1,1 @@
+Support python3.11

--- a/plugins/hydra_submitit_launcher/setup.py
+++ b/plugins/hydra_submitit_launcher/setup.py
@@ -21,6 +21,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Follow up PR to #2418.

Add python3.11 support for plugins (except ray launcher and ax sweeper).