### PR TITLE
plugin tests: use CPU version of pytorch to reduce CI download time

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -139,13 +139,11 @@ def plugin_requires_torch(plugin: Plugin) -> bool:
 def install_cpu_torch(session: Session) -> None:
     """
     Install the CPU version of pytorch.
-    This is a much smaller download size than the normal version of `torch` package hosted on pypi.
+    This is a much smaller download size than the normal version `torch` package hosted on pypi.
     The smaller download prevents our CI jobs from timing out.
     """
-    # Unfortunately there's currently no easy way to install the "latest" CPU version of pytorch.
-    # See https://github.com/pytorch/pytorch/issues/26340
     session.install(
-        "torch==1.13.0+cpu", "-f", "https://download.pytorch.org/whl/torch_stable.html"
+        "torch", "--extra-index-url", "https://download.pytorch.org/whl/cpu"
     )
 
 


### PR DESCRIPTION
Hydra's ax-sweeper plugin requires pytorch as a dependency.
Our CI sometimes times-out when the pytorch dep is downloading.
This PR modifies noxfile to install the CPU version of pytorch if `torch` is
required for a plugin test. This way, download time is minimized.

Commits:
- noxfile: install cpu version of torch
- noxfile plugin tests: print installed pytorch version

Example CI failure: https://app.circleci.com/pipelines/github/facebookresearch/hydra/15223/workflows/6fd6ccd7-2183-4659-b4dd-d2fc95e70adb/jobs/153959
See the `test_plugins_vs_core-3.9` nox session that ran during that CI job. The nox session failed while downloading `torch`.