### PR TITLE
remove python3.6 CI jobs and version classifier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,7 @@ jobs:
   # Misc
   coverage:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     steps:
       - checkout
       - run: sudo pip install nox --progress-bar off
@@ -288,19 +288,19 @@ workflows:
       - test_macos:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+              py_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       - test_linux:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+              py_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       - test_win:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+              py_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       - test_linux_omc_dev:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+              py_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 
   plugin_tests:
@@ -309,17 +309,17 @@ workflows:
       - test_plugin_linux:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+              py_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
               test_plugin: [<< pipeline.parameters.test_plugins >>]
       - test_plugin_macos:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+              py_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
               test_plugin: [<< pipeline.parameters.test_plugins >>]
       - test_plugin_win:
           matrix:
             parameters:
-              py_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+              py_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
               test_plugin: [<< pipeline.parameters.test_plugins >>]
 
 

--- a/news/2304.maintenance
+++ b/news/2304.maintenance
@@ -1,0 +1,1 @@
+Drop support for python3.6

--- a/noxfile.py
+++ b/noxfile.py
@@ -192,9 +192,16 @@ def list_plugins(directory: str) -> List[Plugin]:
         if x not in blacklist
     ]
 
-    # Install read-version in base python environment, needed to run setup.py
+    # Install bootstrap deps in base python environment
     subprocess.check_output(
-        [sys.executable, "-m", "pip", "install", "read-version"],
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "read-version",  # needed to read data from setup.py
+            "toml",  # so read-version can read pyproject.toml
+        ],
     )
 
     plugins: List[Plugin] = []

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ with open("README.md", "r") as fh:
         classifiers=[
             "License :: OSI Approved :: MIT License",
             "Development Status :: 4 - Beta",
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Removing support for python3.6, motivated by CI failure [here](https://app.circleci.com/pipelines/github/facebookresearch/hydra/15263/workflows/cb76a5db-dc19-409d-afb4-c65b42fabf23/jobs/154849)

Closes #2304.
Cross ref to related OmegaConf issue: https://github.com/omry/omegaconf/issues/791