### PR TITLE
Fix int full key when deep copying in instantiate

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -151,8 +151,9 @@ def _deep_copy_full_config(subconfig: Any) -> Any:
         return copy.deepcopy(subconfig)
 
     full_key = subconfig._get_full_key(None)
-    if not full_key:
+    if full_key == "" or full_key is None:  # Do not exit early if full_key is 0
         return copy.deepcopy(subconfig)
+    full_key = str(full_key)
 
     if OmegaConf.is_list(subconfig._get_parent()):
         # OmegaConf has a bug where _get_full_key doesn't add [] if the parent

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -651,6 +651,28 @@ def test_class_instantiate_omegaconf_node(instantiate_func: Any, config: Any) ->
     assert OmegaConf.is_config(obj.c)
 
 
+@mark.parametrize(
+    "src",
+    [
+        (
+            ListConfig(
+                [
+                    {
+                        "_target_": "tests.instantiate.AClass",
+                        "b": 200,
+                        "c": {"x": 10, "y": "${0.b}"},
+                    }
+                ]
+            )
+        )
+    ],
+)
+def test_class_instantiate_list_item(instantiate_func: Any, config: Any) -> Any:
+    obj = instantiate_func(config[0], a=10, d=AnotherClass(99))
+    assert obj == AClass(a=10, b=200, c={"x": 10, "y": 200}, d=AnotherClass(99))
+    assert OmegaConf.is_config(obj.c)
+
+
 @mark.parametrize("src", [{"_target_": "tests.instantiate.Adam"}])
 def test_instantiate_adam(instantiate_func: Any, config: Any) -> None:
     with raises(


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Was seeing an error like this when the full config is a list:
```
hydra/_internal/instantiate/_instantiate2.py", line 161, in _deep_copy_full_config
    full_key = full_key[: -len(str(index))] + f"[{index}]"
TypeError: 'int' object is not subscriptable
```

This fixes it by typecasting to a string, and adds a test to avoid future instances

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

new unittest passes

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
