### PR TITLE
Adding the argument `target_wrapper` to `hydra.utils.instantiate` to support recursive type checking

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -4,7 +4,7 @@ import copy
 import functools
 from enum import Enum
 from textwrap import dedent
-from typing import Any, Callable, Dict, List, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from omegaconf import OmegaConf, SCMode
 from omegaconf._utils import is_structured_config

--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -145,7 +145,7 @@ def _resolve_target(
     return target
 
 
-def instantiate(config: Any, target_wrapper: Optional[Callable[..., Any]], *args: Any, **kwargs: Any) -> Any:
+def instantiate(config: Any, *args: Any, target_wrapper: Optional[Callable[..., Any]] = None, **kwargs: Any) -> Any:
     """
     :param config: An config object describing what to call and what params to use.
                    In addition to the parameters, the config must contain:

--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -282,7 +282,7 @@ def instantiate_node(
     convert: Union[str, ConvertMode] = ConvertMode.NONE,
     recursive: bool = True,
     partial: bool = False,
-    target_wrapper: Optional[Callable[..., Any]]
+    target_wrapper: Optional[Callable[..., Any]] = None,
 ) -> Any:
     # Return None if config is None
     if node is None or (OmegaConf.is_config(node) and node._is_none()):

--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -145,7 +145,12 @@ def _resolve_target(
     return target
 
 
-def instantiate(config: Any, *args: Any, target_wrapper: Optional[Callable[..., Any]] = None, **kwargs: Any) -> Any:
+def instantiate(
+    config: Any,
+    *args: Any,
+    target_wrapper: Optional[Callable[..., Any]] = None,
+    **kwargs: Any,
+) -> Any:
     """
     :param config: An config object describing what to call and what params to use.
                    In addition to the parameters, the config must contain:
@@ -225,7 +230,12 @@ def instantiate(config: Any, *args: Any, target_wrapper: Optional[Callable[..., 
         _partial_ = config.pop(_Keys.PARTIAL, False)
 
         return instantiate_node(
-            config, *args, recursive=_recursive_, convert=_convert_, partial=_partial_, target_wrapper=target_wrapper,
+            config,
+            *args,
+            recursive=_recursive_,
+            convert=_convert_,
+            partial=_partial_,
+            target_wrapper=target_wrapper,
         )
     elif OmegaConf.is_list(config):
         # Finalize config (convert targets to strings, merge with kwargs)
@@ -248,7 +258,12 @@ def instantiate(config: Any, *args: Any, target_wrapper: Optional[Callable[..., 
             )
 
         return instantiate_node(
-            config, *args, recursive=_recursive_, convert=_convert_, partial=_partial_, target_wrapper=target_wrapper,
+            config,
+            *args,
+            recursive=_recursive_,
+            convert=_convert_,
+            partial=_partial_,
+            target_wrapper=target_wrapper,
         )
     else:
         raise InstantiationException(
@@ -316,7 +331,12 @@ def instantiate_node(
     # If OmegaConf list, create new list of instances if recursive
     if OmegaConf.is_list(node):
         items = [
-            instantiate_node(item, convert=convert, recursive=recursive, target_wrapper=target_wrapper)
+            instantiate_node(
+                item,
+                convert=convert,
+                recursive=recursive,
+                target_wrapper=target_wrapper,
+            )
             for item in node._iter_ex(resolve=True)
         ]
 
@@ -335,7 +355,7 @@ def instantiate_node(
             _target_ = _resolve_target(node.get(_Keys.TARGET), full_key)
             if target_wrapper:
                 _target_ = target_wrapper(_target_)
-            
+
             kwargs = {}
             is_partial = node.get("_partial_", False) or partial
             for key in node.keys():
@@ -345,7 +365,10 @@ def instantiate_node(
                     value = node[key]
                     if recursive:
                         value = instantiate_node(
-                            value, convert=convert, recursive=recursive, target_wrapper=target_wrapper,
+                            value,
+                            convert=convert,
+                            recursive=recursive,
+                            target_wrapper=target_wrapper,
                         )
                     kwargs[key] = _convert_node(value, convert)
 


### PR DESCRIPTION
## Motivation

[beartype](https://github.com/beartype/beartype) and other libraries offer runtime typechecking with function and class decorators, like so:

```python
from beartype import beartype
from dataclasses import dataclass

@beartype
@dataclass
class ExampleDataclass:
    name: str
    unit_price: float
    quantity_on_hand: int = 0

inst = ExampleDataclass("a name", 123.32, 23)
# Is ok

inst = ExampleDataclass(123, None, 23)
# Breaks

```

In this PR, we suggest adding an argument to `hydra.utils.instantiate` that is called `target_wrapper`, that receives a callable as an argument. The idea is that callable is then called on `_target_` before it itself is called. This allows to decorate all of a configuration's `_target_`s all at once. (It's possible that the argument should be called `target_decorator`)

One of the ways this can be used is with something like `beartype`, where runtime type-checking to the portion of the code being instantiated with `_target_` where annotations are present, with a single line of non-invasive code, which would be  really incredibly helpful for us.

It would look like this:

```python
hydra.utils.instantiate(cfg, target_wrapper=beartype.beartype)
```

See the `test` example lower in the post for a more full example.

One could imagine other types of wrappers that people could want to do, for profiling for example, where folks could wrap every class type with a profiler before the instantiation happens.

One could also add recursive support for `OmegaConf.structured` with the following, which is very cool:

```python
import dataclasses
import attrs
from omegaconf import OmegaConf


def apply_structured(_target_):
    if dataclasses.is_dataclass(_target_) or attrs.has(_target_):
        def factory(*args, **kwargs):
            return OmegaConf.structured(_target_(*args, **kwargs))
   
    return _target_
```

and then 

```python
hydra.utils.instantiate(cfg, target_wrapper=apply_structured)
```


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

Here is a standalone test with `beartype`:

```python
from pathlib import Path
import builtins
import beartype
import dataclasses
import hydra
import tempfile

CHECKER = beartype.beartype

@dataclasses.dataclass
class DataclassExample:
    argument_integer_example: int


config_example_good = """
_target_: test.DataclassExample
argument_integer_example: 123
"""
config_name_good = "config_name_good"


config_example_error = """
_target_: test.DataclassExample
argument_integer_example: 123aa
"""
config_name_error = "config_name_bad"


def doer(config_name, file_content, should_fail):
    with tempfile.TemporaryDirectory() as temp_dir:
        config_path_good = Path(temp_dir) / f"{config_name}.yaml"
        config_path_good.write_text(file_content)
    
        with hydra.initialize_config_dir(version_base=None, config_dir=temp_dir):
            cfg = hydra.compose(config_name=config_name)

            try:
                instantiated = hydra.utils.instantiate(
                    cfg, 
                    target_wrapper=CHECKER,
                )
                print(instantiated)
                if should_fail:
                    raise RuntimeError(f"`{config_name}` was supposed to fail but didn't: {e}")

            except hydra.errors.InstantiationException as e:
                raise RuntimeError(f"`{config_name}` was not supposed to fail: {e}")


def test_compatible_config():
    doer(config_name_good, config_example_good, should_fail=False)
        

def test_incompatible_config():
    doer(config_name_error, config_example_error, should_fail=True)


if __name__ == "__main__":
    test_compatible_config()
    test_incompatible_config()
```

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
