### PR TITLE
Use syntax updated with Python 3.7 and avoid unnecessary list creations

### DIFF
--- a/build_helpers/test_helpers.py
+++ b/build_helpers/test_helpers.py
@@ -112,8 +112,8 @@ def test_find(
         scan_exclude=scan_exclude,
     )
 
-    ret_set = set([str(Path(x)) for x in ret])
-    expected_set = set([str(Path(x)) for x in expected])
+    ret_set = {str(Path(x)) for x in ret}
+    expected_set = {str(Path(x)) for x in expected}
     assert ret_set == expected_set
 
 

--- a/examples/plugins/example_configsource_plugin/setup.py
+++ b/examples/plugins/example_configsource_plugin/setup.py
@@ -2,7 +2,7 @@
 # type: ignore
 from setuptools import find_namespace_packages, setup
 
-with open("README.md", "r") as fh:
+with open("README.md") as fh:
     LONG_DESC = fh.read()
     setup(
         name="hydra-example-configsource",

--- a/examples/plugins/example_generic_plugin/setup.py
+++ b/examples/plugins/example_generic_plugin/setup.py
@@ -2,7 +2,7 @@
 # type: ignore
 from setuptools import find_namespace_packages, setup
 
-with open("README.md", "r") as fh:
+with open("README.md") as fh:
     LONG_DESC = fh.read()
     setup(
         name="hydra-example-generic-plugin",

--- a/examples/plugins/example_launcher_plugin/setup.py
+++ b/examples/plugins/example_launcher_plugin/setup.py
@@ -2,7 +2,7 @@
 # type: ignore
 from setuptools import find_namespace_packages, setup
 
-with open("README.md", "r") as fh:
+with open("README.md") as fh:
     LONG_DESC = fh.read()
     setup(
         name="hydra-example-launcher",

--- a/examples/plugins/example_registered_plugin/setup.py
+++ b/examples/plugins/example_registered_plugin/setup.py
@@ -2,7 +2,7 @@
 # type: ignore
 from setuptools import setup
 
-with open("README.md", "r") as fh:
+with open("README.md") as fh:
     LONG_DESC = fh.read()
 setup(
     name="hydra-example-registered-plugin",

--- a/examples/plugins/example_searchpath_plugin/setup.py
+++ b/examples/plugins/example_searchpath_plugin/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_namespace_packages, setup, find_packages
 
 
-with open("README.md", "r") as fh:
+with open("README.md") as fh:
     LONG_DESC = fh.read()
     setup(
         name="hydra-example-searchpath-plugin",

--- a/examples/plugins/example_sweeper_plugin/setup.py
+++ b/examples/plugins/example_sweeper_plugin/setup.py
@@ -2,7 +2,7 @@
 # type: ignore
 from setuptools import find_namespace_packages, setup
 
-with open("README.md", "r") as fh:
+with open("README.md") as fh:
     LONG_DESC = fh.read()
     setup(
         name="hydra-example-sweeper",

--- a/hydra/_internal/core_plugins/basic_sweeper.py
+++ b/hydra/_internal/core_plugins/basic_sweeper.py
@@ -62,7 +62,7 @@ class BasicSweeper(Sweeper):
         """
         Instantiates
         """
-        super(BasicSweeper, self).__init__()
+        super().__init__()
 
         if params is None:
             params = {}

--- a/hydra/_internal/core_plugins/zsh_completion.py
+++ b/hydra/_internal/core_plugins/zsh_completion.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 class ZshCompletion(CompletionPlugin):
     def __init__(self, config_loader: ConfigLoader):
-        super(ZshCompletion, self).__init__(config_loader)
+        super().__init__(config_loader)
         from hydra._internal.core_plugins.bash_completion import BashCompletion
 
         self.delegate = BashCompletion(config_loader)

--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -312,7 +312,7 @@ def _check_not_missing(
                 group_path,
                 results_filter=ObjectType.CONFIG,
             )
-            opt_list = "\n".join(["\t" + x for x in options])
+            opt_list = "\n".join("\t" + x for x in options)
             msg = dedent(
                 f"""\
                 You must specify '{override_key}', e.g, {override_key}=<OPTION>
@@ -778,7 +778,7 @@ def config_not_found_error(repo: IConfigRepository, tree: DefaultsTreeNode) -> N
         if isinstance(element, GroupDefault):
             msg = f"Could not find '{element.get_config_path()}'\n"
             if options is not None and len(options) > 0:
-                opt_list = "\n".join(["\t" + x for x in options])
+                opt_list = "\n".join("\t" + x for x in options)
                 msg = f"{msg}\nAvailable options in '{group}':\n" + opt_list
         else:
             msg = dedent(

--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -287,7 +287,7 @@ class Hydra:
             if parent == "":
                 group_name = group
             else:
-                group_name = "{}/{}".format(parent, group)
+                group_name = f"{parent}/{group}"
             files = self.config_loader.get_group_options(group_name, ObjectType.CONFIG)
             dirs = self.config_loader.get_group_options(group_name, ObjectType.GROUP)
             if len(files) > 0:
@@ -305,10 +305,10 @@ class Hydra:
             options = sorted(self.config_loader.get_group_options(group))
             if compact:
                 items = ", ".join(options)
-                line = "{}: {}".format(group, items)
+                line = f"{group}: {items}"
             else:
                 items = "\n".join(["  " + o for o in options])
-                line = "{}:\n{}".format(group, items)
+                line = f"{group}:\n{items}"
             s += line + "\n"
 
         return s
@@ -396,14 +396,14 @@ class Hydra:
             if len(plugins) > 0:
                 Hydra._log_header(header=f"{plugin_type.__name__}:", prefix="\t")
                 for plugin in plugins:
-                    log.debug("\t\t{}".format(plugin.__name__))
+                    log.debug(f"\t\t{plugin.__name__}")
                     if plugin.__name__ in all_plugins:
                         all_plugins.remove(plugin.__name__)
 
         if len(all_plugins) > 0:
             Hydra._log_header(header="Generic plugins: ", prefix="\t")
             for plugin_name in all_plugins:
-                log.debug("\t\t{}".format(plugin_name))
+                log.debug(f"\t\t{plugin_name}")
 
     def _print_search_path(
         self,

--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -233,7 +233,7 @@ class Hydra:
 
         for shell, plugins in shell_to_plugin.items():
             if len(plugins) > 1:
-                lst = ",".join([type(plugin).__name__ for plugin in plugins])
+                lst = ",".join(type(plugin).__name__ for plugin in plugins)
                 raise ValueError(f"Multiple plugins installed for {shell} : {lst}")
 
         return shell_to_plugin
@@ -251,7 +251,7 @@ class Hydra:
 
         def find_plugin(cmd: str) -> CompletionPlugin:
             if cmd not in shell_to_plugin:
-                lst = "\n".join(["\t" + x for x in shell_to_plugin.keys()])
+                lst = "\n".join("\t" + x for x in shell_to_plugin.keys())
                 raise ValueError(
                     f"No completion plugin for '{cmd}' found, available : \n{lst}"
                 )
@@ -307,7 +307,7 @@ class Hydra:
                 items = ", ".join(options)
                 line = f"{group}: {items}"
             else:
-                items = "\n".join(["  " + o for o in options])
+                items = "\n".join("  " + o for o in options)
                 line = f"{group}:\n{items}"
             s += line + "\n"
 

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -494,7 +494,7 @@ def _get_completion_help() -> str:
             completion_info.append(plugin_cls.help(cmd).format(_get_exec_command()))
         completion_info.append("")
 
-    completion_help = "\n".join([f"    {x}" if x else x for x in completion_info])
+    completion_help = "\n".join(f"    {x}" if x else x for x in completion_info)
     return completion_help
 
 

--- a/hydra/core/config_store.py
+++ b/hydra/core/config_store.py
@@ -133,10 +133,10 @@ class ConfigStore(metaclass=Singleton):
     def list(self, path: str) -> List[str]:
         d = self._open(path)
         if d is None:
-            raise IOError(f"Path not found {path}")
+            raise OSError(f"Path not found {path}")
 
         if not isinstance(d, dict):
-            raise IOError(f"Path points to a file : {path}")
+            raise OSError(f"Path points to a file : {path}")
 
         return sorted(d.keys())
 

--- a/hydra/core/singleton.py
+++ b/hydra/core/singleton.py
@@ -10,7 +10,7 @@ class Singleton(type):
 
     def __call__(cls, *args: Any, **kwargs: Any) -> Any:
         if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+            cls._instances[cls] = super().__call__(*args, **kwargs)
         return cls._instances[cls]
 
     def instance(cls: Any, *args: Any, **kwargs: Any) -> Any:

--- a/hydra/errors.py
+++ b/hydra/errors.py
@@ -12,7 +12,7 @@ class CompactHydraException(HydraException):
 
 class OverrideParseException(CompactHydraException):
     def __init__(self, override: str, message: str) -> None:
-        super(OverrideParseException, self).__init__(message)
+        super().__init__(message)
         self.override = override
         self.message = message
 
@@ -36,7 +36,7 @@ class MissingConfigException(IOError, ConfigCompositionException):
         missing_cfg_file: Optional[str] = None,
         options: Optional[Sequence[str]] = None,
     ) -> None:
-        super(MissingConfigException, self).__init__(message)
+        super().__init__(message)
         self.missing_cfg_file = missing_cfg_file
         self.options = options
 

--- a/hydra/plugins/completion_plugin.py
+++ b/hydra/plugins/completion_plugin.py
@@ -127,7 +127,7 @@ class CompletionPlugin(Plugin):
                 else:
                     key_matches = []
 
-                matches.extend([f"{word}{match}" for match in key_matches])
+                matches.extend(f"{word}{match}" for match in key_matches)
             else:
                 last_dot = word.rfind(".")
                 if last_dot != -1:
@@ -135,7 +135,7 @@ class CompletionPlugin(Plugin):
                     partial_key = word[last_dot + 1 :]
                     conf_node = OmegaConf.select(config, base_key)
                     key_matches = CompletionPlugin._get_matches(conf_node, partial_key)
-                    matches.extend([f"{base_key}.{match}" for match in key_matches])
+                    matches.extend(f"{base_key}.{match}" for match in key_matches)
                 else:
                     if isinstance(config, DictConfig):
                         for key, value in config.items_ex(resolve=False):

--- a/hydra/test_utils/test_utils.py
+++ b/hydra/test_utils/test_utils.py
@@ -221,7 +221,7 @@ def find_parent_dir_containing(
         cur = os.path.relpath(os.path.join(cur, ".."))
         max_up = max_up - 1
     if max_up == 0:
-        raise IOError(f"Could not find {target} in parents of {os.getcwd()}")
+        raise OSError(f"Could not find {target} in parents of {os.getcwd()}")
     return cur
 
 
@@ -333,7 +333,7 @@ if __name__ == "__main__":
                 modified_env.update(env_override)
         subprocess.check_call(cmd, env=modified_env)
 
-        with open(output_file, "r") as f:
+        with open(output_file) as f:
             file_str = f.read()
             output = str.splitlines(file_str)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -210,7 +210,7 @@ def list_plugins(directory: str) -> List[Plugin]:
         setup_py = os.path.join(abspath, "setup.py")
         name_and_classifiers: List[str] = subprocess.check_output(
             [sys.executable, setup_py, "--name", "--classifiers"],
-            universal_newlines=True,
+            text=True,
         ).splitlines()
         name, classifiers = name_and_classifiers[0], name_and_classifiers[1:]
 

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
@@ -34,7 +34,7 @@ class TrialBatch:
 
 def encoder_parameters_into_string(parameters: List[Dict[str, Any]]) -> str:
     """Convert a list of params into a string"""
-    mandatory_keys = set(["name", "type", "bounds", "values", "value"])
+    mandatory_keys = {"name", "type", "bounds", "values", "value"}
     parameter_log_string = ""
     for parameter in parameters:
         parameter_log_string += "\n"

--- a/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/_core.py
+++ b/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/_core.py
@@ -90,7 +90,7 @@ def launch(
 
     log.info(
         "Joblib.Parallel({}) is launching {} jobs".format(
-            ",".join([f"{k}={v}" for k, v in joblib_cfg.items()]),
+            ",".join(f"{k}={v}" for k, v in joblib_cfg.items()),
             len(job_overrides),
         )
     )

--- a/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/_core.py
+++ b/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/_core.py
@@ -37,7 +37,7 @@ def execute_job(
         config, list(overrides)
     )
     with open_dict(sweep_config):
-        sweep_config.hydra.job.id = "{}_{}".format(sweep_config.hydra.job.name, idx)
+        sweep_config.hydra.job.id = f"{sweep_config.hydra.job.name}_{idx}"
         sweep_config.hydra.job.num = idx
     HydraConfig.instance().set_config(sweep_config)
 
@@ -94,7 +94,7 @@ def launch(
             len(job_overrides),
         )
     )
-    log.info("Launching jobs, sweep output dir : {}".format(sweep_dir))
+    log.info(f"Launching jobs, sweep output dir : {sweep_dir}")
     for idx, overrides in enumerate(job_overrides):
         log.info("\t#{} : {}".format(idx, " ".join(filter_overrides(overrides))))
 

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
@@ -95,7 +95,7 @@ def launch(
     log.info(
         f"RQ Launcher is enqueuing {len(job_overrides)} job(s) in queue : {rq_cfg.queue}"
     )
-    log.info("Sweep output dir : {}".format(sweep_dir))
+    log.info(f"Sweep output dir : {sweep_dir}")
     if not sweep_dir.is_absolute():
         log.warn(
             "Using relative sweep dir: Please be aware that dir will be relative to where workers are started from."

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with pathlib.Path("requirements/requirements.txt").open() as requirements_txt:
     ]
 
 
-with open("README.md", "r") as fh:
+with open("README.md") as fh:
     LONG_DESC = fh.read()
     setup(
         cmdclass={

--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -39,7 +39,7 @@ def partial_equal(obj1: Any, obj2: Any) -> bool:
     if isinstance(obj1, list):
         if len(obj1) != len(obj2):
             return False
-        return all(partial_equal(o1, o2) for o1, o2 in zip(obj1))
+        return all(partial_equal(o1, o2) for o1, o2 in zip(obj1, obj2))
     if not (isinstance(obj1, partial) and isinstance(obj2, partial)):
         return False
     return all(

--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -39,7 +39,7 @@ def partial_equal(obj1: Any, obj2: Any) -> bool:
     if isinstance(obj1, list):
         if len(obj1) != len(obj2):
             return False
-        return all([partial_equal(obj1[i], obj2[i]) for i in range(len(obj1))])
+        return all(partial_equal(o1, o2) for o1, o2 in zip(obj1))
     if not (isinstance(obj1, partial) and isinstance(obj2, partial)):
         return False
     return all(

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -183,7 +183,7 @@ def test_save_job_return_callback(tmpdir: Path, multirun: bool) -> None:
         log_paths = [tmpdir / "my_app.log"]
 
     for p in log_paths:
-        with open(p, "r") as file:
+        with open(p) as file:
             logs = file.readlines()
             assert log_msg in logs
 
@@ -215,7 +215,7 @@ def test_experimental_rerun(
     assert config_file.exists()
     assert log_file.exists()
 
-    with open(log_file, "r") as file:
+    with open(log_file) as file:
         logs = file.read().splitlines()
         assert "[JOB] Running my_app" in logs
 
@@ -232,6 +232,6 @@ def test_experimental_rerun(
     result, err = run_python_script(cmd, allow_warnings=True)
     assert warning_msg in err
 
-    with open(log_file, "r") as file:
+    with open(log_file) as file:
         logs = file.read().splitlines()
         assert "[JOB] Running my_app" in logs

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -269,7 +269,7 @@ class TestRunCompletion:
 
         cmd.extend(expected)
         if verbose:
-            print("\nCOMMAND:\n" + " ".join([f"'{x}'" for x in cmd]))
+            print("\nCOMMAND:\n" + " ".join(f"'{x}'" for x in cmd))
 
         subprocess.check_call(cmd)
 

--- a/tests/test_examples/test_tutorials_basic.py
+++ b/tests/test_examples/test_tutorials_basic.py
@@ -53,7 +53,7 @@ def test_tutorial_working_directory(tmpdir: Path) -> None:
         "hydra.job.chdir=True",
     ]
     result, _err = run_python_script(cmd)
-    assert result == "Working directory : {}".format(tmpdir)
+    assert result == f"Working directory : {tmpdir}"
 
 
 def test_tutorial_working_directory_original_cwd(tmpdir: Path) -> None:

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1090,7 +1090,7 @@ def test_hydra_output_dir(
     ) as task:
         assert task.temp_dir is not None
         path = Path(task.temp_dir)
-        files = set([str(x)[len(task.temp_dir) + 1 :] for x in path.iterdir()])
+        files = {str(x)[len(task.temp_dir) + 1 :] for x in path.iterdir()}
         assert files == expected_files
 
 

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -2,7 +2,6 @@
 import builtins
 import math
 import re
-from builtins import isinstance
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Union
 

--- a/tools/configen/configen/utils.py
+++ b/tools/configen/configen/utils.py
@@ -59,7 +59,7 @@ def type_str(t: Any) -> str:
 
 def is_tuple_annotation(type_: Any) -> bool:
     origin = getattr(type_, "__origin__", None)
-    return origin is tuple  # pragma: no cover
+    return origin is tuple
 
 
 def convert_imports(imports: Set[Any], string_imports: Iterable[str]) -> List[str]:

--- a/tools/configen/configen/utils.py
+++ b/tools/configen/configen/utils.py
@@ -59,10 +59,7 @@ def type_str(t: Any) -> str:
 
 def is_tuple_annotation(type_: Any) -> bool:
     origin = getattr(type_, "__origin__", None)
-    if sys.version_info < (3, 7, 0):
-        return origin is Tuple or type_ is Tuple  # pragma: no cover
-    else:
-        return origin is tuple  # pragma: no cover
+    return origin is tuple  # pragma: no cover
 
 
 def convert_imports(imports: Set[Any], string_imports: Iterable[str]) -> List[str]:

--- a/tools/configen/configen/utils.py
+++ b/tools/configen/configen/utils.py
@@ -47,7 +47,7 @@ def type_str(t: Any) -> str:
 
     args = getattr(t, "__args__", None)
     if args is not None:
-        args = ", ".join([type_str(t) for t in t.__args__])
+        args = ", ".join(type_str(t) for t in t.__args__)
         ret = f"{name}[{args}]"
     else:
         ret = name

--- a/tools/configen/tests/test_modules/__init__.py
+++ b/tools/configen/tests/test_modules/__init__.py
@@ -180,7 +180,7 @@ class DictValues:
         )
 
 
-class PeskySentinel(object):
+class PeskySentinel:
     def __repr__(self):
         return "<I am a pesky sentinel>"
 

--- a/tools/configen/tests/test_modules/future_annotations.py
+++ b/tools/configen/tests/test_modules/future_annotations.py
@@ -26,12 +26,12 @@ class ExampleClass:
     def __init__(
         self,
         no_default: float,
-        lst: List[str],
-        passthrough_list: List[LibraryClass],
-        dataclass_val: List[User],
-        def_value: List[str] = [],
+        lst: list[str],
+        passthrough_list: list[LibraryClass],
+        dataclass_val: list[User],
+        def_value: list[str] = [],
         default_str="Bond, James Bond",
-        none_str: Optional[str] = None,
+        none_str: str | None = None,
     ):
         self.no_default = no_default
         self.lst = lst

--- a/tools/configen/tests/test_modules/future_annotations.py
+++ b/tools/configen/tests/test_modules/future_annotations.py
@@ -26,12 +26,12 @@ class ExampleClass:
     def __init__(
         self,
         no_default: float,
-        lst: list[str],
-        passthrough_list: list[LibraryClass],
-        dataclass_val: list[User],
-        def_value: list[str] = [],
+        lst: List[str],
+        passthrough_list: List[LibraryClass],
+        dataclass_val: List[User],
+        def_value: List[str] = [],
         default_str="Bond, James Bond",
-        none_str: str | None = None,
+        none_str: Optional[str] = None,
     ):
         self.no_default = no_default
         self.lst = lst


### PR DESCRIPTION
I ran the following, which updates the code to syntax to Python >= 3.7:

```bash
pyupgrade $(find . -name "*.py" -type f) --py37-plus
```

This includes, for example, the Python-2 style of calling `super` and using f-strings where possible. I reviewed these changes manually.

Also, I looked for unnecessary list comprehension creations, where a generator expression could have been created instead, thus saving memory and compute (though small if the lists were small).