### PR TITLE
docs: add github links to compose API code

### DIFF
--- a/website/docs/advanced/compose_api.md
+++ b/website/docs/advanced/compose_api.md
@@ -28,9 +28,9 @@ Doing so forfeits many of the benefits of Hydra
 
 ### Initialization methods
 There are 3 initialization methods:
-- `initialize()`: Initialize with a config path relative to the caller
-- `initialize_config_module()` : Initialize with config_module (absolute)
-- `initialize_config_dir()` : Initialize with a config_dir on the file system (absolute)
+- <GithubLink to="hydra/initialize.py#L37">initialize()</GithubLink>: Initialize with a config path relative to the caller
+- <GithubLink to="hydra/initialize.py#L108">initialize_config_module()</GithubLink>: Initialize with config_module (absolute)
+- <GithubLink to="hydra/initialize.py#L143">initialize_config_dir()</GithubLink>: Initialize with a config_dir on the file system (absolute)
 
 All 3 can be used as methods or contexts.
 When used as methods, they are initializing Hydra globally and should only be called once.

--- a/website/versioned_docs/version-1.3/advanced/compose_api.md
+++ b/website/versioned_docs/version-1.3/advanced/compose_api.md
@@ -28,9 +28,9 @@ Doing so forfeits many of the benefits of Hydra
 
 ### Initialization methods
 There are 3 initialization methods:
-- `initialize()`: Initialize with a config path relative to the caller
-- `initialize_config_module()` : Initialize with config_module (absolute)
-- `initialize_config_dir()` : Initialize with a config_dir on the file system (absolute)
+- <GithubLink to="hydra/initialize.py#L37">initialize()</GithubLink>: Initialize with a config path relative to the caller
+- <GithubLink to="hydra/initialize.py#L108">initialize_config_module()</GithubLink>: Initialize with config_module (absolute)
+- <GithubLink to="hydra/initialize.py#L143">initialize_config_dir()</GithubLink>: Initialize with a config_dir on the file system (absolute)
 
 All 3 can be used as methods or contexts.
 When used as methods, they are initializing Hydra globally and should only be called once.


### PR DESCRIPTION
Add cross reference link from compose API docs to hydra/initialize.py on github.
