### PR TITLE
Remove usages of legacy importlib API.

### DIFF
--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -182,20 +182,16 @@ class Plugins(metaclass=Singleton):
                     import_time = timer()
 
                     with warnings.catch_warnings(record=True) as recorded_warnings:
-                        if sys.version_info < (3, 10):
-                            m = importer.find_module(modname)  # type: ignore
-                            assert m is not None
-                            loaded_mod = m.load_module(modname)
+                        spec = importer.find_spec(modname, None)
+                        assert spec is not None
+                        if modname in sys.modules:
+                            loaded_mod = sys.modules[modname]
                         else:
-                            spec = importer.find_spec(modname)
-                            assert spec is not None
-                            if modname in sys.modules:
-                                loaded_mod = sys.modules[modname]
-                            else:
-                                loaded_mod = importlib.util.module_from_spec(spec)
-                            if loaded_mod is not None:
-                                spec.loader.exec_module(loaded_mod)
-                                sys.modules[modname] = loaded_mod
+                            loaded_mod = importlib.util.module_from_spec(spec)
+                        if loaded_mod is not None:
+                            sys.modules[modname] = loaded_mod
+                            assert spec.loader
+                            spec.loader.exec_module(loaded_mod)
 
                     import_time = timer() - import_time
                     if len(recorded_warnings) > 0:


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

The Python >= 3.10 compatible usages of importlib added in 277ff54b71e31531923a51459b328391d76bb5b3 can be safely applied to any version of Python >= 3.5 which covers the full range that Hydra supports.

Getting rid of the old deprecated API, asides from cleaning up, will keep Hydra compatible with PyInstaller if PyInstaller doesn't get cold feet and revert its dropping of support for the legacy API (https://github.com/pyinstaller/pyinstaller/pull/7344).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

Standard CI/CD testing should be sufficient.

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)

None.
