### PR TITLE
Fix CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ commands:
             if [[ -f ~/miniconda3/LICENSE.txt ]] ; then
               echo "miniconda installed already."
             else
-              curl -o Miniconda3-py38_4.8.3-MacOSX-x86_64.sh https://repo.anaconda.com/miniconda/Miniconda3-py38_4.8.3-MacOSX-x86_64.sh
-              bash ./Miniconda3-py38_4.8.3-MacOSX-x86_64.sh -b
+              curl -o Miniconda3-py39_24.5.0-0-MacOSX-arm64.sh https://repo.anaconda.com/miniconda/Miniconda3-py39_24.5.0-0-MacOSX-arm64.sh
+              bash ./Miniconda3-py39_24.5.0-0-MacOSX-arm64.sh -b
             fi
             ~/miniconda3/bin/conda init bash
       - run:

--- a/plugins/hydra_ray_launcher/integration_test_tools/create_integration_test_ami.py
+++ b/plugins/hydra_ray_launcher/integration_test_tools/create_integration_test_ami.py
@@ -24,7 +24,13 @@ from omegaconf import DictConfig, OmegaConf
 
 def _run_command(command: str) -> str:
     print(f"{str(datetime.now())} - Running: {command}")
-    output = subprocess.getoutput(command)
+    # Do some basic validation to avoid injection but it is not exhaustive,
+    # there is still a security risk here!
+    if ";" in command or "||" in command or "&&" in command or ">" in command:
+        raise ValueError(
+            "To avoid possible injection, command cannot contain ; || or &&"
+        )
+    output = subprocess.getoutput(command)  # nosec B605
     print(f"{str(datetime.now())} - {output}")
     return output
 

--- a/plugins/hydra_ray_launcher/integration_test_tools/create_integration_test_ami.py
+++ b/plugins/hydra_ray_launcher/integration_test_tools/create_integration_test_ami.py
@@ -24,12 +24,6 @@ from omegaconf import DictConfig, OmegaConf
 
 def _run_command(command: str) -> str:
     print(f"{str(datetime.now())} - Running: {command}")
-    # Do some basic validation to avoid injection but it is not exhaustive,
-    # there is still a security risk here!
-    if ";" in command or "||" in command or "&&" in command or ">" in command:
-        raise ValueError(
-            "To avoid possible injection, command cannot contain ; || or &&"
-        )
     output = subprocess.getoutput(command)  # nosec B605
     print(f"{str(datetime.now())} - {output}")
     return output

--- a/plugins/hydra_ray_launcher/integration_test_tools/setup_integration_test_ami.py
+++ b/plugins/hydra_ray_launcher/integration_test_tools/setup_integration_test_ami.py
@@ -16,7 +16,13 @@ dependencies = [
 
 def _run_command(command: str) -> str:
     print(f"{str( datetime.now() )} - OUT: {command}")
-    output = subprocess.getoutput(command)
+    # Do some basic validation to avoid injection but it is not exhaustive,
+    # there is still a security risk here!
+    if ";" in command or "||" in command or "&&" in command or ">" in command:
+        raise ValueError(
+            "To avoid possible injection, command cannot contain ; || or &&"
+        )
+    output = subprocess.getoutput(command)  # nosec B605
     print(f"{str( datetime.now() )} - OUT: {output}")
     return output
 

--- a/plugins/hydra_ray_launcher/integration_test_tools/setup_integration_test_ami.py
+++ b/plugins/hydra_ray_launcher/integration_test_tools/setup_integration_test_ami.py
@@ -16,12 +16,6 @@ dependencies = [
 
 def _run_command(command: str) -> str:
     print(f"{str( datetime.now() )} - OUT: {command}")
-    # Do some basic validation to avoid injection but it is not exhaustive,
-    # there is still a security risk here!
-    if ";" in command or "||" in command or "&&" in command or ">" in command:
-        raise ValueError(
-            "To avoid possible injection, command cannot contain ; || or &&"
-        )
     output = subprocess.getoutput(command)  # nosec B605
     print(f"{str( datetime.now() )} - OUT: {output}")
     return output

--- a/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
@@ -11,7 +11,11 @@ from typing import Any, Dict, Generator, Optional
 
 import boto3  # type: ignore
 import pkg_resources
-from botocore.exceptions import NoCredentialsError, NoRegionError  # type: ignore
+from botocore.exceptions import (  # type: ignore
+    ClientError,
+    NoCredentialsError,
+    NoRegionError,
+)
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
 from hydra.test_utils.launcher_common_tests import (
@@ -49,7 +53,7 @@ try:
     ec2 = boto3.client("ec2")
     ec2.describe_regions()
     aws_not_configured = False
-except (NoCredentialsError, NoRegionError):
+except (ClientError, NoCredentialsError, NoRegionError):
     aws_not_configured = True
 
 
@@ -129,7 +133,13 @@ chdir_plugin_root()
 
 def run_command(commands: str) -> str:
     log.info(f"running: {commands}")
-    output = subprocess.getoutput(commands)
+    # Do some basic validation to avoid injection but it is not exhaustive,
+    # there is still a security risk here!
+    if ";" in commands or "||" in commands or "&&" in commands or ">" in commands:
+        raise ValueError(
+            "To avoid possible injection, command cannot contain ; || or &&"
+        )
+    output = subprocess.getoutput(commands)  # nosec B605
     log.info(f"outputs: {output}")
     return output
 
@@ -139,7 +149,8 @@ def build_ray_launcher_wheel(tmp_wheel_dir: str) -> str:
     plugin = "hydra_ray_launcher"
     os.chdir(Path("plugins") / plugin)
     log.info(f"Build wheel for {plugin}, save wheel to {tmp_wheel_dir}.")
-    run_command(f"python setup.py sdist bdist_wheel && cp dist/*.whl {tmp_wheel_dir}")
+    run_command("python setup.py sdist bdist_wheel")
+    run_command(f"cp dist/*.whl {tmp_wheel_dir}")
     log.info("Download all plugin dependency wheels.")
     run_command(f"pip download . -d {tmp_wheel_dir}")
     plugin_wheel = run_command("ls dist/*.whl").split("/")[-1]
@@ -149,7 +160,8 @@ def build_ray_launcher_wheel(tmp_wheel_dir: str) -> str:
 
 def build_core_wheel(tmp_wheel_dir: str) -> str:
     chdir_hydra_root()
-    run_command(f"python setup.py sdist bdist_wheel && cp dist/*.whl {tmp_wheel_dir}")
+    run_command("python setup.py sdist bdist_wheel")
+    run_command(f"cp dist/*.whl {tmp_wheel_dir}")
 
     # download dependency wheel for hydra-core
     run_command(f"pip download -r requirements/requirements.txt -d {tmp_wheel_dir}")

--- a/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
@@ -133,12 +133,6 @@ chdir_plugin_root()
 
 def run_command(commands: str) -> str:
     log.info(f"running: {commands}")
-    # Do some basic validation to avoid injection but it is not exhaustive,
-    # there is still a security risk here!
-    if ";" in commands or "||" in commands or "&&" in commands or ">" in commands:
-        raise ValueError(
-            "To avoid possible injection, command cannot contain ; || or &&"
-        )
     output = subprocess.getoutput(commands)  # nosec B605
     log.info(f"outputs: {output}")
     return output


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Make all the CI tests passing (or at least not failing). This involves
1. Fixing lint errors about injection security error in test code (mostly done through adding `# nosec B605` to bypass). Also added very basic, non-exhaustive checking to avoid common ways that injection can happen
2. Changed ray_aws launcher to skip if a `ClientError` is thrown (which is currently happening because the AWS cluster has been shut down)
3. Updating the miniconda version being installed onto Mac on CircleCI since they no longer support intel https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

No CI tests failed on this branch

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
