### PR TITLE
Ensure MissingConfigException is picklable

### DIFF
--- a/hydra/errors.py
+++ b/hydra/errors.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Tuple, Type
 
 
 class HydraException(Exception):
@@ -39,6 +39,15 @@ class MissingConfigException(IOError, ConfigCompositionException):
         super(MissingConfigException, self).__init__(message)
         self.missing_cfg_file = missing_cfg_file
         self.options = options
+
+    def __reduce__(
+        self,
+    ) -> Tuple[
+        Type["MissingConfigException"],
+        Tuple[str, Optional[str], Optional[Sequence[str]]],
+    ]:
+        message = self.args[0]
+        return (type(self), (message, self.missing_cfg_file, self.options))
 
 
 class HydraDeprecationError(HydraException):

--- a/hydra/errors.py
+++ b/hydra/errors.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from typing import Optional, Sequence, Tuple, Type
+from typing import Optional, Sequence
 
 
 class HydraException(Exception):
@@ -33,21 +33,12 @@ class MissingConfigException(IOError, ConfigCompositionException):
     def __init__(
         self,
         message: str,
-        missing_cfg_file: Optional[str],
+        missing_cfg_file: Optional[str] = None,
         options: Optional[Sequence[str]] = None,
     ) -> None:
         super(MissingConfigException, self).__init__(message)
         self.missing_cfg_file = missing_cfg_file
         self.options = options
-
-    def __reduce__(
-        self,
-    ) -> Tuple[
-        Type["MissingConfigException"],
-        Tuple[str, Optional[str], Optional[Sequence[str]]],
-    ]:
-        message = self.args[0]
-        return (type(self), (message, self.missing_cfg_file, self.options))
 
 
 class HydraDeprecationError(HydraException):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,14 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import pickle
+
+from hydra.errors import MissingConfigException
+
+
+def test_pickle_missing_config_exception() -> None:
+    exception = MissingConfigException("msg", "filename", ["option1", "option2"])
+    x = pickle.dumps(exception)
+    loaded = pickle.loads(x)
+    assert isinstance(loaded, MissingConfigException)
+    assert loaded.args == ("msg",)
+    assert loaded.missing_cfg_file == "filename"
+    assert loaded.options == ["option1", "option2"]


### PR DESCRIPTION
`hydra.errors.MissingConfigException` cannot be pickled.

To resolve this issue, I've followed the pattern from https://bugs.python.org/issue32696#msg409867 :
this PR adds a `__reduce__` method to `MissingConfigException` to close #2535.
