### PR TITLE
docs: reorganize sections in Configuring Hydra page

### DIFF
--- a/website/docs/configure_hydra/Intro.md
+++ b/website/docs/configure_hydra/Intro.md
@@ -73,7 +73,22 @@ def my_app(cfg: DictConfig) -> None:
     print(HydraConfig.get().job.name)
 ```
 
-The following variables are populated at runtime.  
+### Top-level Hydra settings
+The following fields are present at the top level of the Hydra Config.
+- mode: Optional, one of `RUN` or `MULTIRUN`. See [multirun](/tutorials/basic/running_your_app/2_multirun.md) for more info.
+- **searchpath**: A list of paths that Hydra searches in order to find configs.
+  See [overriding `hydra.searchpath`](advanced/search_path.md#overriding-hydrasearchpath-config)
+- **job_logging** and **hydra_logging**: Configure logging settings.
+  See [logging](/tutorials/basic/running_your_app/4_logging.md) and [customizing logging](logging.md).
+- **sweeper**: [Sweeper](/tutorials/basic/running_your_app/2_multirun.md#sweeper) plugin settings. Defaults to basic sweeper.
+- **launcher**: [Launcher](/tutorials/basic/running_your_app/2_multirun.md#launcher) plugin settings. Defaults to basic launcher.
+- **callbacks**: [Experimental callback support](/experimental/callbacks.md).
+- **help**: Configures your app's `--help` CLI flag. See [customizing application's help](app_help.md).
+- **hydra_help**: Configures the `--hydra-help` CLI flag.
+- **output_subdir**: Configures the `.hydra` subdirectory name.
+  See [changing or disabling the output subdir](/tutorials/basic/running_your_app/3_working_directory.md#changing-or-disabling-hydras-output-subdir).
+- **verbose**: Configures per-file DEBUG-level logging.
+  See [logging](/tutorials/basic/running_your_app/4_logging.md).
 
 ### hydra.job:
 The **hydra.job** node is used for configuring some aspects of your job. 
@@ -117,25 +132,6 @@ Fields under **hydra.overrides** are populated automatically and should not be o
   Contains the same information as the `.hydra/overrides.yaml` file.
   See [Output/Working directory](/tutorials/basic/running_your_app/3_working_directory.md).
 - **hydra**: Contains a list of the command-line `hydra` config overrides used.
-
-### hydra.mode
-See [multirun](/tutorials/basic/running_your_app/2_multirun.md) for more info.
-
-### Other Hydra settings
-The following fields are present at the top level of the Hydra Config.
-- **searchpath**: A list of paths that Hydra searches in order to find configs.
-  See [overriding `hydra.searchpath`](advanced/search_path.md#overriding-hydrasearchpath-config)
-- **job_logging** and **hydra_logging**: Configure logging settings.
-  See [logging](/tutorials/basic/running_your_app/4_logging.md) and [customizing logging](logging.md).
-- **sweeper**: [Sweeper](/tutorials/basic/running_your_app/2_multirun.md#sweeper) plugin settings. Defaults to basic sweeper.
-- **launcher**: [Launcher](/tutorials/basic/running_your_app/2_multirun.md#launcher) plugin settings. Defaults to basic launcher.
-- **callbacks**: [Experimental callback support](/experimental/callbacks.md).
-- **help**: Configures your app's `--help` CLI flag. See [customizing application's help](app_help.md).
-- **hydra_help**: Configures the `--hydra-help` CLI flag.
-- **output_subdir**: Configures the `.hydra` subdirectory name.
-  See [changing or disabling the output subdir](/tutorials/basic/running_your_app/3_working_directory.md#changing-or-disabling-hydras-output-subdir).
-- **verbose**: Configures per-file DEBUG-level logging.
-  See [logging](/tutorials/basic/running_your_app/4_logging.md).
 
 
 ### Resolvers provided by Hydra

--- a/website/versioned_docs/version-1.3/configure_hydra/Intro.md
+++ b/website/versioned_docs/version-1.3/configure_hydra/Intro.md
@@ -73,7 +73,22 @@ def my_app(cfg: DictConfig) -> None:
     print(HydraConfig.get().job.name)
 ```
 
-The following variables are populated at runtime.  
+### Top-level Hydra settings
+The following fields are present at the top level of the Hydra Config.
+- mode: Optional, one of `RUN` or `MULTIRUN`. See [multirun](/tutorials/basic/running_your_app/2_multirun.md) for more info.
+- **searchpath**: A list of paths that Hydra searches in order to find configs.
+  See [overriding `hydra.searchpath`](advanced/search_path.md#overriding-hydrasearchpath-config)
+- **job_logging** and **hydra_logging**: Configure logging settings.
+  See [logging](/tutorials/basic/running_your_app/4_logging.md) and [customizing logging](logging.md).
+- **sweeper**: [Sweeper](/tutorials/basic/running_your_app/2_multirun.md#sweeper) plugin settings. Defaults to basic sweeper.
+- **launcher**: [Launcher](/tutorials/basic/running_your_app/2_multirun.md#launcher) plugin settings. Defaults to basic launcher.
+- **callbacks**: [Experimental callback support](/experimental/callbacks.md).
+- **help**: Configures your app's `--help` CLI flag. See [customizing application's help](app_help.md).
+- **hydra_help**: Configures the `--hydra-help` CLI flag.
+- **output_subdir**: Configures the `.hydra` subdirectory name.
+  See [changing or disabling the output subdir](/tutorials/basic/running_your_app/3_working_directory.md#changing-or-disabling-hydras-output-subdir).
+- **verbose**: Configures per-file DEBUG-level logging.
+  See [logging](/tutorials/basic/running_your_app/4_logging.md).
 
 ### hydra.job:
 The **hydra.job** node is used for configuring some aspects of your job. 
@@ -117,25 +132,6 @@ Fields under **hydra.overrides** are populated automatically and should not be o
   Contains the same information as the `.hydra/overrides.yaml` file.
   See [Output/Working directory](/tutorials/basic/running_your_app/3_working_directory.md).
 - **hydra**: Contains a list of the command-line `hydra` config overrides used.
-
-### hydra.mode
-See [multirun](/tutorials/basic/running_your_app/2_multirun.md) for more info.
-
-### Other Hydra settings
-The following fields are present at the top level of the Hydra Config.
-- **searchpath**: A list of paths that Hydra searches in order to find configs.
-  See [overriding `hydra.searchpath`](advanced/search_path.md#overriding-hydrasearchpath-config)
-- **job_logging** and **hydra_logging**: Configure logging settings.
-  See [logging](/tutorials/basic/running_your_app/4_logging.md) and [customizing logging](logging.md).
-- **sweeper**: [Sweeper](/tutorials/basic/running_your_app/2_multirun.md#sweeper) plugin settings. Defaults to basic sweeper.
-- **launcher**: [Launcher](/tutorials/basic/running_your_app/2_multirun.md#launcher) plugin settings. Defaults to basic launcher.
-- **callbacks**: [Experimental callback support](/experimental/callbacks.md).
-- **help**: Configures your app's `--help` CLI flag. See [customizing application's help](app_help.md).
-- **hydra_help**: Configures the `--hydra-help` CLI flag.
-- **output_subdir**: Configures the `.hydra` subdirectory name.
-  See [changing or disabling the output subdir](/tutorials/basic/running_your_app/3_working_directory.md#changing-or-disabling-hydras-output-subdir).
-- **verbose**: Configures per-file DEBUG-level logging.
-  See [logging](/tutorials/basic/running_your_app/4_logging.md).
 
 
 ### Resolvers provided by Hydra


### PR DESCRIPTION
This PR reorders sections on the https://hydra.cc/docs/1.3/configure_hydra/intro/ webpage.
I've moved the section on top-level hydra config settings higher up on the page, and
I've merged the section on `hydra.mode` into the section on top-level hydra settings.
Additionally, I've added a clarifying sentence to the entry regarding. `hydra.mode`.
