### PR TITLE
[minor] more verbose about a job's error

### DIFF
--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import sys
+import traceback
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
@@ -186,6 +187,9 @@ def run_job(
                 ret.return_value = task_function(task_cfg)
                 ret.status = JobStatus.COMPLETED
             except Exception as e:
+                name = "HYDRA_FULL_ERROR"
+                if name in os.environ and os.environ[name] == "1":
+                    log.info(traceback.format_exc())
                 ret.return_value = e
                 ret.status = JobStatus.FAILED
 


### PR DESCRIPTION
When a job raises an exception, it seems to be swallowed. After this change, the backtrace shows up in main.log as well as the job's stdout file. See below
![image](https://user-images.githubusercontent.com/24926999/206864795-a2e5b562-916d-431d-895d-3aee04711ae8.png)
