### PR TITLE
Rename references of `master` into `main`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 (Write your motivation for proposed changes here.)
 
-### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/master/CONTRIBUTING.md)?
+### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?
 
 Yes/No
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/facebookresearch/hydra/master/website/static/img/Hydra-Readme-logo2.svg" alt="logo" width="70%" /></p>
+<p align="center"><img src="https://raw.githubusercontent.com/facebookresearch/hydra/main/website/static/img/Hydra-Readme-logo2.svg" alt="logo" width="70%" /></p>
 
 <p align="center">
   <a href="https://pypi.org/project/hydra-core/">

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
@@ -38,7 +38,7 @@ class SlurmQueueConf(BaseQueueConf):
     )
 
     # Params are used to configure sbatch, for more info check:
-    # https://github.com/facebookincubator/submitit/blob/master/submitit/slurm/slurm.py
+    # https://github.com/facebookincubator/submitit/blob/main/submitit/slurm/slurm.py
 
     # Following parameters are slurm specific
     # More information: https://slurm.schedmd.com/sbatch.html
@@ -64,7 +64,7 @@ class SlurmQueueConf(BaseQueueConf):
     # Change this only after you confirmed your code can handle re-submission
     # by properly resuming from the latest stored checkpoint.
     # check the following for more info on slurm_max_num_timeout
-    # https://github.com/facebookincubator/submitit/blob/master/docs/checkpointing.md
+    # https://github.com/facebookincubator/submitit/blob/main/docs/checkpointing.md
     max_num_timeout: int = 0
     # Useful to add parameters which are not currently available in the plugin.
     # Eg: {"mail-user": "blublu@fb.com", "mail-type": "BEGIN"}


### PR DESCRIPTION
I've checked all links to make sure the change makes sense and that they work fine.