### PR TITLE
missing 'and' in docs

### DIFF
--- a/website/docs/advanced/compose_api.md
+++ b/website/docs/advanced/compose_api.md
@@ -34,7 +34,7 @@ There are 3 initialization methods:
 
 All 3 can be used as methods or contexts.
 When used as methods, they are initializing Hydra globally and should only be called once.
-When used as contexts, they are initializing Hydra within the context can be used multiple times.
+When used as contexts, they are initializing Hydra within the context and can be used multiple times.
 Like <b>@hydra.main()</b> all three support the [version_base](../upgrades/version_base.md) parameter
 to define the compatibility level to use.
 


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

I was reading https://hydra.cc/docs/1.1/advanced/compose_api/#initialization-methods and there seemed to be a missing "and" in the flow of the text.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

Docs-only change, only 'testing' needing is a maintainer to check that this is what was intended.

## Related Issues and PRs

I didn't both opening an issue for this as it felt like creating more noise for the maintainers, but if it aids your workflow, I'm happy to create an issue, just let me know.
