### PR TITLE
No block slurm

### DIFF
--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
@@ -28,6 +28,11 @@ class BaseQueueConf:
     # redirect stderr to stdout
     stderr_to_stdout: bool = False
 
+    # If True, the launcher will not wait for the job to finish (useful for very long runs)
+    # This value is not passed to submitit, it is used by the launcher itself. When enabled,
+    # a set of sentinel values are returned to the sweeper to indicate that the job is running.
+    no_block: bool = False
+
 
 @dataclass
 class SlurmQueueConf(BaseQueueConf):

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
@@ -151,8 +151,8 @@ class BaseSubmititLauncher(Launcher):
         jobs = executor.map_array(self, *zip(*job_params))
 
         if self.no_block:
-            sentinal = JobReturn(status=JobStatus.COMPLETED, _return_value=None)
-            return [sentinal] * num_jobs
+            sentinel = JobReturn(status=JobStatus.COMPLETED, _return_value=None)
+            return [sentinel] * num_jobs
         else:
             return [j.results()[0] for j in jobs]
 

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
@@ -7,10 +7,10 @@ from typing import Any, Dict, List, Optional, Sequence
 from hydra.core.singleton import Singleton
 from hydra.core.utils import (
     JobReturn,
+    JobStatus,
     filter_overrides,
     run_job,
     setup_globals,
-    JobStatus,
 )
 from hydra.plugins.launcher import Launcher
 from hydra.types import HydraContext, TaskFunction

--- a/plugins/hydra_submitit_launcher/tests/test_submitit_launcher.py
+++ b/plugins/hydra_submitit_launcher/tests/test_submitit_launcher.py
@@ -61,3 +61,16 @@ def test_example(tmpdir: Path) -> None:
         ],
         allow_warnings=True,
     )
+
+
+def test_example_no_block(tmpdir: Path) -> None:
+    run_python_script(
+        [
+            "example/my_app.py",
+            "-m",
+            f"hydra.sweep.dir={tmpdir}",
+            "hydra/launcher=submitit_local",
+            "hydra.launcher.no_block=True",
+        ],
+        allow_warnings=True,
+    )


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

I am using hydra for ML and I need to run my training on the HPC. Our HPC does not allow long running jobs on the login node, so to utilise the hydra submitit launcher it needs to be non-blocking.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

I have run the unit tests for plugin and also added an additional one specifically for the changes made.

I have not extensively tested this change with the sweeper, as I am not expecting to use the sweeper with it, however, I have added sentinel values for the job returns to prevent the sweeper from raising an error. It should be noted in the documentation that this feature is not designed to function with the sweeper. I do not think it needs to be, since sweeping generally does not take long running jobs, and should be performed on smaller datasets and training sessions which last less than a few hours.

## Related Issues and PRs

This potentially fixes #2479.