### PR TITLE
Upgrade follow-redirects version to address vulnerability issue

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,7 @@
     "@docusaurus/preset-classic": "^2.0.0-beta.14",
     "classnames": "^2.2.6",
     "docusaurus-plugin-internaldocs-fb": "0.10.4",
+    "follow-redirects": "^1.15.6",
     "micromatch": "^4.0.8",
     "node-fetch": "^2.6.7",
     "path-to-regexp": "^1.9.0",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -4031,6 +4031,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
   integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
 
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
 foreach@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

follow-redirects is an indirect dependency and gets resolved to version < 1.15.4 which has vulnerability issue, so the PR explicitly sets the version to address that.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

Download nvm / node as needed (tested on node JS 20, Mac OS)
```
nvm use 20
npm install -g yarn
```

Then, install the website:
```
cd website
yarn
```

Last but not least, start the website on a local server, and browse it:
```
yarn start
```

It should work normally.

## Related Issues and PRs

N/A
