### PR TITLE
Use latest configstore singleton instead of storing it

### DIFF
--- a/hydra/_internal/core_plugins/structured_config_source.py
+++ b/hydra/_internal/core_plugins/structured_config_source.py
@@ -9,12 +9,10 @@ from hydra.plugins.config_source import ConfigResult, ConfigSource
 
 
 class StructuredConfigSource(ConfigSource):
-    store: ConfigStore
 
     def __init__(self, provider: str, path: str) -> None:
         super().__init__(provider=provider, path=path)
         # Import the module, the __init__ there is expected to register the configs.
-        self.store = ConfigStore.instance()
         if self.path != "":
             try:
                 importlib.import_module(self.path)
@@ -30,7 +28,7 @@ class StructuredConfigSource(ConfigSource):
 
     def load_config(self, config_path: str) -> ConfigResult:
         normalized_config_path = self._normalize_file_name(config_path)
-        ret = self.store.load(config_path=normalized_config_path)
+        ret = ConfigStore.instance().load(config_path=normalized_config_path)
         provider = ret.provider if ret.provider is not None else self.provider
         header = {"package": ret.package}
         return ConfigResult(
@@ -44,17 +42,17 @@ class StructuredConfigSource(ConfigSource):
         return True
 
     def is_group(self, config_path: str) -> bool:
-        type_ = self.store.get_type(config_path.rstrip("/"))
+        type_ = ConfigStore.instance().get_type(config_path.rstrip("/"))
         return type_ == ObjectType.GROUP
 
     def is_config(self, config_path: str) -> bool:
         filename = self._normalize_file_name(config_path.rstrip("/"))
-        type_ = self.store.get_type(filename)
+        type_ = ConfigStore.instance().get_type(filename)
         return type_ == ObjectType.CONFIG
 
     def list(self, config_path: str, results_filter: Optional[ObjectType]) -> List[str]:
         ret: List[str] = []
-        files = self.store.list(config_path)
+        files = ConfigStore.instance().list(config_path)
 
         for file in files:
             self._list_add_result(

--- a/news/2928.bugfix
+++ b/news/2928.bugfix
@@ -1,0 +1,1 @@
+Fix StructuredConfigStore using old singleton copy when using lazy imports


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Instead of storing the `ConfigStore.instance()` on `StructuredConfigStore`, refetch it every time. This ensures that if somehow the `ConfigStore` singleton is duplicated, we're getting the most recent one instead of an old copy (when Hydra loads configurations it makes a deep copy of the repository and deep copies of its singletons generate a new instance of the singleton, which causes issues with lazy imports)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

Fairly safe change, CI passes. That being said, if anyone is accessing `StructuredConfigSource.store` (which seems unlikely), they should switch to using `ConfigStore.instance()`

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
