### PR TITLE
fixup docstring for get_object

### DIFF
--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -69,7 +69,7 @@ get_static_method = get_method
 
 def get_object(path: str) -> Any:
     """
-    Look up a callable based on a dotpath.
+    Look up an object based on a dotpath.
 
     >>> import my_module
     >>> from hydra.utils import get_object


### PR DESCRIPTION
Follow up to PR #2520: fixup the docstring for `hydra.utils.get_object`.
Based on Omry's comment [here](https://github.com/facebookresearch/hydra/pull/2520?notification_referrer_id=NT_kwDOAIhZ7bI1MTcwNTAzNTAxOjg5MzU5MTc#discussion_r1068136041).
