### PR TITLE
Synchronize with submitit Slurmexecutor python arg addition

### DIFF
--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
@@ -66,6 +66,8 @@ class SlurmQueueConf(BaseQueueConf):
     # check the following for more info on slurm_max_num_timeout
     # https://github.com/facebookincubator/submitit/blob/main/docs/checkpointing.md
     max_num_timeout: int = 0
+    # Python executable to use instead of the default sys.executable
+    python: Optional[str] = None
     # Useful to add parameters which are not currently available in the plugin.
     # Eg: {"mail-user": "blublu@fb.com", "mail-type": "BEGIN"}
     additional_parameters: Dict[str, Any] = field(default_factory=dict)

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
@@ -95,7 +95,7 @@ class BaseSubmititLauncher(Launcher):
         params = self.params
         # build executor
         init_params = {"folder": self.params["submitit_folder"]}
-        specific_init_keys = {"max_num_timeout"}
+        specific_init_keys = {"max_num_timeout", "python"}
 
         init_params.update(
             **{

--- a/plugins/hydra_submitit_launcher/news/3309.feature
+++ b/plugins/hydra_submitit_launcher/news/3309.feature
@@ -1,0 +1,1 @@
+Add support for selecting the Python executable in the Submitit launcher.

--- a/plugins/hydra_submitit_launcher/setup.py
+++ b/plugins/hydra_submitit_launcher/setup.py
@@ -29,7 +29,7 @@ setup(
     python_requires=">=3.10",
     install_requires=[
         "hydra-core>=1.1.0.dev7",
-        "submitit>=1.3.3",
+        "submitit>=1.4.6",
     ],
     include_package_data=True,
 )

--- a/plugins/hydra_submitit_launcher/tests/test_submitit_launcher.py
+++ b/plugins/hydra_submitit_launcher/tests/test_submitit_launcher.py
@@ -1,7 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from pathlib import Path
-from typing import Type
+from typing import Optional, Type
+from unittest.mock import MagicMock, patch
 
+import submitit
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
 from hydra.test_utils.launcher_common_tests import (
@@ -9,9 +11,12 @@ from hydra.test_utils.launcher_common_tests import (
     LauncherTestSuite,
 )
 from hydra.test_utils.test_utils import chdir_plugin_root, run_python_script
+from hydra.utils import instantiate
+from omegaconf import OmegaConf
 from pytest import mark
 
 from hydra_plugins.hydra_submitit_launcher import submitit_launcher
+from hydra_plugins.hydra_submitit_launcher.config import SlurmQueueConf
 
 chdir_plugin_root()
 
@@ -51,6 +56,42 @@ class TestSubmititLauncher(LauncherTestSuite):
 )
 class TestSubmititLauncherIntegration(IntegrationTestSuite):
     pass
+
+
+@mark.parametrize("python", [None, "/opt/venv/bin/python"])
+def test_slurm_python_parameter(tmp_path: Path, python: Optional[str]) -> None:
+    executor = MagicMock()
+    executor.map_array.return_value = []
+    auto_executor = MagicMock(return_value=executor)
+
+    config = OmegaConf.create(
+        {
+            "hydra": {
+                "job": {"name": "test"},
+                "sweep": {"dir": str(tmp_path / "sweep")},
+                "launcher": OmegaConf.structured(SlurmQueueConf),
+            }
+        }
+    )
+    config.hydra.launcher.python = python
+    launcher = instantiate(
+        config.hydra.launcher,
+        _target_whitelist_=(
+            "hydra_plugins.hydra_submitit_launcher.submitit_launcher.SlurmLauncher"
+        ),
+    )
+    launcher.config = config
+
+    with patch.object(submitit, "AutoExecutor", auto_executor):
+        assert launcher.launch([[]], initial_job_idx=0) == []
+
+    auto_executor.assert_called_once_with(
+        cluster="slurm",
+        folder=str(tmp_path / "sweep" / ".submitit" / "%j"),
+        slurm_max_num_timeout=0,
+        slurm_python=python,
+    )
+    assert "slurm_python" not in executor.update_parameters.call_args.kwargs
 
 
 def test_example(tmpdir: Path) -> None:

--- a/website/docs/plugins/submitit_launcher.md
+++ b/website/docs/plugins/submitit_launcher.md
@@ -59,6 +59,7 @@ The Submitit Plugin implements 2 different launchers: `submitit_slurm` to run on
   account: null
   signal_delay_s: 120
   max_num_timeout: 0
+  python: null
   additional_parameters: {}
   array_parallelism: 256
   setup: null
@@ -88,6 +89,13 @@ You can set all these parameters in your configuration file and/or override them
 ```text
 python foo.py --multirun hydra/launcher=submitit_slurm hydra.launcher.timeout_min=3
 ```
+Set `hydra.launcher.python` to use a Python executable other than the one
+running Hydra:
+
+```text
+python foo.py --multirun hydra/launcher=submitit_slurm hydra.launcher.python=/opt/venv/bin/python
+```
+
 For more details, including descriptions for each parameter, check out the <GithubLink to="plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py">config file</GithubLink>.
 You can also check the [Submitit documentation](https://github.com/facebookincubator/submitit).
 


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Synchronizing with now merged submitit change (https://github.com/facebookincubator/submitit/pull/1729) that allows to pass in a "python" variable to SlurmExecutor.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

This minimal added optional variable works for my setup.

## Related Issues and PRs

The previous PR #2654 does the same, but the PR was closed before it could be merged.
