### PR TITLE
Typo fix in Doc example

### DIFF
--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -270,7 +270,7 @@ assert isinstance(obj_object.foo, Foo)
 assert isinstance(obj_object.bar, dict)
 
 obj_all = instantiate(cfg, _convert_="all")
-assert isinstance(obj_none, MyTarget)
+assert isinstance(obj_all, MyTarget)
 assert isinstance(obj_all.foo, dict)
 assert isinstance(obj_all.bar, dict)
 ```


### PR DESCRIPTION
The example in the documentation had a minor copy-paste error. This PR addresses that typo.

Changed 
`assert isinstance(obj_none, MyTarget)` 
to 
`assert isinstance(obj_all, MyTarget)`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes