### PR TITLE
Allow specifying a non-relative module name in config_path

### DIFF
--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -123,9 +123,13 @@ def compute_search_path_dir(
     calling_module: Optional[str],
     config_path: Optional[str],
 ) -> Optional[str]:
-    if config_path is not None and os.path.isabs(config_path):
-        search_path_dir = config_path
-    elif calling_file is not None:
+    if config_path is not None:
+        if os.path.isabs(config_path):
+            return config_path
+        if config_path.startswith("pkg://"):
+            return config_path
+
+    if calling_file is not None:
         abs_base_dir = realpath(dirname(calling_file))
 
         if config_path is not None:

--- a/hydra/main.py
+++ b/hydra/main.py
@@ -48,7 +48,11 @@ def main(
     version_base: Optional[str] = _UNSPECIFIED_,
 ) -> Callable[[TaskFunction], Any]:
     """
-    :param config_path: The config path, a directory relative to the declaring python file.
+    :param config_path: The config path, a directory where Hydra will search for
+                        config files. This path is added to Hydra's searchpath.
+                        Relative paths are interpreted relative to the declaring python
+                        file. Alternatively, you can use the prefix `pkg://` to specify
+                        a python package to add to the searchpath.
                         If config_path is None no directory is added to the Config search path.
     :param config_name: The name of the config (usually the file name without the .yaml extension)
     """

--- a/news/2564.feature
+++ b/news/2564.feature
@@ -1,0 +1,1 @@
+Allow config_path to specify a non-relative module path, by starting with `pkg://`

--- a/tests/test_config_search_path.py
+++ b/tests/test_config_search_path.py
@@ -172,6 +172,7 @@ def test_prepend(
             "../conf",
             realpath(os.path.join(os.getcwd(), "../conf")),
         ),
+        (None, "package.module", "pkg://some/conf", "pkg://some/conf"),
     ],
 )
 def test_compute_search_path_dir(


### PR DESCRIPTION
## Motivation

When constructing the config search path, allow callers to directly pass in a non-relative module name starting with `pkg://`.  This allows callers to bypass the relative name lookup, and always get consistent behavior regardless of the current environment variables at runtime.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Added a new entry in test_config_search_path.py

## Related Issues and PRs

#2564