### PR TITLE
Extend list function

### DIFF
--- a/build_helpers/build_helpers.py
+++ b/build_helpers/build_helpers.py
@@ -164,7 +164,7 @@ class Develop(develop.develop):
 
 class SDistCommand(sdist.sdist):
     def run(self) -> None:
-        if not self.dry_run:  # type: ignore
+        if not self.dry_run:
             self.run_command("clean")
             run_antlr(self)
         sdist.sdist.run(self)

--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -385,6 +385,15 @@ class ConfigLoaderImpl(ConfigLoader):
                         )
                 elif override.is_force_add():
                     OmegaConf.update(cfg, key, value, merge=True, force_add=True)
+                elif override.is_list_extend():
+                    config_val = OmegaConf.select(cfg, key, throw_on_missing=True)
+                    if not OmegaConf.is_list(config_val):
+                        raise ConfigCompositionException(
+                            "Could not append to config list. The existing value of"
+                            f" '{override.key_or_group}' is {config_val} which is not"
+                            f" a list."
+                        )
+                    config_val.extend(value)
                 else:
                     try:
                         OmegaConf.update(cfg, key, value, merge=True)

--- a/hydra/_internal/grammar/grammar_functions.py
+++ b/hydra/_internal/grammar/grammar_functions.py
@@ -403,4 +403,7 @@ def glob(
 
 
 def extend_list(*args: Any) -> ListExtensionOverrideValue:
+    """
+    Extends an existing list in the config with the given values.
+    """
     return ListExtensionOverrideValue(values=list(args))

--- a/hydra/_internal/grammar/grammar_functions.py
+++ b/hydra/_internal/grammar/grammar_functions.py
@@ -10,6 +10,7 @@ from hydra.core.override_parser.types import (
     ChoiceSweep,
     Glob,
     IntervalSweep,
+    ListExtensionOverrideValue,
     ParsedElementType,
     QuotedString,
     RangeSweep,
@@ -399,3 +400,7 @@ def glob(
         exclude = [exclude]
 
     return Glob(include=include, exclude=exclude)
+
+
+def extend_list(*args: Any) -> ListExtensionOverrideValue:
+    return ListExtensionOverrideValue(values=list(args))

--- a/hydra/core/override_parser/overrides_parser.py
+++ b/hydra/core/override_parser/overrides_parser.py
@@ -124,4 +124,5 @@ def create_functions() -> Functions:
     functions.register(name="sort", func=grammar_functions.sort)
     functions.register(name="shuffle", func=grammar_functions.shuffle)
     functions.register(name="glob", func=grammar_functions.glob)
+    functions.register(name="extend_list", func=grammar_functions.extend_list)
     return functions

--- a/hydra/core/override_parser/overrides_visitor.py
+++ b/hydra/core/override_parser/overrides_visitor.py
@@ -18,6 +18,7 @@ from hydra.core.override_parser.types import (
     Glob,
     IntervalSweep,
     Key,
+    ListExtensionOverrideValue,
     Override,
     OverrideType,
     ParsedElementType,
@@ -190,6 +191,13 @@ class HydraOverrideVisitor(OverrideParserVisitor):
                     value_type = ValueType.RANGE_SWEEP
                 else:
                     value_type = ValueType.ELEMENT
+                    if isinstance(value, ListExtensionOverrideValue):
+                        if not override_type == OverrideType.CHANGE:
+                            raise HydraException(
+                                "Trying to use override symbols when extending a list"
+                            )
+                        override_type = OverrideType.EXTEND_LIST
+                        value = value.values
 
         return Override(
             type=override_type,

--- a/hydra/core/override_parser/types.py
+++ b/hydra/core/override_parser/types.py
@@ -189,6 +189,7 @@ class OverrideType(Enum):
     ADD = 2
     FORCE_ADD = 3
     DEL = 4
+    EXTEND_LIST = 5
 
 
 class ValueType(Enum):
@@ -225,6 +226,11 @@ class Glob:
                 res.append(name)
 
         return res
+
+
+@dataclass
+class ListExtensionOverrideValue:
+    values: List["ParsedElementType"]
 
 
 class Transformer:
@@ -285,6 +291,12 @@ class Override:
         :return: True if this override represents a forced addition of a config value
         """
         return self.type == OverrideType.FORCE_ADD
+
+    def is_list_extend(self) -> bool:
+        """
+        :return: True if this override represents appending to a list config value
+        """
+        return self.type == OverrideType.EXTEND_LIST
 
     @staticmethod
     def _convert_value(value: ParsedElementType) -> Optional[ElementType]:

--- a/news/1547.feature
+++ b/news/1547.feature
@@ -1,0 +1,1 @@
+Add extend_list function to override syntax

--- a/tests/test_hydra_cli_errors.py
+++ b/tests/test_hydra_cli_errors.py
@@ -41,6 +41,17 @@ ValueError while evaluating 'choice()': empty choice is not legal""",
             id="empty choice",
         ),
         param(
+            "+key=extend_list(1, 2, 3)",
+            """Error parsing override '+key=extend_list(1, 2, 3)'
+Trying to use override symbols when extending a list""",
+            id="plus key extend_list",
+        ),
+        param(
+            "key={inner_key=extend_list(1, 2, 3)}",
+            "no viable alternative at input '{inner_key='",
+            id="embedded extend_list",
+        ),
+        param(
             ["+key=choice(choice(a,b))", "-m"],
             """Error parsing override '+key=choice(choice(a,b))'
 ValueError while evaluating 'choice(choice(a,b))': nesting choices is not supported

--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -236,6 +236,8 @@ foo=[1,2,3]
 nested=[a,[b,[c]]]
 ```
 
+Lists are assigned, not merged. To extend an existing list, use the [`extend_list` function](extended.md#extending-lists).
+
 ### Dictionaries
 ```python
 foo={a:10,b:20}

--- a/website/docs/advanced/override_grammar/extended.md
+++ b/website/docs/advanced/override_grammar/extended.md
@@ -6,7 +6,7 @@ hide_title: true
 
 ##  Extended Override syntax
 Hydra Overrides supports functions.
-When calling a function, one can optionally name parameters. This is following the Python 
+When calling a function, one can optionally name parameters. This is following the Python
 convention of naming parameters.
 
 <div className="row">
@@ -41,9 +41,9 @@ another function added, please file an issue and explain the use case.
 :::
 
 ## Sweeps
-Sweep overrides are used by Sweepers to determine what to do. For example, 
-one can instruct the Basic Sweeper to sweep over all combinations of the 
-ranges `num1=range(0,3)` and `num2=range(0,3)` - resulting in `9` jobs, each getting a 
+Sweep overrides are used by Sweepers to determine what to do. For example,
+one can instruct the Basic Sweeper to sweep over all combinations of the
+ranges `num1=range(0,3)` and `num2=range(0,3)` - resulting in `9` jobs, each getting a
 different pair of numbers from `0`, `1` and `2`.
 
 ### Choice sweep
@@ -58,7 +58,7 @@ def choice(
 Choice sweeps are the most common sweeps.
 A choice sweep is described in one of two equivalent forms.
 ```python title="Examples"
-db=mysql,postgresql          # a comma separated list of two or more elements. 
+db=mysql,postgresql          # a comma separated list of two or more elements.
 db=choice(mysql,postgresql)  # choice
 ```
 ### Glob choice sweep
@@ -108,7 +108,7 @@ num=range(-5,step=-1)                 # 0,-1,-2,-3,-4
 ### Interval sweep
 An interval sweep represents all the floating point value between two values.
 This is used by optimizing sweepers like Ax and Nevergrad. The basic sweeper does not support interval.
- 
+
 ```python title="Signature"
 def interval(start: Union[int, float], end: Union[int, float]) -> IntervalSweep:
     """
@@ -133,6 +133,46 @@ def tag(*args: Union[str, Union[Sweep]], sweep: Optional[Sweep] = None) -> Sweep
 tag(log,interval(0,1))          # 1.0 <= x < 1.0, tags=[log]
 tag(foo,bar,interval(0,1))      # 1.0 <= x < 1.0, tags=[foo,bar]
 ```
+
+## Extending lists
+
+### extend_list
+```python title="Signature"
+def extend_list(*args: Any) -> ListExtensionOverrideValue:
+    """
+    Extends an existing list in the config with the given values.
+    """
+```
+
+<div className="row">
+<div className="col col--6">
+
+```yaml title="Input config"
+tags:
+- database
+- log
+```
+
+</div>
+
+<div className="col  col--6">
+
+
+```yaml title="tag=extend_list(extended, experimental)"
+tags:
+- database
+- log
+- extended
+- experimental
+```
+
+</div>
+</div>
+
+Note that this cannot be used in conjunction with appending or removing config value. The following usages are invalid:
+* `+list_key=extend_list(val1, val2)`
+* `++list_key=extend_listval1, val2)`
+* `~list_key=extend_list(val1, val2)`
 
 ## Reordering lists and sweeps
 
@@ -183,11 +223,11 @@ def shuffle(
 shuffle(a,b,c)                                       # shuffled a,b,c
 shuffle(choice(a,b,c)), shuffle(sweep=choice(a,b,c)) # shuffled choice(a,b,c)
 shuffle(range(1,10))                                 # shuffled range(1,10)
-shuffle([a,b,c]), shuffle(list=[a,b,c])              # shuffled list [a,b,c] 
+shuffle([a,b,c]), shuffle(list=[a,b,c])              # shuffled list [a,b,c]
 ```
 
 ## Type casting
-You can cast values and sweeps to `int`, `float`, `bool`, `str` or `json_str`. Note that unlike the 
+You can cast values and sweeps to `int`, `float`, `bool`, `str` or `json_str`. Note that unlike the
 others, `json_str` will affect the whole container rather than just the values.
 ```python title="Example"
 int(3.14)                  # 3 (int)
@@ -223,7 +263,7 @@ def bool(value: Any) -> bool:
 
 <div className="col  col--6">
 
-```python title="Hydra" 
+```python title="Hydra"
 def bool(s: str) -> bool:
     if isinstance(value, str):
         if value.lower() == "false":
@@ -258,7 +298,7 @@ def cast_int(value: Any):
 
 <div className="col  col--6">
 
-```python title="Hydra" 
+```python title="Hydra"
 def cast_int(value: Any):
     if isinstance(v, list):
         return list(map(cast_int, v))
@@ -292,7 +332,7 @@ def cast_int(value: Any):
 
 <div className="col  col--6">
 
-```python title="Hydra" 
+```python title="Hydra"
 def cast_int(value: Any):
     if isinstance(value, dict):
         return apply_to_values(
@@ -326,7 +366,7 @@ def cast_int(value: Any):
 
 <div className="col  col--6">
 
-```python title="Hydra" 
+```python title="Hydra"
 def cast_int(value: Any):
     if isinstance(value, RangeSweep):
         return RangeSweep(
@@ -361,7 +401,7 @@ Input are grouped by type.
 |  “” (empty string) 	| error       	| error             	| “”                	| error                 	| '“”'                   |
 |        “10”        	| 10          	| 10.0              	| “10”              	| error                 	| '“10”'                 |
 |       “10.0”       	| error       	| 10.0              	| “10.0”            	| error                 	| '“10.0”'               |
-|       “true”       	| error       	| error             	| “true”            	| true                  	| '“true”'               | 
+|       “true”       	| error       	| error             	| “true”            	| true                  	| '“true”'               |
 |       “false”      	| error       	| error             	| “false”           	| false                 	| '“false”'              |
 |      “[1,2,3]”     	| error       	| error             	| “[1,2,3]”         	| error                 	| '“[1,2,3]”'            |
 |      “{a:10}”      	| error       	| error             	| “{a:10}”          	| error                 	| '“{a:10}”'             |


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation
https://github.com/facebookresearch/hydra/issues/1547
There is currently no clean way to append to a list using the override syntax. It was suggested in the above issue that this could be done by adding a custom function, so that's what this PR does. It means that if the config is:
```
extras:
    tags: [experiment, trial_1]
```

composing the config with this as an override:
`extras.tags="extend_list(another_tag, yet_another_tag)"`

would generate
```
extras:
    tags: [experiment, trial_1, another_tag, yet_another_tag]
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

Added unit tests that pass, also checked the added documentation looks correct using yarn start

## Related Issues and PRs

https://github.com/facebookresearch/hydra/issues/1547
