### PR TITLE
Force resolve follow-redirects to vulnerability-free version

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,6 @@
     "@docusaurus/preset-classic": "^2.0.0-beta.14",
     "classnames": "^2.2.6",
     "docusaurus-plugin-internaldocs-fb": "0.10.4",
-    "follow-redirects": "^1.15.6",
     "micromatch": "^4.0.8",
     "node-fetch": "^2.6.7",
     "path-to-regexp": "^1.9.0",
@@ -24,6 +23,7 @@
     "webpack": "^5.94"
   },
   "resolutions": {
+    "follow-redirects": "^1.15.6",
     "prism-react-renderer": "1.1.0"
   },
   "browserslist": {

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -4026,12 +4026,7 @@ flux@^4.0.1:
     fbemitter "^3.0.0"
     fbjs "^3.0.1"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0:
-  version "1.14.8"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
-  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
-
-follow-redirects@^1.15.6:
+follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.15.6:
   version "1.15.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

The previous [pr](https://github.com/facebookresearch/hydra/pull/2955) tried to achieve that but it turns out we have to add the version to `resolutions` to force resolve to vulnerability-free version.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

```
yarn
yarn start
```

And verified the website works normally.
## Related Issues and PRs
N/A
