### PR TITLE
convert circleci jobs to github actions

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -1,0 +1,21 @@
+name: setup-linux
+description: Setup Miniconda and Java on linux
+inputs:
+  py_version:
+    description: 'Python version'
+    required: false
+runs:
+  using: composite
+  steps:
+  - uses: "./.github/actions/setup-miniconda"
+    with:
+      py_version: "${{ matrix.py_version }}"
+  - uses: actions/setup-java@v4
+    with:
+      distribution: 'microsoft'
+      java-version: '11'
+  - name: Preparing environment - Other dependency
+    shell: bash
+    run: |-
+      sudo apt-get update
+      sudo apt-get install -y expect fish zsh

--- a/.github/actions/setup-macos/action.yml
+++ b/.github/actions/setup-macos/action.yml
@@ -1,0 +1,36 @@
+name: setup-macos
+description: Setup macOS environment
+inputs:
+  py_version:
+    description: 'Python version'
+    required: false
+runs:
+  using: composite
+  steps:
+    - uses: maxim-lobanov/setup-xcode@v1.6.0
+      with:
+        xcode-version: 13.4.1
+    - name: Homebrew cache
+      uses: actions/cache@v4.0.2
+      with:
+        key: "v1-macos-sys-${{ github.head_ref }}"
+        path: ~/Library/Caches/Homebrew
+    - uses: "./.github/actions/setup-miniconda"
+      with:
+        py_version: "${{ matrix.py_version }}"
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'microsoft'
+        java-version: '11'
+    - name: Preparing environment - Brew
+      shell: bash
+      run: |-
+        brew update
+        brew upgrade git
+        brew install fish
+        brew install zsh
+        brew cleanup
+    - name: Preparing environment - Hydra
+      shell: bash -el {0}
+      run: |-
+        conda run -n hydra pip install nox --progress-bar off

--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -1,0 +1,27 @@
+name: setup-miniconda
+description: 'Setup Miniconda'
+inputs:
+  py_version:
+    description: 'Python version'
+    required: true
+runs:
+  using: composite
+  steps:
+    # use my fork of the conda-incubator/setup-miniconda@v3 action
+    # until this PR is merged: https://github.com/conda-incubator/setup-miniconda/pull/350
+    - uses: robandpdx-org/setup-miniconda@fix-conda-env-var
+      with:
+        activate-environment: hydra
+        python-version: ${{ inputs.py_version }}
+    - name: Get Date
+      shell: bash
+      id: get-date
+      run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
+    - name: Cache conda
+      uses: actions/cache@v3
+      env:
+        CACHE_NUMBER: 1
+      with:
+        path: ${{ env.CONDA }}/envs
+        key:
+          v${{ env.CACHE_NUMBER }}-conda-${{ runner.os }}-${{ runner.arch }}-${{ steps.get-date.outputs.today }}

--- a/.github/actions/setup-windows/action.yml
+++ b/.github/actions/setup-windows/action.yml
@@ -1,0 +1,20 @@
+name: setup-windows
+description: Setup windows environment
+inputs:
+  py_version:
+    description: 'Python version'
+    required: false
+runs:
+  using: composite
+  steps:
+    - uses: "./.github/actions/setup-miniconda"
+      with:
+        py_version: "${{ matrix.py_version }}"
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'microsoft'
+        java-version: '11'
+    - name: Preparing environment - Hydra
+      shell: bash -el {0}
+      run: |-
+        pip install nox dataclasses --progress-bar off

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,194 @@
+name: facebookresearch/hydra/tests
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  test_macos:
+    runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        py_version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: "./.github/actions/setup-macos"
+      with:
+        py_version: "${{ matrix.py_version }}"
+    - name: Testing Hydra
+      run: |-
+        export NOX_PYTHON_VERSIONS=${{ matrix.py_version }}
+        pip install nox dataclasses --progress-bar off
+        if [ -n "${{ github.event.number }}" ]; then
+          nox -s lint test_tools test_core \
+            test_jupyter_notebooks lint_plugins test_plugins test_plugins_vs_core -ts
+        else
+          nox -s lint test_tools test_core test_jupyter_notebooks -ts
+        fi
+  test_linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        py_version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: "./.github/actions/setup-linux"
+      with:
+        py_version: "${{ matrix.py_version }}"
+    - name: Testing Hydra
+      run: |-
+        export NOX_PYTHON_VERSIONS=${{ matrix.py_version }}
+        pip install nox dataclasses --progress-bar off
+        if [ -n "${{ github.event.number }}" ]; then
+          nox -s lint test_tools test_core \
+            test_jupyter_notebooks lint_plugins test_plugins test_plugins_vs_core -ts
+        else
+          nox -s lint test_tools test_core test_jupyter_notebooks -ts
+        fi
+  test_win:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        py_version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+    steps:
+    - uses: actions/checkout@v4
+    - uses: "./.github/actions/setup-windows"
+      with:
+        py_version: "${{ matrix.py_version }}"
+    - name: Testing Hydra
+      run: |-
+        $env:NOX_PYTHON_VERSIONS="${{ matrix.py_version }}"
+        $env:ConEmuDefaultCp=65001
+        $env:PYTHONIOENCODING="utf_8"
+        conda activate hydra
+        If ($env:${{ github.event.number }}) {
+          nox -s lint test_tools test_core test_jupyter_notebooks lint_plugins test_plugins test_plugins_vs_core -ts
+        } else {
+          nox -s lint test_tools test_core test_jupyter_notebooks -ts
+        }
+        exit $LASTEXITCODE
+  ## plugin tests
+  test_plugin_linux:
+    # True if PR is not from a fork
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        py_version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+        plugin:
+          - hydra_joblib_launcher
+          - hydra_optuna_sweeper
+          - hydra_ax_sweeper
+          - hydra_submitit_launcher
+          - hydra_nevergrad_sweeper
+          - hydra_rq_launcher
+          - hydra_ray_launcher
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: "./.github/actions/setup-linux"
+      with:
+        py_version: "${{ matrix.py_version }}"
+    - name: "${{ matrix.plugin }}"
+      run: |-
+        export PATH="$HOME/miniconda3/envs/hydra/bin:$PATH"
+        export NOX_PYTHON_VERSIONS=${{ matrix.py_version }}
+        export PLUGINS=${{ matrix.plugin }}
+        pip install nox dataclasses --progress-bar off
+        nox -s lint_plugins test_plugins test_plugins_vs_core -ts
+  test_plugin_macos:
+    # True if PR is not from a fork
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        py_version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+        plugin:
+          - hydra_joblib_launcher
+          - hydra_optuna_sweeper
+          - hydra_ax_sweeper
+          - hydra_submitit_launcher
+          - hydra_nevergrad_sweeper
+          - hydra_rq_launcher
+          - hydra_ray_launcher
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/setup-macos"
+      with:
+        py_version: "${{ matrix.py_version }}"
+    - name: "${{ matrix.plugin }}"
+      run: |-
+        export NOX_PYTHON_VERSIONS=${{ matrix.py_version }}
+        export PLUGINS=${{ matrix.plugin }}
+        conda activate hydra
+        pip install nox dataclasses --progress-bar off
+        nox -s lint_plugins test_plugins test_plugins_vs_core -ts
+  test_plugin_win:
+    # True if PR is not from a fork
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        py_version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+        test_plugin:
+          - hydra_joblib_launcher
+          - hydra_optuna_sweeper
+          - hydra_ax_sweeper
+          - hydra_submitit_launcher
+          - hydra_nevergrad_sweeper
+          - hydra_rq_launcher
+          - hydra_ray_launcher
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: "./.github/actions/setup-windows"
+      with:
+        py_version: "${{ matrix.py_version }}"
+    - name: "${{ matrix.plugin }}"
+      run: |-
+        $env:NOX_PYTHON_VERSIONS="${{ matrix.py_version }}"
+        $env:ConEmuDefaultCp=65001
+        $env:PYTHONIOENCODING="utf_8"
+        $env:PLUGINS="${{ matrix.plugin }}"
+        conda activate hydra
+        nox -s lint_plugins test_plugins test_plugins_vs_core -ts
+        exit $LASTEXITCODE


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

This pull request converts the CircleCI workflows to GitHub actions workflows.  

## Notes
I chose the use the `microsoft` version of openjdk. See [supported distributions](https://github.com/actions/setup-java?tab=readme-ov-file#supported-distributions) for other options.  

Ubuntu 18.04 reached EOL May 2023. I have removed this job that tests on this OS version from the workflow.  

It may be desireable to set `fail-fast: true` in order to save $ on runners when jobs fail. I set this to true in order to see the results of all jobs.  

There is currently a defect in the `conda-incubator/setup-miniconda` action, I believe. The `CONDA` environment variable is not set in the environment in all conditions. I have created [an issue in the repo](https://github.com/conda-incubator/setup-miniconda/issues/349) for this. My [PR here](https://github.com/conda-incubator/setup-miniconda/pull/350) solves the issue and is awaiting approval and merge. Once that is merged, change the `.github/actions/setup-miniconda/action.yml` file to use the official version of the action rather than my fork/branch.  

## Errors
I did my best to make all the jobs work, but lacking knowledge specific to this project makes it nearly impossible for me to get everything working. Someone with better knowledge of this project will need to address the errors.  

The `test_macos`, `test_linux`, `test_win`, and `test_plugin_win` jobs fail with an error. The best way to view the errors is by viewing the latest workflow run in my fork. [Here is the latest workflow run in my fork](https://github.com/robandpdx-org/hydra/actions/runs/8928933597).  

---
https://fburl.com/workplace/f6mz6tmw  


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

Tested in fork. 
