### PR TITLE
improve hydra.utils.get_{class,method,object}

### DIFF
--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -28,7 +28,7 @@ def get_class(path: str) -> type:
             )
         return cls
     except Exception as e:
-        log.error(f"Error initializing class at {path}: {e}")
+        log.error(f"Error getting class at {path}: {e}")
         raise e
 
 

--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -19,6 +19,14 @@ ConvertMode = hydra.types.ConvertMode
 
 
 def get_class(path: str) -> type:
+    """
+    Look up a class based on a dotpath.
+    Fails if the path does not point to a class.
+
+    >>> import my_module
+    >>> from hydra.utils import get_class
+    >>> assert get_class("my_module.MyClass") is my_module.MyClass
+    """
     try:
         cls = _locate(path)
         if not isinstance(cls, type):
@@ -33,6 +41,14 @@ def get_class(path: str) -> type:
 
 
 def get_method(path: str) -> Callable[..., Any]:
+    """
+    Look up a callable based on a dotpath.
+    Fails if the path does not point to a callable object.
+
+    >>> import my_module
+    >>> from hydra.utils import get_method
+    >>> assert get_method("my_module.my_function") is my_module.my_function
+    """
     try:
         obj = _locate(path)
         if not callable(obj):
@@ -52,6 +68,13 @@ get_static_method = get_method
 
 
 def get_object(path: str) -> Any:
+    """
+    Look up a callable based on a dotpath.
+
+    >>> import my_module
+    >>> from hydra.utils import get_object
+    >>> assert get_object("my_module.my_object") is my_module.my_object
+    """
     try:
         obj = _locate(path)
         return obj

--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -51,6 +51,15 @@ def get_method(path: str) -> Callable[..., Any]:
 get_static_method = get_method
 
 
+def get_object(path: str) -> Any:
+    try:
+        obj = _locate(path)
+        return obj
+    except Exception as e:
+        log.error(f"Error getting object at {path} : {e}")
+        raise e
+
+
 def get_original_cwd() -> str:
     """
     :return: the original working directory the Hydra application was launched from

--- a/news/2139.feature
+++ b/news/2139.feature
@@ -1,0 +1,1 @@
+Add a `hydra.utils.get_object` function that gives users access to Hydra's dotpath-lookup machinery.

--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -436,3 +436,5 @@ def recisinstance(got: Any, expected: Any) -> bool:
             for key in expected._fields
         )
     return True
+
+an_object = object()

--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -437,4 +437,5 @@ def recisinstance(got: Any, expected: Any) -> bool:
         )
     return True
 
+
 an_object = object()

--- a/tests/instantiate/test_helpers.py
+++ b/tests/instantiate/test_helpers.py
@@ -16,6 +16,7 @@ from tests.instantiate import (
     ASubclass,
     NestingClass,
     Parameters,
+    an_object,
 )
 
 from .module_shadowed_by_function import a_function
@@ -131,6 +132,7 @@ from .module_shadowed_by_function import a_function
             ),
             id="import_assertion_error",
         ),
+        param("tests.instantiate.an_object", an_object, id="object"),
     ],
 )
 def test_locate(name: str, expected: Any) -> None:
@@ -174,6 +176,14 @@ def test_locate_relative_import_fails(name: str) -> None:
             ),
             id="module-error",
         ),
+        param(
+            "tests.instantiate.an_object",
+            raises(
+                ValueError,
+                match="Located non-callable of type 'object' while loading 'tests.instantiate.an_object'",
+            ),
+            id="object-error",
+        ),
     ],
 )
 def test_get_method(path: str, expected: Any) -> None:
@@ -204,6 +214,14 @@ def test_get_method(path: str, expected: Any) -> None:
                 match="Located non-class of type 'module' while loading 'datetime'",
             ),
             id="module-error",
+        ),
+        param(
+            "tests.instantiate.an_object",
+            raises(
+                ValueError,
+                match="Located non-class of type 'object' while loading 'tests.instantiate.an_object'",
+            ),
+            id="object-error",
         ),
     ],
 )

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -392,3 +392,51 @@ from hydra.utils import instantiate
 # instantiate({"_target_": "len"}, [1,2,3])  # this gives an InstantiationException
 instantiate({"_target_": "builtins.len"}, [1,2,3])  # this works, returns the number 3
 ```
+
+### Dotpath lookup machinery
+
+Hydra looks up a given `_target_` by attempting to find a module that
+corresponds to a prefix of the given dotpath and then looking for an object in
+that module corresponding to the dotpath's tail. For example, to look up a `_target_`
+given by the dotpath `"my_module.my_nested_module.my_object"`, hydra first locates
+the module `my_module.my_nested_module`, then find `my_object` inside that nested module.
+
+Hydra exposes an API allowing direct use of this dotpath lookup machinery.
+The following three functions, which can be imported from the <GithubLink to="hydra/utils.py">hydra.utils</GithubLink> module,
+accept a string-typed dotpath as an argument and return the located class/callable/object:
+```python
+def get_class(path: str) -> type:
+    """
+    Look up a class based on a dotpath.
+    Fails if the path does not point to a class.
+
+    >>> import my_module
+    >>> from hydra.utils import get_class
+    >>> assert get_class("my_module.MyClass") is my_module.MyClass
+    """
+    ...
+
+def get_method(path: str) -> Callable[..., Any]:
+    """
+    Look up a callable based on a dotpath.
+    Fails if the path does not point to a callable object.
+
+    >>> import my_module
+    >>> from hydra.utils import get_method
+    >>> assert get_method("my_module.my_function") is my_module.my_function
+    """
+    ...
+
+# Alias for get_method
+get_static_method = get_method
+
+def get_object(path: str) -> Any:
+    """
+    Look up a callable based on a dotpath.
+
+    >>> import my_module
+    >>> from hydra.utils import get_object
+    >>> assert get_object("my_module.my_object") is my_module.my_object
+    """
+    ...
+```

--- a/website/versioned_docs/version-1.3/advanced/instantiate_objects/overview.md
+++ b/website/versioned_docs/version-1.3/advanced/instantiate_objects/overview.md
@@ -392,3 +392,41 @@ from hydra.utils import instantiate
 # instantiate({"_target_": "len"}, [1,2,3])  # this gives an InstantiationException
 instantiate({"_target_": "builtins.len"}, [1,2,3])  # this works, returns the number 3
 ```
+
+### Dotpath lookup machinery
+
+Hydra looks up a given `_target_` by attempting to find a module that
+corresponds to a prefix of the given dotpath and then looking for an object in
+that module corresponding to the dotpath's tail. For example, to look up a `_target_`
+given by the dotpath `"my_module.my_nested_module.my_object"`, hydra first locates
+the module `my_module.my_nested_module`, then find `my_object` inside that nested module.
+
+Hydra exposes an API allowing direct use of this dotpath lookup machinery.
+The following two functions, which can be imported from the <GithubLink to="hydra/utils.py">hydra.utils</GithubLink> module,
+accept a string-typed dotpath as an argument and return the located class/callable/object:
+```python
+def get_class(path: str) -> type:
+    """
+    Look up a class based on a dotpath.
+    Fails if the path does not point to a class.
+
+    >>> import my_module
+    >>> from hydra.utils import get_class
+    >>> assert get_class("my_module.MyClass") is my_module.MyClass
+    """
+    ...
+
+def get_method(path: str) -> Callable[..., Any]:
+    """
+    Look up a callable based on a dotpath.
+    Fails if the path does not point to a callable object.
+
+    >>> import my_module
+    >>> from hydra.utils import get_method
+    >>> assert get_method("my_module.my_function") is my_module.my_function
+    """
+    ...
+
+# Alias for get_method
+get_static_method = get_method
+```


### PR DESCRIPTION
Implement `hydra.utils.get_object` for an easier way to look up objects from a dotpath.



Commits:
- improve err msg for get_class failure
- improve tests for get_{class,method}
- implement hydra.utils.get_object (Closes #2139)
- document hydra.utils.get_{class,method,object} (Closes #1972)