### PR TITLE
Obey `_recursive_` parameter on non-target nodes

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -354,18 +354,24 @@ def instantiate_node(
             ):
                 dict_items = {}
                 for key, value in node.items():
-                    # list items inherits recursive flag from the containing dict.
-                    dict_items[key] = instantiate_node(
-                        value, convert=convert, recursive=recursive
-                    )
+                    if recursive:
+                        # list items inherits recursive flag from the containing dict.
+                        dict_items[key] = instantiate_node(
+                            value, convert=convert, recursive=recursive
+                        )
+                    else:
+                        dict_items[key] = value
                 return dict_items
             else:
                 # Otherwise use DictConfig and resolve interpolations lazily.
                 cfg = OmegaConf.create({}, flags={"allow_objects": True})
                 for key, value in node.items():
-                    cfg[key] = instantiate_node(
-                        value, convert=convert, recursive=recursive
-                    )
+                    if recursive:
+                        cfg[key] = instantiate_node(
+                            value, convert=convert, recursive=recursive
+                        )
+                    else:
+                        cfg[key] = value
                 cfg._set_parent(node)
                 cfg._metadata.object_type = node._metadata.object_type
                 if convert == ConvertMode.OBJECT:

--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -420,6 +420,11 @@ class NestedConf:
     b: Any = field(default_factory=lambda: User(name="b", age=2))
 
 
+@dataclass
+class NestedConfNoTarget:
+    a: Any = field(default_factory=lambda: SimpleClassDefaultPrimitiveConf)
+
+
 def recisinstance(got: Any, expected: Any) -> bool:
     """Compare got with expected type, recursively on dict and list."""
     if not isinstance(got, type(expected)):

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -33,6 +33,7 @@ from tests.instantiate import (
     Mapping,
     MappingConf,
     NestedConf,
+    NestedConfNoTarget,
     NestingClass,
     OuterClass,
     Parameters,
@@ -2096,3 +2097,13 @@ def test_dict_as_none(instantiate_func: Any) -> None:
     cfg = OmegaConf.structured(DictValuesConf)
     obj = instantiate_func(config=cfg)
     assert obj.d is None
+
+
+
+def test_non_target_recursive(instantiate_func: Any) -> None:
+    cfg = OmegaConf.structured(NestedConfNoTarget)
+    obj = instantiate_func(config=cfg, _recursive_=False)
+    assert isinstance(obj.a, DictConfig)
+
+    obj = instantiate_func(config=cfg, _recursive_=True)
+    assert isinstance(obj.a, SimpleClass)


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

When recursively instantiating a config, the _recursive_ parameter is ignored unless the config is a target node (i.e. has a `_target_` parameter). It would be nice if the `_recursive_` flag were considered for non-target nodes as well so that a recursive flow of instantiation can be "broken" (i.e. all nodes from a certain level in the config "tree" remain as `DictConfig` objects). The reason why there is an upstream `_recursive_=True` is because the parent node has other children who we do want to recursively instantiate. As a concrete example, consider the following set of configs and corresponding classes to be instantiated (I tried to keep them as minimal as possible)

```python
@dataclass
class MyArchitecture:
    _target_: str = ".../Architecture"


@dataclass
class MyLRScheduler:
    _target_: str = ".../LRScheduler"


@dataclass
class MyOptimizer:
    _recursive_: bool = False
    scheduler: MyLRScheduler = field(default_factory=MyLRScheduler)


@dataclass
class MyNN:
    _target_: str = ".../NN"
    _recursive_: bool = True

    architecture: MyArchitecture = field(default_factory=MyArchitecture)
    optimizer: MyOptimizer = field(default_factory=MyOptimizer)


@dataclass
class MyConfig:
    nn: MyNN = field(default_factory=MyNN)


cs = ConfigStore.instance()
cs.store(name="config", node=MyConfig)


class LRScheduler:
    ...


class Architecture:
    ...


class NN:
    def __init__(self, architecture: Architecture, optimizer: MyOptimizer) -> None:
        # NB: the `optimizer` expected here is a DictConfig (duck-typed as MyOptimizer)
        self.architecture = architecture
        self.optimizer = optimizer


@hydra.main(config_name="config")
def my_app(cfg: MyConfig) -> None:
    instantiated_config: NN = instantiate(cfg.nn)
    print(f"Scheduler was instantiated: {not isinstance(instantiated_config.optimizer.scheduler, DictConfig)}")

if __name__ == "__main__":
    my_app()
```

The output of the print statement above is `"Scheduler was instantiated: True"`, while the idea behind this PR is that it should be False (due to the setting of the `_recursive_=False` parameter in the `MyOptimizer` config).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Added an additional test in `tests/instantiate/test_instantiate` and verified that no existing tests are broken. As far as I can tell, none of the failing CI tests are due to this PR.


## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
