### PR TITLE
Feature/scope

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -324,7 +324,7 @@ def instantiate_node(
     # If OmegaConf list, create new list of instances if recursive
     if OmegaConf.is_list(node):
         items = [
-            instantiate_node(item, convert=convert, recursive=recursive)
+            instantiate_node(item, convert=convert, recursive=recursive, scope=scope)
             for item in node._iter_ex(resolve=True)
         ]
 
@@ -384,7 +384,7 @@ def instantiate_node(
                 for key, value in node.items():
                     # list items inherits recursive flag from the containing dict.
                     dict_items[key] = instantiate_node(
-                        value, convert=convert, recursive=recursive
+                        value, convert=convert, recursive=recursive, scope=scope
                     )
                 return dict_items
             else:
@@ -392,7 +392,7 @@ def instantiate_node(
                 cfg = OmegaConf.create({}, flags={"allow_objects": True})
                 for key, value in node.items():
                     cfg[key] = instantiate_node(
-                        value, convert=convert, recursive=recursive
+                        value, convert=convert, recursive=recursive, scope=scope
                     )
                 cfg._set_parent(node)
                 cfg._metadata.object_type = node._metadata.object_type

--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -354,8 +354,8 @@ def instantiate_node(
 
         if _is_target(node):
             _target_ = node.get(_Keys.TARGET)
-            if scope is not None:
-                _target_ = ".".join([scope, _target_])
+            if scope is not None and _target_.startswith("."):
+                _target_ = f"{scope}{_target_}"
 
             _target_ = _resolve_target(_target_, full_key)
 


### PR DESCRIPTION
`_scope_` keyword be added to specify a common root module for a dictionary and its sub-dictionaries.

## Motivation

This feature can reduce repetition in the configuration files and codes. On the other hand, it could also isolate users and developers by treating _target_ as a configuration item.

Currently, I have to write a data class configuration for every class I use. If this feature is added, I could implement a similar function simply through a decorator that checks input types based on the _init_ function signature.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

I have not yet added tests for this code because these changes are just for the demonstration implementation I envisioned. 
However, I did create a small, simple demo that runs correctly, as shown below:

main.py
``` python
import hydra
from omegaconf import DictConfig, OmegaConf
from hydra.utils import instantiate


class A:
    def __init__(self, a1=1, a2="a2"):
        self.a1 = a1
        self.a2 = a2

    def __str__(self):
        return f"A: {self.a1}, {self.a2}"


class B:
    def __init__(self, b1=1, b2="b2"):
        self.b1 = b1
        self.b2 = b2

    def __str__(self):
        return f"B: {self.b1}, {self.b2}"
    
class C:
    def __init__(self, a: A, b: B):
        self.a = a
        self.b = b

    def __str__(self):
        return f"C: {self.a}, {self.b}"
    

@hydra.main(config_path="conf", config_name="config")
def main(cfg):
    c = instantiate(cfg.c)
    print(c)
    print(OmegaConf.to_yaml(cfg))


if __name__ == "__main__":
    main()
```

config.yaml
``` yaml
c:
  _scope_: "__main__"
  _target_: ".C"
  a:
    _target_: ".A"
    a1: 10
  b:
    _target_: ".B"
    b1: 100
```

Output
```
C: A: 10, a2, B: 100, b2
c:
  _scope_: __main__
  _target_: .C
  a:
    _target_: .A
    a1: 10
  b:
    _target_: .B
    b1: 100
```

## Related Issues and PRs

Issue: #2883 
Discussion: #2882 
