### PR TITLE
`compose`: Use immutable object as default for `overrides` parameter.

### DIFF
--- a/hydra/compose.py
+++ b/hydra/compose.py
@@ -13,7 +13,7 @@ from ._internal.deprecation_warning import deprecation_warning
 
 def compose(
     config_name: Optional[str] = None,
-    overrides: List[str] = [],
+    overrides: Optional[List[str]] = None,
     return_hydra_config: bool = False,
     strict: Optional[bool] = None,
 ) -> DictConfig:
@@ -25,6 +25,10 @@ def compose(
     :param strict: DEPRECATED. If false, returned config has struct mode disabled.
     :return: the composed config
     """
+    
+    if overrides is None:
+            overrides = []
+    
     assert (
         GlobalHydra().is_initialized()
     ), "GlobalHydra is not initialized, use @hydra.main() or call one of the hydra initialization methods first"

--- a/hydra/compose.py
+++ b/hydra/compose.py
@@ -25,10 +25,10 @@ def compose(
     :param strict: DEPRECATED. If false, returned config has struct mode disabled.
     :return: the composed config
     """
-    
+
     if overrides is None:
-            overrides = []
-    
+        overrides = []
+
     assert (
         GlobalHydra().is_initialized()
     ), "GlobalHydra is not initialized, use @hydra.main() or call one of the hydra initialization methods first"


### PR DESCRIPTION
## Motivation

Mutable default parameters are dangerous: https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Should be covered by already existing tests.

## Related Issues and PRs
None.
