### PR TITLE
Remove unmaintained pytest-snail dependency

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,7 +12,6 @@ packaging
 pre-commit
 pytest==8.3.5
 pytest-benchmark
-pytest-snail
 read-version
 setuptools
 towncrier


### PR DESCRIPTION
Remove pytest-snail from dev requirements. This plugin is unmaintained and causes deprecation warnings with modern pytest. The @pytest.mark.slow marker it provides is not used anywhere in the codebase.

This is kind of just a test to see if CI is green for me / I can push etc