### PR TITLE
Add support for plugins via entrypoints

### DIFF
--- a/examples/plugins/example_searchpath_plugin_entry_points/MANIFEST.in
+++ b/examples/plugins/example_searchpath_plugin_entry_points/MANIFEST.in
@@ -1,0 +1,3 @@
+global-exclude *.pyc
+global-exclude __pycache__
+recursive-include arbitrary_package/* *.yaml

--- a/examples/plugins/example_searchpath_plugin_entry_points/README.md
+++ b/examples/plugins/example_searchpath_plugin_entry_points/README.md
@@ -1,0 +1,11 @@
+# Hydra example SearchPath plugin (Entry points)
+
+This plugin provides an example for how to write a SearchPathPlugin that can manipulate the search path via [Entry points](https://packaging.python.org/en/latest/specifications/entry-points/)
+
+Typical use cases includes:
+ * A framework that wants to allow user code to discover its configurations and be able to compose with them.
+ * A plugin that wants to extend Hydra or another plugin by providing additional configs in existing config groups like `hydra/launcher`.
+ * A plugin that can replace the default configuration of another plugin or of Hydra itself by prepending its configurations before those that it want to replace.
+
+SearchPath plugins are discovered and enabled automatically once they are installed.
+You can use `python foo.py --info` to see the search path and the installed plugins.

--- a/examples/plugins/example_searchpath_plugin_entry_points/arbitrary_package/__init__.py
+++ b/examples/plugins/example_searchpath_plugin_entry_points/arbitrary_package/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/examples/plugins/example_searchpath_plugin_entry_points/arbitrary_package/conf/__init__.py
+++ b/examples/plugins/example_searchpath_plugin_entry_points/arbitrary_package/conf/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/examples/plugins/example_searchpath_plugin_entry_points/arbitrary_package/conf/hydra/output/my_default_output_dir.yaml
+++ b/examples/plugins/example_searchpath_plugin_entry_points/arbitrary_package/conf/hydra/output/my_default_output_dir.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+hydra:
+  run:
+    dir: /tmp/${now:%Y-%m-%d}/${now:%H-%M-%S}

--- a/examples/plugins/example_searchpath_plugin_entry_points/arbitrary_package/example_searchpath_plugin_entry_points.py
+++ b/examples/plugins/example_searchpath_plugin_entry_points/arbitrary_package/example_searchpath_plugin_entry_points.py
@@ -1,0 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from hydra.core.config_search_path import ConfigSearchPath
+from hydra.plugins.search_path_plugin import SearchPathPlugin
+
+
+class ExampleSearchPathPluginEntryPoints(SearchPathPlugin):
+    def manipulate_search_path(self, search_path: ConfigSearchPath) -> None:
+        # Appends the search path for this plugin to the end of the search path
+        # Note that foobar/conf is outside of the example plugin module.
+        # There is no requirement for it to be packaged with the plugin, it just needs
+        # be available in a package.
+        # Remember to verify the config is packaged properly (build sdist and look inside,
+        # and verify MANIFEST.in is correct).
+        search_path.append(
+            provider="example-searchpath-plugin-entry-points", path="pkg://arbitrary_package/conf"
+        )

--- a/examples/plugins/example_searchpath_plugin_entry_points/setup.py
+++ b/examples/plugins/example_searchpath_plugin_entry_points/setup.py
@@ -1,0 +1,44 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+# type: ignore
+from setuptools import find_namespace_packages, setup, find_packages
+
+
+with open("README.md") as fh:
+    LONG_DESC = fh.read()
+    setup(
+        name="hydra-example-searchpath-plugin-entry-points",
+        version="1.0.0",
+        author="Omry Yadan",
+        author_email="omry@fb.com",
+        description="Example Hydra SearchPath plugin",
+        long_description=LONG_DESC,
+        long_description_content_type="text/markdown",
+        url="https://github.com/facebookresearch/hydra/",
+        packages=find_packages(include=["arbitrary_package.*"]),
+        entry_points={
+            'hydra.plugins': [
+                'example-searchpath-plugin-entry-points = arbitrary_package.example_searchpath_plugin_entry_points',
+            ],
+        },
+        classifiers=[
+            # Feel free to use another license.
+            "License :: OSI Approved :: MIT License",
+            # Hydra uses Python version and Operating system to determine
+            # In which environments to test this plugin
+            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
+            "Operating System :: OS Independent",
+        ],
+        install_requires=[
+            # consider pinning to a specific major version of Hydra to avoid unexpected problems
+            # if a new major version of Hydra introduces breaking changes for plugins.
+            # e.g: "hydra-core==1.0.*",
+            "hydra-core",
+        ],
+        # If this plugin is providing configuration files, be sure to include them in the package.
+        # See MANIFEST.in.
+        # For configurations to be discoverable at runtime, they should also be added to the search path.
+        include_package_data=True,
+    )

--- a/examples/plugins/example_searchpath_plugin_entry_points/tests/__init__.py
+++ b/examples/plugins/example_searchpath_plugin_entry_points/tests/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/examples/plugins/example_searchpath_plugin_entry_points/tests/test_example_search_path_plugin_entry_points.py
+++ b/examples/plugins/example_searchpath_plugin_entry_points/tests/test_example_search_path_plugin_entry_points.py
@@ -1,0 +1,25 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from hydra.core.global_hydra import GlobalHydra
+from hydra.core.plugins import Plugins
+from hydra import initialize
+from hydra.plugins.search_path_plugin import SearchPathPlugin
+
+from arbitrary_package.example_searchpath_plugin_entry_points import (
+    ExampleSearchPathPluginEntryPoints,
+)
+
+
+
+def test_discovery() -> None:
+    # Tests that this plugin can be discovered via the plugins subsystem when looking at all Plugins
+    assert ExampleSearchPathPluginEntryPoints.__name__ in [
+        x.__name__ for x in Plugins.instance().discover(SearchPathPlugin)
+    ]
+
+
+def test_config_installed() -> None:
+    with initialize(version_base=None):
+        config_loader = GlobalHydra.instance().config_loader()
+        assert "my_default_output_dir" in config_loader.get_group_options(
+            "hydra/output"
+        )

--- a/news/3052.feature
+++ b/news/3052.feature
@@ -1,0 +1,1 @@
+Support Hydra plugins via Python Entry Points

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,4 @@
 omegaconf>=2.4.0.dev2
 importlib-resources;python_version<'3.9'
+importlib-metadata;python_version<'3.10'
 packaging


### PR DESCRIPTION
## Motivation

Hydra currently uses a shared namespace package to manage plugins.
This is a bit precarious for users, and makes it a bit difficult to grow a plugin ecosystem.

Python already has a mechanism for this, namely [entry points](https://packaging.python.org/en/latest/specifications/entry-points/).
This is used extensively across the ecosystem, including e.g. [airflow](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/plugins.html).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

Added an example plugin which includes tests to validate behavior, existing tests left alone to validate prior behavior.

## Related Issues and PRs
fixes:
https://github.com/facebookresearch/hydra/issues/1554

relates to:
https://github.com/facebookresearch/hydra/issues/3015
https://github.com/facebookresearch/hydra/issues/2359
https://github.com/facebookresearch/hydra/issues/1128
https://github.com/facebookresearch/hydra/issues/1893
https://github.com/facebookresearch/hydra/issues/1880

loosely relates to:
https://github.com/facebookresearch/hydra/issues/3010
https://github.com/facebookresearch/hydra/issues/2835
https://github.com/facebookresearch/hydra/issues/1943