### PR TITLE
Fix bug when deep copying full config with missing parent

### DIFF
--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, NoReturn, Optional, Tuple
 from omegaconf import MISSING, DictConfig, ListConfig
 
 from hydra.types import TargetConf
+from hydra.utils import instantiate
 from tests.instantiate.module_shadowed_by_function import a_function
 
 module_shadowed_by_function = a_function
@@ -416,6 +417,19 @@ class NestedConf:
     _target_: str = "tests.instantiate.SimpleClass"
     a: Any = field(default_factory=lambda: User(name="a", age=1))
     b: Any = field(default_factory=lambda: User(name="b", age=2))
+
+
+class TargetWithInstantiateInInit:
+    def __init__(
+        self, user_config: Optional[DictConfig], user: Optional[User] = None
+    ) -> None:
+        if user:
+            self.user = user
+        else:
+            self.user = instantiate(user_config)
+
+    def __eq__(self, other: Any) -> bool:
+        return self.user.__eq__(other.user)
 
 
 def recisinstance(got: Any, expected: Any) -> bool:

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -43,6 +43,7 @@ from tests.instantiate import (
     SimpleClassNonPrimitiveConf,
     SimpleClassPrimitiveConf,
     SimpleDataClass,
+    TargetWithInstantiateInInit,
     Tree,
     TreeConf,
     UntypedPassthroughClass,
@@ -570,6 +571,30 @@ def test_none_cases(
             {},
             OmegaConf.create({"unique_id": 5}),
             id="interpolation_from_parent_with_interpolation",
+        ),
+        param(
+            DictConfig(
+                {
+                    "username": "test_user",
+                    "node": {
+                        "_target_": "tests.instantiate.TargetWithInstantiateInInit",
+                        "_recursive_": False,
+                        "user_config": {
+                            "_target_": "tests.instantiate.User",
+                            "name": "${foo_b.username}",
+                            "age": 40,
+                        },
+                    },
+                    "foo_b": {
+                        "username": "${username}",
+                    },
+                }
+            ),
+            {},
+            TargetWithInstantiateInInit(
+                user_config=None, user=User(name="test_user", age=40)
+            ),
+            id="target_with_instantiate_in_init",
         ),
     ],
 )


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Previously the implementation assumed that `OmegaConf.select(subconfig._get_root(), subconfig._get_full_key(None) == subconfig` but this isn't actually the case because sometimes `subconfig`'s parent is set to `None` without modifying the full key.

This PR fixes it by
1. Removing any `subconfig._get_root()` eg. if
None is parent of B (full key A.B) is parent of C (full key A.B.C) is parent of D (full key A.B.C.D)
then the root of D is B
The key we should use is C.D which is D's full key with B's full key removed from the prefix

2. If for whatever reason even with this logic, we still can't retrieve the subconfig from the root config correctly, give up on trying to do the full copy and revert to previous behavior

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan
New tests pass

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
