### PR TITLE
Add a util function to convert basic python objects to override format

### DIFF
--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import json
 import logging.config
 import os
 from pathlib import Path
@@ -115,3 +116,30 @@ def to_absolute_path(path: str) -> str:
     else:
         ret = base / p
     return str(ret)
+
+
+def to_hydra_override_value_str(obj: Any) -> str:
+    """
+    Basic conversion of an object to a string that can be used in a Hydra override.
+    Does not explicitly support all types but should work for basic structures.
+
+    >>> obj = {"foo": 1, "bar": "baz"}
+    >>> compose(config_name="config", overrides=[f"a={to_hydra_override_value_str(obj)}", "x=1"])
+
+    :param obj: object to convert
+    :return: string representation of the object that can be used in a Hydra override
+    """
+    if isinstance(obj, dict):
+        return (
+            "{"
+            + ", ".join(
+                f"{key}: {to_hydra_override_value_str(value)}"
+                for key, value in obj.items()
+            )
+            + "}"
+        )
+    elif isinstance(obj, list):
+        return (
+            "[" + ", ".join([to_hydra_override_value_str(value) for value in obj]) + "]"
+        )
+    return json.dumps(obj)

--- a/news/2934.feature
+++ b/news/2934.feature
@@ -1,0 +1,1 @@
+Add to_hydra_override_value_str util function

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -74,6 +74,25 @@ def test_to_absolute_path_without_hydra(
 
 
 @mark.parametrize(
+    "obj, expected",
+    [
+        ("foo bar", '"foo bar"'),
+        (10, "10"),
+        ({"foo": '\\"bar'}, '{foo: "\\\\\\"bar"}'),
+        ([1, 2, "3", {"a": "xyz"}], '[1, 2, "3", {a: "xyz"}]'),
+        (
+            {"a": 10, "b": "c", "d": {"e": [1, 2, "3"], "f": ["g", {"h": {"i": "j"}}]}},
+            '{a: 10, b: "c", d: {e: [1, 2, "3"], f: ["g", {h: {i: "j"}}]}}',
+        ),
+    ],
+)
+def test_to_hydra_override_value_str(
+    hydra_restore_singletons: Any, obj: Any, expected: str
+) -> None:
+    assert utils.to_hydra_override_value_str(obj) == expected
+
+
+@mark.parametrize(
     "env_setting,expected_error",
     [
         param(None, False, id="env_unset"),


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

To pass overrides to a subprocess, sometimes override values need to be programmatically generated. This adds a basic util function to convert a python object to an override value string.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

Added some test cases

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
