### PR TITLE
Ax Sweeper Plugin support for Python 3.11

### DIFF
--- a/plugins/hydra_ax_sweeper/example/conf/config.yaml
+++ b/plugins/hydra_ax_sweeper/example/conf/config.yaml
@@ -18,7 +18,9 @@ hydra:
 
       experiment:
         # Default to minimize, set to false to maximize
-        minimize: true
+        objectives:
+          result: 
+            minimize: true
 
       early_stop:
         # Number of epochs without a significant improvement from

--- a/plugins/hydra_ax_sweeper/example/conf/config.yaml
+++ b/plugins/hydra_ax_sweeper/example/conf/config.yaml
@@ -19,7 +19,7 @@ hydra:
       experiment:
         # Default to minimize, set to false to maximize
         objectives:
-          result: 
+          result:
             minimize: true
 
       early_stop:

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/_core.py
@@ -184,7 +184,12 @@ class CoreAxSweeper(Sweeper):
                 num_trials_so_far += len(list_of_trials_to_launch)
                 num_trials_left -= len(list_of_trials_to_launch)
 
-                best_parameters, predictions = ax_client.get_best_parameters()
+                result = ax_client.get_best_parameters()
+                if result is None:
+                    log.info("Ax has not yet found any parameters")
+                    continue
+
+                best_parameters, predictions = result
                 metric = predictions[0][ax_client.objective_name]
 
                 if self.early_stopper.should_stop(metric, best_parameters):
@@ -336,8 +341,8 @@ def create_choice_param_from_range_override(override: Override) -> Dict[str, Any
         "name": key,
         "type": "choice",
         "values": [val for val in override.sweep_iterator()],
+        "is_ordered": False,
     }
-
     return param
 
 

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/config.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/config.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from hydra.core.config_store import ConfigStore
 
+from ax.service.utils.instantiation import ObjectiveProperties
 
 @dataclass
 class EarlyStopConfig:
@@ -20,11 +21,7 @@ class ExperimentConfig:
     # Experiment name
     name: Optional[str] = None
 
-    # Name of metric to optimize or null if you only return one metric
-    objective_name: str = "objective"
-
-    # Defaults to minimize, set to false to maximize
-    minimize: bool = True
+    objectives: Optional[Dict[str, ObjectiveProperties]] = None
 
     # For the remaining parameters, refer the Ax documentation: https://ax.dev/api/core.html#experiment
     parameter_constraints: Optional[List[str]] = None

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/config.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/config.py
@@ -2,9 +2,9 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from ax.service.utils.instantiation import ObjectiveProperties
 from hydra.core.config_store import ConfigStore
 
-from ax.service.utils.instantiation import ObjectiveProperties
 
 @dataclass
 class EarlyStopConfig:

--- a/plugins/hydra_ax_sweeper/setup.py
+++ b/plugins/hydra_ax_sweeper/setup.py
@@ -21,15 +21,16 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS",
         "Development Status :: 4 - Beta",
     ],
     install_requires=[
-        "hydra-core>=1.1.0.dev7",
-        "ax-platform>=0.1.20,<0.2.1",  # https://github.com/facebookresearch/hydra/issues/1767
-        "torch",
-        "gpytorch<=1.8.1",  # avoid deprecation warnings. This can probably be removed when ax-platform is unpinned.
+        "hydra-core>=1.2",
+        "ax-platform>=0.3.4,<0.4",
     ],
     include_package_data=True,
 )
+
+

--- a/plugins/hydra_ax_sweeper/setup.py
+++ b/plugins/hydra_ax_sweeper/setup.py
@@ -32,5 +32,3 @@ setup(
     ],
     include_package_data=True,
 )
-
-

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial.yaml
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial.yaml
@@ -12,7 +12,9 @@ hydra:
       max_trials: 10
 
       experiment:
-        minimize: true
+        objectives:
+          result: 
+            minimize: true
 
       early_stop:
         max_epochs_without_improvement: 2

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_coefficients.yaml
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_coefficients.yaml
@@ -1,18 +1,19 @@
+---
 defaults:
-  - override hydra/sweeper: ax
+    - override hydra/sweeper: ax
 
 polynomial:
-  coefficients: ???
+    coefficients: ???
 
 hydra:
-  sweeper:
-    ax_config:
-      max_trials: 10
+    sweeper:
+        ax_config:
+            max_trials: 10
 
-      experiment:
-        objectives:
-          result: 
-            minimize: true
+            experiment:
+                objectives:
+                    result:
+                        minimize: true
 
-      early_stop:
-        max_epochs_without_improvement: 2
+            early_stop:
+                max_epochs_without_improvement: 2

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_coefficients.yaml
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_coefficients.yaml
@@ -10,7 +10,9 @@ hydra:
       max_trials: 10
 
       experiment:
-        minimize: true
+        objectives:
+          result: 
+            minimize: true
 
       early_stop:
         max_epochs_without_improvement: 2

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_constraint.yaml
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_constraint.yaml
@@ -12,8 +12,9 @@ hydra:
       max_trials: 10
 
       experiment:
-        minimize: true
-        objective_name: result
+        objectives:
+          result: 
+            minimize: true
         outcome_constraints: ['constraint_metric >= 2.1']  # Optional.
 
       early_stop:

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_constraint.yaml
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_constraint.yaml
@@ -1,26 +1,27 @@
+---
 defaults:
-  - override hydra/sweeper: ax
+    - override hydra/sweeper: ax
 
 polynomial:
-  x: ???
-  y: ???
-  z: ???
+    x: ???
+    y: ???
+    z: ???
 
 hydra:
-  sweeper:
-    ax_config:
-      max_trials: 10
+    sweeper:
+        ax_config:
+            max_trials: 10
 
-      experiment:
-        objectives:
-          result: 
-            minimize: true
-        outcome_constraints: ['constraint_metric >= 2.1']  # Optional.
+            experiment:
+                objectives:
+                    result:
+                        minimize: true
+                outcome_constraints: [constraint_metric >= 2.1]  # Optional.
 
-      early_stop:
-        max_epochs_without_improvement: 2
+            early_stop:
+                max_epochs_without_improvement: 2
 
-      params:
-        polynomial.x:
-          type: range
-          bounds: [-1, 1]
+            params:
+                polynomial.x:
+                    type: range
+                    bounds: [-1, 1]

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_dict_coefficients.yaml
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_dict_coefficients.yaml
@@ -1,18 +1,19 @@
+---
 defaults:
-  - override hydra/sweeper: ax
+    - override hydra/sweeper: ax
 
 polynomial:
-  coefficients: ???
+    coefficients: ???
 
 hydra:
-  sweeper:
-    ax_config:
-      max_trials: 10
+    sweeper:
+        ax_config:
+            max_trials: 10
 
-      experiment:
-        objectives:
-          result: 
-            minimize: true
+            experiment:
+                objectives:
+                    result:
+                        minimize: true
 
-      early_stop:
-        max_epochs_without_improvement: 2
+            early_stop:
+                max_epochs_without_improvement: 2

--- a/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_dict_coefficients.yaml
+++ b/plugins/hydra_ax_sweeper/tests/apps/polynomial_with_dict_coefficients.yaml
@@ -10,7 +10,9 @@ hydra:
       max_trials: 10
 
       experiment:
-        minimize: true
+        objectives:
+          result: 
+            minimize: true
 
       early_stop:
         max_epochs_without_improvement: 2

--- a/plugins/hydra_ax_sweeper/tests/config/config.yaml
+++ b/plugins/hydra_ax_sweeper/tests/config/config.yaml
@@ -17,7 +17,9 @@ hydra:
       max_trials: 5
 
       experiment:
-        minimize: true
+        objectives:
+          result: 
+            minimize: true
 
       early_stop:
         max_epochs_without_improvement: 2

--- a/plugins/hydra_ax_sweeper/tests/config/config.yaml
+++ b/plugins/hydra_ax_sweeper/tests/config/config.yaml
@@ -18,7 +18,7 @@ hydra:
 
       experiment:
         objectives:
-          result: 
+          result:
             minimize: true
 
       early_stop:

--- a/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
+++ b/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Any, List
 
 import pytest
-
 from hydra.core.plugins import Plugins
 from hydra.plugins.sweeper import Sweeper
 from hydra.test_utils.test_utils import (
@@ -22,7 +21,12 @@ chdir_plugin_root()
 
 os.environ["HYDRA_FULL_ERROR"] = "1"
 
-filter_ax_internal_warnings = pytest.mark.filterwarnings("ignore::DeprecationWarning", "ignore::FutureWarning", "ignore::RuntimeWarning", "ignore::linear_operator.utils.warnings.NumericalWarning")
+filter_ax_internal_warnings = pytest.mark.filterwarnings(
+    "ignore::DeprecationWarning",
+    "ignore::FutureWarning",
+    "ignore::RuntimeWarning",
+    "ignore::linear_operator.utils.warnings.NumericalWarning",
+)
 
 
 def test_discovery() -> None:
@@ -66,6 +70,7 @@ def test_chunk_method_for_invalid_inputs(n: int) -> None:
     batch = [1, 2, 3, 4, 5]
     with raises(ValueError):
         list(chunk_func(batch, n))
+
 
 @filter_ax_internal_warnings
 def test_jobs_dirs(hydra_sweep_runner: TSweepRunner) -> None:
@@ -149,6 +154,7 @@ def test_jobs_configured_via_cmd(
         assert math.isclose(best_parameters["quadratic.x"], expected_x, abs_tol=1e-4)
         assert math.isclose(best_parameters["quadratic.y"], -2.0, abs_tol=1e-4)
 
+
 @filter_ax_internal_warnings
 def test_jobs_configured_via_cmd_and_config(hydra_sweep_runner: TSweepRunner) -> None:
     sweep = hydra_sweep_runner(
@@ -173,6 +179,7 @@ def test_jobs_configured_via_cmd_and_config(hydra_sweep_runner: TSweepRunner) ->
         best_parameters = returns.ax
         assert math.isclose(best_parameters["quadratic.x"], -2.0, abs_tol=1e-4)
         assert math.isclose(best_parameters["quadratic.y"], 1.0, abs_tol=1e-4)
+
 
 @filter_ax_internal_warnings
 def test_configuration_set_via_cmd_and_default_config(
@@ -200,6 +207,7 @@ def test_configuration_set_via_cmd_and_default_config(
         best_parameters = returns.ax
         assert "quadratic.x" in best_parameters
         assert "quadratic.y" in best_parameters
+
 
 @mark.parametrize(
     "cmd_arg, expected_str",
@@ -231,6 +239,7 @@ def test_ax_logging(tmpdir: Path, cmd_arg: str, expected_str: str) -> None:
     assert "polynomial.x: range=[-5.0, -2.0]" in result
     assert expected_str in result
     assert "polynomial.z: fixed=10" in result
+
 
 @mark.parametrize(
     "cmd_args",
@@ -306,6 +315,7 @@ def test_jobs_using_choice_between_lists(
     assert f"polynomial.coefficients: {serialized_encoding}" in result
     assert f"'polynomial.coefficients': {best_coefficients}" in result
     assert f"New best value: {best_value}" in result
+
 
 @mark.parametrize(
     "cmd_arg, serialized_encoding, best_coefficients, best_value",

--- a/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
+++ b/plugins/hydra_ax_sweeper/tests/test_ax_sweeper_plugin.py
@@ -22,7 +22,7 @@ chdir_plugin_root()
 
 os.environ["HYDRA_FULL_ERROR"] = "1"
 
-filter_ax_internal_warnings = pytest.mark.filterwarnings("ignore::DeprecationWarning", "ignore::FutureWarning", "ignore::RuntimeWarning", "ignore::UserWarning", "ignore::linear_operator.utils.warnings.NumericalWarning")
+filter_ax_internal_warnings = pytest.mark.filterwarnings("ignore::DeprecationWarning", "ignore::FutureWarning", "ignore::RuntimeWarning", "ignore::linear_operator.utils.warnings.NumericalWarning")
 
 
 def test_discovery() -> None:
@@ -201,7 +201,6 @@ def test_configuration_set_via_cmd_and_default_config(
         assert "quadratic.x" in best_parameters
         assert "quadratic.y" in best_parameters
 
-@filter_ax_internal_warnings
 @mark.parametrize(
     "cmd_arg, expected_str",
     [
@@ -233,7 +232,6 @@ def test_ax_logging(tmpdir: Path, cmd_arg: str, expected_str: str) -> None:
     assert expected_str in result
     assert "polynomial.z: fixed=10" in result
 
-@filter_ax_internal_warnings
 @mark.parametrize(
     "cmd_args",
     [
@@ -249,7 +247,7 @@ def test_search_space_exhausted_exception(tmpdir: Path, cmd_args: List[str]) -> 
         "hydra.job.chdir=True",
         "hydra.sweeper.ax_config.max_trials=2",
     ] + cmd_args
-    run_python_script(cmd)
+    run_python_script(cmd, allow_warnings=True)
 
 
 @mark.parametrize(
@@ -326,7 +324,6 @@ def test_jobs_using_choice_between_lists(
         ),
     ],
 )
-@filter_ax_internal_warnings
 def test_jobs_using_choice_between_dicts(
     tmpdir: Path,
     cmd_arg: str,
@@ -347,7 +344,6 @@ def test_jobs_using_choice_between_dicts(
     assert f"New best value: {best_value}" in result
 
 
-@filter_ax_internal_warnings
 def test_example_app(tmpdir: Path) -> None:
     cmd = [
         "example/banana.py",


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Ax Sweeper Plugin is now being supported in python 3.11 and Ax 0.3.4

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Notes

There were multiple warning being raised by internal dependencies of the Ax library, which can only be worked out with one or more updates in that library.

## Related Issues and PRs

#2489 
