### PR TITLE
Fix CI failures

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -14,3 +14,6 @@ ignore_errors = True
 
 [mypy-nevergrad.*]
 ignore_missing_imports = True
+
+[mypy-rq.*]
+ignore_missing_imports = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -11,3 +11,6 @@ ignore_missing_imports = True
 [mypy-hydra.grammar.gen.*]
 ignore_missing_imports = True
 ignore_errors = True
+
+[mypy-nevergrad.*]
+ignore_missing_imports = True

--- a/plugins/hydra_ax_sweeper/setup.py
+++ b/plugins/hydra_ax_sweeper/setup.py
@@ -30,7 +30,7 @@ setup(
         "ax-platform>=0.1.20,<0.2.1",  # https://github.com/facebookresearch/hydra/issues/1767
         "torch",
         "gpytorch<=1.8.1",  # avoid deprecation warnings. This can probably be removed when ax-platform is unpinned.
-        "pandas<1.5.0",  # https://github.com/facebook/Ax/issues/1153, unpin when upgrading ax
+        "pandas<1.5.0",  # https://github.com/facebook/Ax/issues/1153, unpin when upgrading ax to >=0.2.8
     ],
     include_package_data=True,
 )

--- a/plugins/hydra_ax_sweeper/setup.py
+++ b/plugins/hydra_ax_sweeper/setup.py
@@ -30,6 +30,7 @@ setup(
         "ax-platform>=0.1.20,<0.2.1",  # https://github.com/facebookresearch/hydra/issues/1767
         "torch",
         "gpytorch<=1.8.1",  # avoid deprecation warnings. This can probably be removed when ax-platform is unpinned.
+        "pandas<1.5.0",  # https://github.com/facebook/Ax/issues/1153, unpin when upgrading ax
     ],
     include_package_data=True,
 )

--- a/plugins/hydra_ax_sweeper/setup.py
+++ b/plugins/hydra_ax_sweeper/setup.py
@@ -31,6 +31,7 @@ setup(
         "torch",
         "gpytorch<=1.8.1",  # avoid deprecation warnings. This can probably be removed when ax-platform is unpinned.
         "pandas<1.5.0",  # https://github.com/facebook/Ax/issues/1153, unpin when upgrading ax to >=0.2.8
+        "numpy<1.25.0",  # same as above, silences deprecation from np.find_common_type for pandas <1.5
     ],
     include_package_data=True,
 )

--- a/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/_impl.py
+++ b/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/_impl.py
@@ -76,7 +76,7 @@ def create_nevergrad_parameter_from_override(override: Override) -> Any:
         if "log" in val.tags:
             scalar = ng.p.Log(lower=val.start, upper=val.end)
         else:
-            scalar = ng.p.Scalar(lower=val.start, upper=val.end)  # type: ignore
+            scalar = ng.p.Scalar(lower=val.start, upper=val.end)
         if isinstance(val.start, int):
             scalar.set_integer_casting()
         return scalar

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -29,6 +29,7 @@ setup(
     install_requires=[
         "hydra-core>=1.1.0.dev7",
         "optuna>=2.10.0,<3.0.0",
+        "sqlalchemy~=1.3.0",  # TODO: Unpin when upgrading to optuna v3.0
     ],
     include_package_data=True,
 )

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_config.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_config.py
@@ -3,11 +3,11 @@ import sys
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum
 from importlib import import_module
+from importlib.metadata import version
 from typing import Any, Dict, List, Optional
 
 from hydra.core.config_store import ConfigStore
 from omegaconf import OmegaConf
-from pkg_resources import get_distribution
 
 
 @dataclass
@@ -178,11 +178,11 @@ def _pip_pkgs_default_factory() -> Dict[str, str]:
         "hydra_core": "${ray_pkg_version:hydra}",
         "ray": "${ray_pkg_version:ray}",
         "cloudpickle": "${ray_pkg_version:cloudpickle}",
-        "hydra_ray_launcher": get_distribution("hydra_ray_launcher").version,
+        "hydra_ray_launcher": version("hydra_ray_launcher"),
     }
 
     if sys.version_info < (3, 8):
-        d["pickle5"] = get_distribution("pickle5").version
+        d["pickle5"] = version("pickle5")
 
     return d
 

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core.py
@@ -32,6 +32,8 @@ def launch(
         f"sweep output dir: {sweep_dir}"
     )
 
+    # Avoid allocating too little memory in CI https://github.com/ray-project/ray/issues/11966#issuecomment-1318100747
+    launcher.ray_cfg.init.setdefault("object_store_memory", 78643200)
     start_ray(launcher.ray_cfg.init)
 
     runs = []

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
@@ -130,7 +130,7 @@ def launch(
             sweep_config=sweep_config,
             task_function=launcher.task_function,
             singleton_state=singleton_state,
-            **enqueue_keywords,  # type: ignore
+            **enqueue_keywords,
         )
         jobs.append(job)
 

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
@@ -19,7 +19,7 @@ from hydra.core.utils import (
 from hydra.types import HydraContext, TaskFunction
 from omegaconf import DictConfig, OmegaConf, open_dict
 from redis import Redis
-from rq import Queue  # type: ignore
+from rq import Queue
 
 from .rq_launcher import RQLauncher
 
@@ -130,7 +130,7 @@ def launch(
             sweep_config=sweep_config,
             task_function=launcher.task_function,
             singleton_state=singleton_state,
-            **enqueue_keywords,
+            **enqueue_keywords,  # type: ignore
         )
         jobs.append(job)
 

--- a/plugins/hydra_rq_launcher/setup.py
+++ b/plugins/hydra_rq_launcher/setup.py
@@ -29,7 +29,7 @@ setup(
         "cloudpickle",
         "fakeredis<1.7.4",  # https://github.com/dsoftwareinc/fakeredis-py/issues/3
         "hydra-core>=1.1.0.dev7",
-        "rq>=1.5.1",
+        "rq>=1.5.1,<1.12",
     ],
     include_package_data=True,
 )

--- a/plugins/hydra_submitit_launcher/tests/test_submitit_launcher.py
+++ b/plugins/hydra_submitit_launcher/tests/test_submitit_launcher.py
@@ -58,5 +58,6 @@ def test_example(tmpdir: Path) -> None:
             "-m",
             f"hydra.sweep.dir={tmpdir}",
             "hydra/launcher=submitit_local",
-        ]
+        ],
+        allow_warnings=True,
     )

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,3 +16,5 @@ filterwarnings =
   ignore:.*Future Hydra versions will no longer change working directory at job runtime by default.*:UserWarning
   ; Jupyter notebook test on Windows yield warnings
   ignore:.*Proactor event loop does not implement add_reader family of methods required for zmq.*:RuntimeWarning
+  ; Ignore deprecation warning related to pkg_resources
+  ignore:.*pkg_resources is deprecated*

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,6 +5,7 @@ build
 coverage
 flake8<6  # pinned due to https://github.com/savoirfairelinux/flake8-copyright/issues/19
 flake8-copyright
+importlib-metadata<5.0; python_version <= '3.7'
 isort==5.5.2
 mypy
 nox


### PR DESCRIPTION
## Motivation
Fixing CI issues described in #2841.

### CI failures fixed by this PR
- [x] lint-3.7
  - Pinned `importlib-metadata<5.0` for Python <= 3.7 in `requirements/dev.txt`
- [x] lint_plugins-3.8(hydra-nevergrad-sweeper)
  -  Remove `# type: ignore` comments in `plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/_impl.py`
  - Ignore `nevergrad` module in `.mypy.ini`
- [x]  lint_plugins-3.8(hydra-rq-launcher)
  -  Add / remove `# type: ignore` comments in `plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py`
  - Ignore `rq` module in `.mypy.ini`
- [x] test_plugins-3.8(hydra-ax-sweeper)
  - Pinned `pandas<1.5.0` in `plugins/hydra_ax_sweeper/setup.py`. This dependency should be unpinned when upgrading ax to `>=0.2.8`.
- [x] test_plugins-3.8(hydra-optuna-sweeper)
  - Pinned `sqlalchemy~=1.3.0` in `plugins/hydra_optuna_sweeper/setup.py`. This dependency should be unpinned in #2360 when upgrading `optuna` to `>=3.0`.
    
    Alternatively, we could go for a more permissive version range `sqlalchemy>=1.3.0,<2.0.0`, but that would require adding `ignore:` statement for warnings produced by `sqlalchemy` to `pytest.ini`
- [x] test_plugins-3.8(hydra-rq-launcher)
  - Pinned `rq>=1.5.1,<1.12` in `plugins/hydra_rq_launcher/setup.py`. This is the highest version for which the tests pass, `<1.13` leads to failures.
- [x] test_plugins-3.8(hydra-submitit-launcher)
  - Set `allow_warnings=True` in `test_example` in `plugins/hydra_submitit_launcher/tests/test_submitit_launcher.py`
  - Add line `ignore:.*pkg_resources is deprecated*` in `pytest.ini`. DeprecationWarning comes from other package (`submitit`), so we have no way to fix them on the `hydra` side.
- [x] test_plugins_vs_core-3.8
  - Use `importlib.metadata.version` instead of `pkg_resources.get_distribution` in `plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_config.py`.


### Errors that I was unable to fix
- [ ] test_plugins-3.8(hydra-ray-launcher), test_plugins-3.9(hydra-ray-launcher)
  - Setting default `object_store_memory` to `78643200`, as recommended in https://github.com/ray-project/ray/issues/11966#issuecomment-1318100747, did not help. 
  
  Possible solutions:
    - Using instances with more memory ([as recommended here](https://github.com/ray-project/ray/issues/11966#issuecomment-1318100747)). This is most likely the problem, seeing how ray tests pass on macos and windows.
    - Upgrading to ray 2.0 ([as recommended here](https://github.com/ray-project/ray/issues/11966#issuecomment-1286421012))

- [ ] lint_plugins-3.7(hydra-nevergrad-sweeper), lint_plugins-3.7(hydra-ray-launcher), test_plugins-3.7(hydra-ray-launcher), test_plugins_vs_core-3.7
  - Not prioritizing these issues since Python 3.7 support will be dropped.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

This PR does not introduce any new functionality, so no new tests are needed. Only existing tests will be fixed.

## Related Issues and PRs

This PR resolves #2841