### PR TITLE
link to omegaconf custom resolvers to fix 2839

### DIFF
--- a/website/docs/configure_hydra/Intro.md
+++ b/website/docs/configure_hydra/Intro.md
@@ -154,4 +154,6 @@ minor:   ${python_version:minor}     # 3.8
 micro:   ${python_version:micro}     # 3.8.2
 ```
 
+Additionally hydra supports OmegaConf <a class="external" href="https://omegaconf.readthedocs.io/en/latest/custom_resolvers.html#custom-resolvers" target="_blank">custom resolvers</a>
+
 You can learn more about OmegaConf <a class="external" href="https://omegaconf.readthedocs.io/en/latest/usage.html#access-and-manipulation" target="_blank">here</a>.


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Aside from the resolvers provided by hydra, there is the possibility to include custom resolvers, which adds a lot of flexibility to hydra.
This is motivated by Issue 2839 which asks whether is possible to include the SHA of the git revision in the name of the ouput dir, a good practice to link the experiment artifacts with the commit that produced them. This can be trivially done by adding a custom omegaconf resolver.

The possibility of using custom resolvers was not documented.
This PR adds a link in the doc pointing to the possibility of using custom resolvers.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

N/A

## Related Issues and PRs

Related to issue 2839