### PR TITLE
Relax OmegaConf pin

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-omegaconf~=2.2
+omegaconf>=2.2,<2.4
 antlr4-python3-runtime==4.9.*
 importlib-resources;python_version<'3.9'
 packaging


### PR DESCRIPTION
Related to #2510.

## Motivation

OmegaConf 2.3 officially supports Python3.11, but OmegaConf 2.2 does not.