### PR TITLE
feat: raise UnsupportedExtensionException when loading .yml files

### DIFF
--- a/hydra/errors.py
+++ b/hydra/errors.py
@@ -37,3 +37,6 @@ class MissingConfigException(IOError, ConfigCompositionException):
 
 
 class HydraDeprecationError(HydraException): ...
+
+
+class UnsupportedExtensionException(HydraException): ...

--- a/hydra/errors.py
+++ b/hydra/errors.py
@@ -37,6 +37,3 @@ class MissingConfigException(IOError, ConfigCompositionException):
 
 
 class HydraDeprecationError(HydraException): ...
-
-
-class UnsupportedExtensionException(HydraException): ...

--- a/hydra/plugins/config_source.py
+++ b/hydra/plugins/config_source.py
@@ -10,7 +10,7 @@ from hydra import version
 from hydra._internal.deprecation_warning import deprecation_warning
 from hydra.core.default_element import InputDefault
 from hydra.core.object_type import ObjectType
-from hydra.errors import HydraException
+from hydra.errors import HydraException, UnsupportedExtensionException
 from hydra.plugins.plugin import Plugin
 
 
@@ -116,7 +116,12 @@ class ConfigSource(Plugin):
     @staticmethod
     def _normalize_file_name(filename: str) -> str:
         supported_extensions = [".yaml"]
-        if not version.base_at_least("1.2"):
+        if version.base_at_least("1.2"):
+            if filename.endswith(".yml"):
+                raise UnsupportedExtensionException(
+                    ".yml files are not supported. Use .yaml extension for Hydra config files."
+                )
+        else:
             supported_extensions.append(".yml")
             if filename.endswith(".yml"):
                 deprecation_warning(

--- a/hydra/plugins/config_source.py
+++ b/hydra/plugins/config_source.py
@@ -10,7 +10,7 @@ from hydra import version
 from hydra._internal.deprecation_warning import deprecation_warning
 from hydra.core.default_element import InputDefault
 from hydra.core.object_type import ObjectType
-from hydra.errors import HydraException, UnsupportedExtensionException
+from hydra.errors import HydraException
 from hydra.plugins.plugin import Plugin
 
 
@@ -118,8 +118,9 @@ class ConfigSource(Plugin):
         supported_extensions = [".yaml"]
         if version.base_at_least("1.2"):
             if filename.endswith(".yml"):
-                raise UnsupportedExtensionException(
-                    ".yml files are not supported. Use .yaml extension for Hydra config files."
+                raise ConfigLoadError(
+                    "Unsupported config file extension '.yml'. "
+                    "Hydra config files must use the '.yaml' extension."
                 )
         else:
             supported_extensions.append(".yml")

--- a/news/2889.bugfix
+++ b/news/2889.bugfix
@@ -1,0 +1,1 @@
+Report unsupported `.yml` config files with a clear error.

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -18,6 +18,7 @@ from hydra.errors import (
     ConfigCompositionException,
     HydraException,
     MissingConfigException,
+    UnsupportedExtensionException,
 )
 from hydra.test_utils.test_utils import chdir_hydra_root
 from hydra.types import RunMode
@@ -191,6 +192,12 @@ class TestConfigLoader:
         config_loader = ConfigLoaderImpl(
             config_search_path=create_config_search_path(path)
         )
+        with raises(UnsupportedExtensionException):
+            cfg = config_loader.load_configuration(
+                config_name="config.yml",
+                overrides=[],
+                run_mode=RunMode.RUN,
+            )
         version.setbase("1.1")
         with warns(
             UserWarning,

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -18,8 +18,8 @@ from hydra.errors import (
     ConfigCompositionException,
     HydraException,
     MissingConfigException,
-    UnsupportedExtensionException,
 )
+from hydra.plugins.config_source import ConfigLoadError
 from hydra.test_utils.test_utils import chdir_hydra_root
 from hydra.types import RunMode
 from tests.instantiate import UserGroup
@@ -192,8 +192,15 @@ class TestConfigLoader:
         config_loader = ConfigLoaderImpl(
             config_search_path=create_config_search_path(path)
         )
-        with raises(UnsupportedExtensionException):
-            cfg = config_loader.load_configuration(
+        version.setbase("1.2")
+        with raises(
+            ConfigLoadError,
+            match=re.escape(
+                "Unsupported config file extension '.yml'. "
+                "Hydra config files must use the '.yaml' extension."
+            ),
+        ):
+            config_loader.load_configuration(
                 config_name="config.yml",
                 overrides=[],
                 run_mode=RunMode.RUN,


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

When trying to open a config with the unsupported extension .yml a misleading MissingConfigException is returned.
For details see #2889 
The proposed change raises a UnsupportedExtensionException with a helpful error message.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

The test `test_load_yml_file` has been adapted to check that the exception is raised correctly.

## Related Issues and PRs
#2889 
