### PR TITLE
Fix CI test failures

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,7 @@ from nox.logger import logger
 
 BASE = os.path.abspath(os.path.dirname(__file__))
 
-DEFAULT_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
+DEFAULT_PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
 DEFAULT_OS_NAMES = ["Linux", "MacOS", "Windows"]
 
 PYTHON_VERSIONS = os.environ.get(
@@ -357,7 +357,7 @@ def lint(session: Session) -> None:
     session.run(*isort, silent=SILENT)
 
     session.run(
-        *_mypy_cmd(strict=True),
+        *_mypy_cmd(python_version=session.python, strict=True),
         ".",
         "--exclude=^examples/",
         "--exclude=^tests/standalone_apps/",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,7 +10,7 @@ mypy==1.8.0
 nox
 packaging
 pre-commit
-pytest
+pytest==8.3.5
 pytest-benchmark
 pytest-snail
 read-version

--- a/tests/instantiate/test_helpers.py
+++ b/tests/instantiate/test_helpers.py
@@ -4,8 +4,11 @@ import re
 from textwrap import dedent
 from typing import Any
 
-from _pytest.python_api import RaisesContext, raises
-from pytest import mark, param
+try:
+    from _pytest.python_api import RaisesContext
+except ImportError:
+    from _pytest.raises import RaisesExc as RaisesContext  # type: ignore
+from pytest import mark, param, raises
 
 from hydra._internal.utils import _locate
 from hydra.utils import get_class, get_method, get_object

--- a/tests/test_examples/test_tutorials_basic.py
+++ b/tests/test_examples/test_tutorials_basic.py
@@ -6,7 +6,10 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any, List
 
-from _pytest.python_api import RaisesContext
+try:
+    from _pytest.python_api import RaisesContext
+except ImportError:
+    from _pytest.raises import RaisesExc as RaisesContext  # type: ignore
 from omegaconf import DictConfig, OmegaConf
 from pytest import mark, raises
 

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -5,7 +5,10 @@ import re
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Union
 
-from _pytest.python_api import RaisesContext
+try:
+    from _pytest.python_api import RaisesContext
+except ImportError:
+    from _pytest.raises import RaisesExc as RaisesContext  # type: ignore
 from pytest import mark, param, raises, warns
 
 from hydra import version

--- a/tools/configen/tests/test_generate.py
+++ b/tools/configen/tests/test_generate.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import os
 import sys
 
 from difflib import unified_diff
@@ -292,7 +293,12 @@ def test_example_application(monkeypatch: Any, tmpdir: Path):
         "hydra.job.chdir=True",
         "user.name=Batman",
     ]
-    result, _err = run_python_script(cmd)
+    python_path = (
+        f"%PYTHONPATH%;{';'.join(sys.path)}"
+        if sys.platform.startswith("win")
+        else f"$PYTHONPATH:{':'.join(sys.path)}"
+    )
+    result, _err = run_python_script(cmd, dict(os.environ, PYTHONPATH=python_path))
     assert result == dedent(
         """\
     User: name=Batman, age=7


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Fixing CI test failures to enable better safety for future PRs

* Fix pytest errors from new version: pytest moved the import path for RaisesContext so uses a try except to check both locations and pins the pytest version to avoid varying mypy lint errors
* Remove python 3.8 from tests since it is EOL is no long included in github action windows environments
* Fix module not found error in test where it seems the python path was not being correctly set up

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

See CI

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
