### PR TITLE
Correct missing link import typo in colorlog website page.

### DIFF
--- a/website/docs/plugins/colorlog.md
+++ b/website/docs/plugins/colorlog.md
@@ -4,7 +4,8 @@ title: Colorlog plugin
 sidebar_label: Colorlog plugin
 ---
 
-import {ExampleGithubLink} from "@site/src/components/GithubLink"
+import GithubLink,{ExampleGithubLink} from "@site/src/components/GithubLink"
+
 
 [![PyPI](https://img.shields.io/pypi/v/hydra-colorlog)](https://pypi.org/project/hydra-colorlog/)
 ![PyPI - License](https://img.shields.io/pypi/l/hydra-colorlog)


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

There is an issue on the `colorlog` website: 

![image](https://github.com/user-attachments/assets/3a9950d9-a19c-42ed-8f9e-f00cd4bdc33e)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

No

## Test Plan

Someone should build the website and ensure this is correct. I just noticed that there was no import for `GithubLink` in the code whereas other similar pages have one (e.g. https://github.com/facebookresearch/hydra/blob/57690d7c4e8b5e88dad07d67278f613a739e6d13/website/docs/advanced/packaging.md?plain=1#L7C1-L8C1)

## Related Issues and PRs

None that I know of, but I didn't really check -- I just noticed the issue and figured I'd send this over really quickly given how small it was. Hopefully this is helpful, and apologies if there was a better way to do this!
