### PR TITLE
Explicitly add a versioned dependency for path-to-regexp

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,7 @@
     "docusaurus-plugin-internaldocs-fb": "0.10.4",
     "micromatch": "^4.0.8",
     "node-fetch": "^2.6.7",
+    "path-to-regexp": "^1.9.0",
     "prism-react-renderer": "1.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1418,7 +1418,7 @@
     "@docusaurus/theme-classic" "2.0.0-beta.14"
     "@docusaurus/theme-search-algolia" "2.0.0-beta.14"
 
-"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -6128,6 +6128,13 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-to-regexp@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.9.0.tgz#5dc0753acbf8521ca2e0f137b4578b917b10cf24"
+  integrity sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -6753,6 +6760,14 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   integrity sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==
   dependencies:
     "@babel/runtime" "^7.10.3"
+
+"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
+  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
+  dependencies:
+    "@types/react" "*"
+    prop-types "^15.6.2"
 
 react-router-config@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
We depend on path-to-regexp, through the webserver framework Express, which I think is coming from webpack or docusaurus.

Versions of path-to-regexp  0.2.0 < version < 1.9.0 have a security vulnerability.
By explicitly specifying the version of path-to-regexp, yarn chooses the right versions for everything else.

## Motivation

Address a security vulnerability

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

Download nvm / node as needed (tested on node JS 20, Mac OS)
```
nvm use 20
npm install -g yarn
```

Then, install the website:
```
cd website
yarn
```

Last but not least, start the website on a local server, and browse it:
```
yarn start
```

It should work normally.

## Related Issues and PRs

None