### PR TITLE
submitit launcher async support

### DIFF
--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
@@ -142,7 +142,12 @@ class BaseSubmititLauncher(Launcher):
             )
 
         jobs = executor.map_array(self, *zip(*job_params))
-        return [j.results()[0] for j in jobs]
+
+        return [asyncLauncher() for j in jobs]
+
+class asyncLauncher:
+    def __init__(self):
+        self.return_value = 0
 
 
 class LocalLauncher(BaseSubmititLauncher):


### PR DESCRIPTION
## Motivation

After launching a job via the hydra_submitit launcher, I noticed that the command line stayed active, waiting for the job to finish.  I prefer for my submission command to finish executing after the job is launched.  I've included a very hacky solution here, but would need someone more familiar with the codebase to properly implement this change.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan
Ideally we should include some flag (async vs sync), and ensure both modes still work correctly.  Sorry, if I had more time I'd do this, but figured I'd make a PR in case others also wanted this feature.

## Related Issues and PRs
https://github.com/facebookresearch/hydra/issues/2479
