### PR TITLE
Support recursive target resolve

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -137,6 +137,8 @@ def _resolve_target(
             if full_key:
                 msg += f"\nfull_key: {full_key}"
             raise InstantiationException(msg) from e
+    elif _is_target(target):  # Recursive target resolve
+        target = instantiate_node(target)
     if not callable(target):
         msg = f"Expected a callable target, got '{target}' of type '{type(target).__name__}'"
         if full_key:

--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -85,6 +85,21 @@ class OuterClass:
             return "OuterClass.Nested.method return"
 
 
+class ChainClass:
+    def __init__(self, a) -> None:
+        self.a = a
+
+    def set_b(self, b) -> "ChainClass":
+        self.b = b
+        return self
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, ChainClass):
+            return self.a == other.a and self.b == other.b
+        else:
+            return False
+
+
 def add_values(a: int, b: int) -> int:
     return a + b
 

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -26,6 +26,7 @@ from tests.instantiate import (
     BClass,
     CenterCrop,
     CenterCropConf,
+    ChainClass,
     Compose,
     ComposeConf,
     IllegalType,
@@ -253,6 +254,22 @@ def config(request: Any, src: Any) -> Any:
             {},
             43,
             id="static_method",
+        ),
+        # Check recursive
+        param(
+            {
+                "_target_":{
+                    "_target_": "builtins.getattr",
+                    "_args_":[{
+                        "_target_": "tests.instantiate.ChainClass",
+                        "a": 1
+                    }, "set_b"],
+                },
+                'b':2
+            },
+            {},
+            ChainClass(1).set_b(2),
+            id="recursive_target",
         ),
         # Check nested types and static methods
         param(


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Support recursive target resolve for chained method calls or attaching decorators.

### Chained Method Calls
```python
from hydra.utils import instantiate

class ChainClass:
    def __init__(self, a) -> None:
        self.a = a

    def set_b(self, b) -> "ChainClass":
        self.b = b
        return self

# In python
ChainClass(1).set_b(2)

# In config
config = {
    "_target_":{
        "_target_": "builtins.getattr",
        "_args_":[{
            "_target_": "tests.instantiate.ChainClass",
            "a": 1
        }, "set_b"],
    },
    'b':2
}
cfg_obj = instantiate(config)  # ChainClass(1).set_b(2)
```

### Attach Decorators
```python
config = {
    "_target_":{
        "_target_": "torch.no_grad",
        "_args_":[{
            "_target_": "timm.create_model",
        }],
    },
    'model_name': 'vit_small_patch14_dinov2.lvd142m'
}
```

### Have you read the [Contributing Guidelines on pull requests]
Yes

## Test Plan
New and existing tests pass

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)

No
