### PR TITLE
fix filehandler of colorlog will change the output directory of log file

### DIFF
--- a/plugins/hydra_colorlog/hydra_plugins/hydra_colorlog/conf/hydra/job_logging/colorlog.yaml
+++ b/plugins/hydra_colorlog/hydra_plugins/hydra_colorlog/conf/hydra/job_logging/colorlog.yaml
@@ -22,7 +22,7 @@ handlers:
     class: logging.FileHandler
     formatter: simple
     # relative to the job log directory
-    filename: ${hydra.job.name}.log
+    filename: ${hydra.runtime.output_dir}/${hydra.job.name}.log
 root:
   level: INFO
   handlers: [console, file]

--- a/plugins/hydra_colorlog/news/2663.bugfix
+++ b/plugins/hydra_colorlog/news/2663.bugfix
@@ -1,0 +1,1 @@
+fix filehandler of colorlog will change the output directory of log file

--- a/plugins/hydra_colorlog/news/2663.bugfix
+++ b/plugins/hydra_colorlog/news/2663.bugfix
@@ -1,1 +1,1 @@
-fix filehandler of colorlog will change the output directory of log file
+Fix log file path for colorlog to work correctly if Hydra does not change the current working directory


### PR DESCRIPTION
This is to fix the issue #2662 