### PR TITLE
ignore deprecation warning from pkg_resources

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -504,7 +504,13 @@ def test_core(session: Session) -> None:
     session.install("pytest")
 
     if not SKIP_CORE_TESTS:
-        run_pytest(session, "build_helpers", "tests", *session.posargs)
+        run_pytest(
+            session,
+            "build_helpers",
+            "tests",
+            "-W ignore:pkg_resources is deprecated as an API:DeprecationWarning:pkg_resources",
+            *session.posargs,
+        )
     else:
         session.log("Skipping Hydra core tests")
 


### PR DESCRIPTION
Fixing core_tests failure.
See e.g. CI failure on PR #2613.
