### PR TITLE
Ignore new deprecation message from setuptools.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -16,3 +16,5 @@ filterwarnings =
   ignore:.*Future Hydra versions will no longer change working directory at job runtime by default.*:UserWarning
   ; Jupyter notebook test on Windows yield warnings
   ignore:.*Proactor event loop does not implement add_reader family of methods required for zmq.*:RuntimeWarning
+  ; setuptools 67.5.0+ emits this warning when setuptools.commands.develop is imported
+  ignore:pkg_resources is deprecated as an API:DeprecationWarning


### PR DESCRIPTION
In setuptools 67.5.0+, a new DeprecationWarning is emitted whenever pkg_resources is imported, which we need to ignore during tests.

I am creating this patch to use in [nixpkgs](https://github.com/NixOS/nixpkgs), as I am updating setuptools there. I'm going to close this PR as I don't want to read or sign a CLA (indeed, I don't remember if I have in the past). Feel free to use it or not use it as you see fit.
