### PR TITLE
Optuna resume study

### DIFF
--- a/plugins/hydra_optuna_sweeper/example/conf/config.yaml
+++ b/plugins/hydra_optuna_sweeper/example/conf/config.yaml
@@ -12,7 +12,7 @@ hydra:
     n_trials: 20
     n_jobs: 1
     max_failure_rate: 0.0
-    load_if_exists: true
+    load_if_exists: True
     params:
       x: range(-5.5, 5.5, step=0.5)
       y: choice(-5 ,0 ,5)

--- a/plugins/hydra_optuna_sweeper/example/conf/config.yaml
+++ b/plugins/hydra_optuna_sweeper/example/conf/config.yaml
@@ -12,6 +12,7 @@ hydra:
     n_trials: 20
     n_jobs: 1
     max_failure_rate: 0.0
+    load_if_exists: true
     params:
       x: range(-5.5, 5.5, step=0.5)
       y: choice(-5 ,0 ,5)

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -156,10 +156,10 @@ class OptunaSweeperImpl(Sweeper):
         n_trials: int,
         n_jobs: int,
         max_failure_rate: float,
+        load_if_exists: Optional[bool],
         search_space: Optional[DictConfig],
         custom_search_space: Optional[str],
         params: Optional[DictConfig],
-        load_if_exists: Optional[bool] = True,
     ) -> None:
         self.sampler = sampler
         self.direction = direction

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -159,6 +159,7 @@ class OptunaSweeperImpl(Sweeper):
         search_space: Optional[DictConfig],
         custom_search_space: Optional[str],
         params: Optional[DictConfig],
+        load_if_exists: Optional[bool] = True,
     ) -> None:
         self.sampler = sampler
         self.direction = direction
@@ -169,6 +170,7 @@ class OptunaSweeperImpl(Sweeper):
         self.max_failure_rate = max_failure_rate
         assert self.max_failure_rate >= 0.0
         assert self.max_failure_rate <= 1.0
+        self.load_if_exists = load_if_exists
         self.custom_search_space_extender: Optional[
             Callable[[DictConfig, Trial], None]
         ] = None
@@ -330,7 +332,7 @@ class OptunaSweeperImpl(Sweeper):
             storage=self.storage,
             sampler=self.sampler,
             directions=directions,
-            load_if_exists=True,
+            load_if_exists=self.load_if_exists,
         )
         log.info(f"Study name: {study.study_name}")
         log.info(f"Storage: {self.storage}")
@@ -338,7 +340,8 @@ class OptunaSweeperImpl(Sweeper):
         log.info(f"Directions: {directions}")
 
         batch_size = self.n_jobs
-        n_trials_to_go = self.n_trials
+        n_trials_to_go = self.n_trials - len(study.trials)
+        self.job_idx = len(study.trials)
 
         while n_trials_to_go > 0:
             batch_size = min(n_trials_to_go, batch_size)

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/config.py
@@ -175,6 +175,9 @@ class OptunaSweeperConf:
     # Maximum authorized failure rate for a batch of parameters
     max_failure_rate: float = 0.0
 
+    # Load an existing study and resume it.
+    load_if_exists: bool = True
+
     search_space: Optional[Dict[str, Any]] = None
 
     params: Optional[Dict[str, str]] = None

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/optuna_sweeper.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/optuna_sweeper.py
@@ -20,10 +20,10 @@ class OptunaSweeper(Sweeper):
         n_trials: int,
         n_jobs: int,
         max_failure_rate: float,
+        load_if_exists: Optional[bool],
         search_space: Optional[DictConfig],
         custom_search_space: Optional[str],
         params: Optional[DictConfig],
-        load_if_exists: Optional[bool] = True,
     ) -> None:
         from ._impl import OptunaSweeperImpl
 
@@ -35,10 +35,10 @@ class OptunaSweeper(Sweeper):
             n_trials,
             n_jobs,
             max_failure_rate,
+            load_if_exists,
             search_space,
             custom_search_space,
             params,
-            load_if_exists,
         )
 
     def setup(

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/optuna_sweeper.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/optuna_sweeper.py
@@ -23,6 +23,7 @@ class OptunaSweeper(Sweeper):
         search_space: Optional[DictConfig],
         custom_search_space: Optional[str],
         params: Optional[DictConfig],
+        load_if_exists: Optional[bool] = True,
     ) -> None:
         from ._impl import OptunaSweeperImpl
 
@@ -37,6 +38,7 @@ class OptunaSweeper(Sweeper):
             search_space,
             custom_search_space,
             params,
+            load_if_exists,
         )
 
     def setup(

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,3 +16,5 @@ filterwarnings =
   ignore:.*Future Hydra versions will no longer change working directory at job runtime by default.*:UserWarning
   ; Jupyter notebook test on Windows yield warnings
   ignore:.*Proactor event loop does not implement add_reader family of methods required for zmq.*:RuntimeWarning
+  ; setuptools 67.5.0+ emits this warning when setuptools.commands.develop is imported
+  ignore:pkg_resources is deprecated as an API:DeprecationWarning

--- a/website/docs/plugins/optuna_sweeper.md
+++ b/website/docs/plugins/optuna_sweeper.md
@@ -71,7 +71,7 @@ study_name: sphere
 n_trials: 20
 n_jobs: 1
 max_failure_rate: 0.0
-load_if_exists: true
+load_if_exists: True
 params:
   x: range(-5.5,5.5,step=0.5)
   y: choice(-5,0,5)

--- a/website/docs/plugins/optuna_sweeper.md
+++ b/website/docs/plugins/optuna_sweeper.md
@@ -71,6 +71,7 @@ study_name: sphere
 n_trials: 20
 n_jobs: 1
 max_failure_rate: 0.0
+load_if_exists: true
 params:
   x: range(-5.5,5.5,step=0.5)
   y: choice(-5,0,5)


### PR DESCRIPTION
## Motivation
When using the Optuna sweeper and the `storage` option, the `optuna.study` will actually be resumed ([ref](https://github.com/facebookresearch/hydra/blob/744318bb4e3947190a54b7ba8593bd22a02b4544/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py#L333)).
However, the sweeper will reset the `job_idx` to 0 and the `n_trials_to_go` to the number originally configured (i.e., before interrupting the sweep).

It's confusing that the reloading is done but the configured job parameters are not updated. This PR makes it explicit by allowing the configuration of the `load_if_exists` parameter. If `True` (by default - for strongest backwards compatibility) the study is loaded if it already exists. The `n_trials_to_go` and `job_idx` are then updated accordingly. If `False`, an Optuna error will be raised. Note this parameter acts exactly in accordance with [optuna](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.create_study.html#optuna-create-study).


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?
Yes, but it's my first contribution so any feedback is welcome.

## Test Plan
I added an additional test to demonstrate and test the desired behavior.

## Related Issues and PRs
This is related to  #1407 and should close #1679. (W.r.t. #1679 the garbage collecting can be done in a callback, I can optionally demonstrate in that issue before it's closed).
