### PR TITLE
Don't call next() inside assert statment in parser

### DIFF
--- a/hydra/core/override_parser/overrides_visitor.py
+++ b/hydra/core/override_parser/overrides_visitor.py
@@ -107,7 +107,8 @@ class HydraOverrideVisitor(OverrideParserVisitor):
         item = next(children)
         assert isinstance(item, OverrideParser.DictKeyContext)
         pkey = self.visitDictKey(item)
-        assert self.is_matching_terminal(next(children), OverrideLexer.COLON)
+        colon = next(children)
+        assert self.is_matching_terminal(colon, OverrideLexer.COLON)
         value = next(children)
         assert isinstance(value, OverrideParser.ElementContext)
         return pkey, self.visitElement(value)
@@ -212,7 +213,8 @@ class HydraOverrideVisitor(OverrideParserVisitor):
         kwargs = {}
         children = ctx.getChildren()
         func_name = next(children).getText()
-        assert self.is_matching_terminal(next(children), OverrideLexer.POPEN)
+        popen = next(children)
+        assert self.is_matching_terminal(popen, OverrideLexer.POPEN)
         in_kwargs = False
         while True:
             cur = next(children)

--- a/news/2570.bugfix
+++ b/news/2570.bugfix
@@ -1,0 +1,1 @@
+Fix a command line parsing bug in multirun mode when `PYTHONOPTIMIZE=1`

--- a/news/2609.bugfix
+++ b/news/2609.bugfix
@@ -1,0 +1,1 @@
+Fix a command line parsing bug in multirun mode when `PYTHONOPTIMIZE=1`

--- a/news/2609.bugfix
+++ b/news/2609.bugfix
@@ -1,1 +1,0 @@
-Fix a command line parsing bug in multirun mode when `PYTHONOPTIMIZE=1`


### PR DESCRIPTION
`assert` statements can get removed by the Python interpreter, for instance if the env var `PYTHONOPTIMIZE` is set to 1. Consequently, the structure of `assert next(children) ...` leads to parsing errors if the assert statment is removed, because the `children` iterator ends up in a bad state.

This PR fixes the two instances of this bug I found in `overrides_visitor.py`. Fixes #2570.

