### PR TITLE
Synchronize with upcoming submitit Slurmexecutor python arg addition

### DIFF
--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
@@ -66,6 +66,9 @@ class SlurmQueueConf(BaseQueueConf):
     # check the following for more info on slurm_max_num_timeout
     # https://github.com/facebookincubator/submitit/blob/master/docs/checkpointing.md
     max_num_timeout: int = 0
+    # Path to Python executable.
+    # Useful when calling the Slurm Python executable is different from the original.
+    python: Optional[str] = None
     # Useful to add parameters which are not currently available in the plugin.
     # Eg: {"mail-user": "blublu@fb.com", "mail-type": "BEGIN"}
     additional_parameters: Dict[str, Any] = field(default_factory=dict)

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
@@ -96,7 +96,10 @@ class BaseSubmititLauncher(Launcher):
         # build executor
         init_params = {"folder": self.params["submitit_folder"]}
         specific_init_keys = {"max_num_timeout"}
-
+        
+        if self._EXECUTOR == "slurm":
+            specific_init_keys = specific_init_keys | {"python"}
+        
         init_params.update(
             **{
                 f"{self._EXECUTOR}_{x}": y


### PR DESCRIPTION
Synchronizing with upcoming submitit change (https://github.com/facebookincubator/submitit/pull/1729) that allows to pass in a "python" variable to SlurmExecutor.

(Updated from https://github.com/facebookresearch/hydra/pull/2649 due to CLA)

(Likely to not pass CI tests until the above PR is merged)