### PR TITLE
Fix instantiate side effect modifying input config parent

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -163,7 +163,12 @@ def _deep_copy_full_config(subconfig: Any) -> Any:
         return copy.deepcopy(subconfig)
 
 
-def instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
+def instantiate(
+    config: Any,
+    *args: Any,
+    _skip_instantiate_full_deepcopy_: bool = False,
+    **kwargs: Any,
+) -> Any:
     """
     :param config: An config object describing what to call and what params to use.
                    In addition to the parameters, the config must contain:
@@ -186,6 +191,10 @@ def instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
                                   are converted to dicts / lists too.
                    _partial_: If True, return functools.partial wrapped method or object
                               False by default. Configure per target.
+    :param _skip_instantiate_full_deepcopy_: If True, deep copy just the input config instead
+                    of full config before resolving omegaconf interpolations, which may
+                    potentially modify the config's parent/sibling configs in place.
+                    False by default.
     :param args: Optional positional parameters pass-through
     :param kwargs: Optional named parameters to override
                    parameters in the config object. Parameters not present
@@ -225,8 +234,12 @@ def instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
 
     if OmegaConf.is_dict(config):
         # Finalize config (convert targets to strings, merge with kwargs)
-        # Create full copy to avoid mutating original
-        config_copy = _deep_copy_full_config(config)
+        # Create copy to avoid mutating original
+        if _skip_instantiate_full_deepcopy_:
+            config_copy = copy.deepcopy(config)
+            config_copy._set_parent(config._get_parent())
+        else:
+            config_copy = _deep_copy_full_config(config)
         config_copy._set_flag(
             flags=["allow_objects", "struct", "readonly"], values=[True, False, False]
         )
@@ -246,8 +259,12 @@ def instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
         )
     elif OmegaConf.is_list(config):
         # Finalize config (convert targets to strings, merge with kwargs)
-        # Create full copy to avoid mutating original
-        config_copy = _deep_copy_full_config(config)
+        # Create copy to avoid mutating original
+        if _skip_instantiate_full_deepcopy_:
+            config_copy = copy.deepcopy(config)
+            config_copy._set_parent(config._get_parent())
+        else:
+            config_copy = _deep_copy_full_config(config)
         config_copy._set_flag(
             flags=["allow_objects", "struct", "readonly"], values=[True, False, False]
         )

--- a/news/3001.bugfix
+++ b/news/3001.bugfix
@@ -1,0 +1,1 @@
+Fix unexpected resolution side-effect that caused modifications to the input config parent in `hydra.utils.instantiate`

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -419,8 +419,10 @@ def test_class_instantiate(
     recursive: bool,
 ) -> Any:
     passthrough["_recursive_"] = recursive
+    original_config_str = str(config)
     obj = instantiate_func(config, **passthrough)
     assert partial_equal(obj, expected)
+    assert str(config) == original_config_str
 
 
 def test_partial_with_missing(instantiate_func: Any) -> Any:
@@ -431,10 +433,12 @@ def test_partial_with_missing(instantiate_func: Any) -> Any:
         "b": 20,
         "c": 30,
     }
+    original_config_str = str(config)
     partial_obj = instantiate_func(config)
     assert partial_equal(partial_obj, partial(AClass, b=20, c=30))
     obj = partial_obj(a=10)
     assert partial_equal(obj, AClass(a=10, b=20, c=30))
+    assert str(config) == original_config_str
 
 
 def test_instantiate_with_missing(instantiate_func: Any) -> Any:
@@ -468,6 +472,7 @@ def test_none_cases(
             ListConfig(None),
         ],
     }
+    original_config_str = str(cfg)
     ret = instantiate_func(cfg)
     assert ret.kwargs["none_dict"] is None
     assert ret.kwargs["none_list"] is None
@@ -477,8 +482,10 @@ def test_none_cases(
     assert ret.kwargs["list"][0] == 10
     assert ret.kwargs["list"][1] is None
     assert ret.kwargs["list"][2] is None
+    assert str(cfg) == original_config_str
 
 
+@mark.parametrize("convert_to_list", [True, False])
 @mark.parametrize(
     "input_conf, passthrough, expected",
     [
@@ -537,6 +544,32 @@ def test_none_cases(
             6,
             id="interpolation_from_recursive",
         ),
+        param(
+            {
+                "my_id": 5,
+                "node": {
+                    "b": "${foo_b}",
+                },
+                "foo_b": {
+                    "unique_id": "${my_id}",
+                },
+            },
+            {},
+            OmegaConf.create({"b": {"unique_id": 5}}),
+            id="interpolation_from_parent_with_interpolation",
+        ),
+        param(
+            {
+                "my_id": 5,
+                "node": "${foo_b}",
+                "foo_b": {
+                    "unique_id": "${my_id}",
+                },
+            },
+            {},
+            OmegaConf.create({"unique_id": 5}),
+            id="interpolation_from_parent_with_interpolation",
+        ),
     ],
 )
 def test_interpolation_accessing_parent(
@@ -544,15 +577,24 @@ def test_interpolation_accessing_parent(
     input_conf: Any,
     passthrough: Dict[str, Any],
     expected: Any,
+    convert_to_list: bool,
 ) -> Any:
+    if convert_to_list:
+        input_conf = copy.deepcopy(input_conf)
+        input_conf["node"] = [input_conf["node"]]
     cfg_copy = OmegaConf.create(input_conf)
     input_conf = OmegaConf.create(input_conf)
-    obj = instantiate_func(input_conf.node, **passthrough)
+    original_config_str = str(input_conf)
+    if convert_to_list:
+        obj = instantiate_func(input_conf.node[0], **passthrough)
+    else:
+        obj = instantiate_func(input_conf.node, **passthrough)
     if isinstance(expected, partial):
         assert partial_equal(obj, expected)
     else:
         assert obj == expected
     assert input_conf == cfg_copy
+    assert str(input_conf) == original_config_str
 
 
 @mark.parametrize(

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -485,6 +485,7 @@ def test_none_cases(
     assert str(cfg) == original_config_str
 
 
+@mark.parametrize("skip_deepcopy", [True, False])
 @mark.parametrize("convert_to_list", [True, False])
 @mark.parametrize(
     "input_conf, passthrough, expected",
@@ -578,6 +579,7 @@ def test_interpolation_accessing_parent(
     passthrough: Dict[str, Any],
     expected: Any,
     convert_to_list: bool,
+    skip_deepcopy: bool,
 ) -> Any:
     if convert_to_list:
         input_conf = copy.deepcopy(input_conf)
@@ -586,15 +588,24 @@ def test_interpolation_accessing_parent(
     input_conf = OmegaConf.create(input_conf)
     original_config_str = str(input_conf)
     if convert_to_list:
-        obj = instantiate_func(input_conf.node[0], **passthrough)
+        obj = instantiate_func(
+            input_conf.node[0],
+            _skip_instantiate_full_deepcopy_=skip_deepcopy,
+            **passthrough,
+        )
     else:
-        obj = instantiate_func(input_conf.node, **passthrough)
+        obj = instantiate_func(
+            input_conf.node,
+            _skip_instantiate_full_deepcopy_=skip_deepcopy,
+            **passthrough,
+        )
     if isinstance(expected, partial):
         assert partial_equal(obj, expected)
     else:
         assert obj == expected
     assert input_conf == cfg_copy
-    assert str(input_conf) == original_config_str
+    if not skip_deepcopy:
+        assert str(input_conf) == original_config_str
 
 
 @mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

See #3001 for details, tldr if you call `hydra.utils.instantiate` on a subconfig, it might modify the parent config through omegaconf resolution which is an unexpected side effect. While there is currently logic to deepcopy the subconfig to avoid such a side effect, we actually need to deepcopy the entire config to avoid it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan
New and existing tests pass

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)

Fixes #3001 
