### PR TITLE
noxfile: update pytest DeprecationWarning ignore stmt

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -508,7 +508,7 @@ def test_core(session: Session) -> None:
             session,
             "build_helpers",
             "tests",
-            "-W ignore:pkg_resources is deprecated as an API:DeprecationWarning:pkg_resources",
+            "-W ignore:pkg_resources is deprecated as an API:DeprecationWarning",
             *session.posargs,
         )
     else:


### PR DESCRIPTION
Closes #2692.

Pytest was failing with a DeprecationWarning from a downstream dependency.
This PR reconfigures the python warnings filter to ignore the warning.
