### PR TITLE
rm python3.6 from noxfile and plugins

### DIFF
--- a/examples/plugins/example_configsource_plugin/setup.py
+++ b/examples/plugins/example_configsource_plugin/setup.py
@@ -19,7 +19,6 @@ with open("README.md", "r") as fh:
             "License :: OSI Approved :: MIT License",
             # Hydra uses Python version and Operating system to determine
             # In which environments to test this plugin
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",

--- a/examples/plugins/example_generic_plugin/setup.py
+++ b/examples/plugins/example_generic_plugin/setup.py
@@ -19,7 +19,6 @@ with open("README.md", "r") as fh:
             "License :: OSI Approved :: MIT License",
             # Hydra uses Python version and Operating system to determine
             # In which environments to test this plugin
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",

--- a/examples/plugins/example_launcher_plugin/setup.py
+++ b/examples/plugins/example_launcher_plugin/setup.py
@@ -19,7 +19,6 @@ with open("README.md", "r") as fh:
             "License :: OSI Approved :: MIT License",
             # Hydra uses Python version and Operating system to determine
             # In which environments to test this plugin
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",

--- a/examples/plugins/example_registered_plugin/setup.py
+++ b/examples/plugins/example_registered_plugin/setup.py
@@ -19,7 +19,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         # Hydra uses Python version and Operating system to determine
         # In which environments to test this plugin
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/examples/plugins/example_searchpath_plugin/setup.py
+++ b/examples/plugins/example_searchpath_plugin/setup.py
@@ -21,7 +21,6 @@ with open("README.md", "r") as fh:
             "License :: OSI Approved :: MIT License",
             # Hydra uses Python version and Operating system to determine
             # In which environments to test this plugin
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",

--- a/examples/plugins/example_sweeper_plugin/setup.py
+++ b/examples/plugins/example_sweeper_plugin/setup.py
@@ -19,7 +19,6 @@ with open("README.md", "r") as fh:
             "License :: OSI Approved :: MIT License",
             # Hydra uses Python version and Operating system to determine
             # In which environments to test this plugin
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,7 @@ from nox.logger import logger
 
 BASE = os.path.abspath(os.path.dirname(__file__))
 
-DEFAULT_PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+DEFAULT_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 DEFAULT_OS_NAMES = ["Linux", "MacOS", "Windows"]
 
 PYTHON_VERSIONS = os.environ.get(

--- a/plugins/hydra_colorlog/setup.py
+++ b/plugins/hydra_colorlog/setup.py
@@ -17,7 +17,6 @@ setup(
     packages=find_namespace_packages(include=["hydra_plugins.*"]),
     classifiers=[
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/plugins/hydra_nevergrad_sweeper/setup.py
+++ b/plugins/hydra_nevergrad_sweeper/setup.py
@@ -17,7 +17,6 @@ setup(
     packages=find_namespace_packages(include=["hydra_plugins.*"]),
     classifiers=[
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -17,7 +17,6 @@ setup(
     packages=find_namespace_packages(include=["hydra_plugins.*"]),
     classifiers=[
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/plugins/hydra_rq_launcher/setup.py
+++ b/plugins/hydra_rq_launcher/setup.py
@@ -17,7 +17,6 @@ setup(
     packages=find_namespace_packages(include=["hydra_plugins.*"]),
     classifiers=[
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/website/docs/development/overview.md
+++ b/website/docs/development/overview.md
@@ -13,7 +13,7 @@ conda create -n hydra38 python=3.8 -qy
 ```
 
 :::info NOTE
-The core Hydra framework supports Python 3.6 or newer. You may need to create additional environments for different Python versions if CI detect issues on a supported version of Python.
+The core Hydra framework supports Python 3.7 or newer. You may need to create additional environments for different Python versions if CI detect issues on a supported version of Python.
 :::
 
 Activate the environment:

--- a/website/docs/development/testing.md
+++ b/website/docs/development/testing.md
@@ -27,7 +27,7 @@ to test a single plugin:
 ```shell {4}
 $ PLUGINS=hydra_colorlog nox -s test_plugins-3.8
 Operating system        :       Linux
-NOX_PYTHON_VERSIONS     :       ['3.6', '3.7', '3.8', '3.9']
+NOX_PYTHON_VERSIONS     :       ['3.7', '3.8', '3.9', '3.10', '3.11']
 PLUGINS                 :       ['hydra_colorlog']
 SKIP_CORE_TESTS         :       False
 FIX                     :       False


### PR DESCRIPTION
Remove references to python3.6 from `noxfile.py` and from the plugin `setup.py` files.
This is a follow-up to PR #2523, which removed python3.6 ci jobs.