### PR TITLE
Add support for Python 3.12 - 3.14

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,4 +19,4 @@ max-line-length = 119
 copyright-check = True
 select = E,F,W,C
 copyright-regexp=Copyright \(c\) Facebook, Inc. and its affiliates. All Rights Reserved
-ignore=W503,E203,E231,E701,E704
+ignore=W503,E203,E231,E241,E701,E704

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -45,6 +45,8 @@ jobs:
   test_linux:
     runs-on: ubuntu-latest
     strategy:
+      # TODO: Re-enable fail-fast before merging - currently disabled to see all test failures
+      fail-fast: false
       matrix:
         py_version:
           - '3.9'
@@ -90,6 +92,8 @@ jobs:
   test_linux_omc_dev:
     runs-on: ubuntu-latest
     strategy:
+      # TODO: Re-enable fail-fast before merging - currently disabled to see all test failures
+      fail-fast: false
       matrix:
         py_version:
           - '3.9'

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -26,6 +26,9 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
+          - '3.13'
+          - '3.14'
     steps:
       - uses: actions/checkout@v4.1.0
       - uses: "./.github/actions/macos"
@@ -47,6 +50,9 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
+          - '3.13'
+          - '3.14'
     steps:
       - uses: actions/checkout@v4.1.0
       - uses: "./.github/actions/linux"
@@ -67,6 +73,9 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
+          - '3.13'
+          - '3.14'
     steps:
       - uses: actions/checkout@v4.1.0
       - uses: "./.github/actions/windows"
@@ -86,6 +95,9 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
+          - '3.13'
+          - '3.14'
     steps:
       - uses: actions/checkout@v4.1.0
       - uses: "./.github/actions/linux"

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -45,8 +45,6 @@ jobs:
   test_linux:
     runs-on: ubuntu-latest
     strategy:
-      # TODO: Re-enable fail-fast before merging - currently disabled to see all test failures
-      fail-fast: false
       matrix:
         py_version:
           - '3.9'
@@ -92,8 +90,6 @@ jobs:
   test_linux_omc_dev:
     runs-on: ubuntu-latest
     strategy:
-      # TODO: Re-enable fail-fast before merging - currently disabled to see all test failures
-      fail-fast: false
       matrix:
         py_version:
           - '3.9'

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ pip-wheel-metadata
 /.dmypy.json
 TODO.txt
 /venv
+/.venv

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -544,12 +544,28 @@ def get_args_parser() -> argparse.ArgumentParser:
         def __repr__(self) -> str:
             return f"Install or Uninstall shell completion:\n{_get_completion_help()}"
 
-    parser.add_argument(
-        "--shell-completion",
-        "-sc",
-        action="store_true",
-        help=LazyCompletionHelp(),  # type: ignore
-    )
+    if sys.version_info >= (3, 14):
+        original_check_help = argparse.ArgumentParser._check_help  # type: ignore
+        argparse.ArgumentParser._check_help = (  # type: ignore
+            lambda self, action: None
+        )
+        try:
+            parser.add_argument(
+                "--shell-completion",
+                "-sc",
+                action="store_true",
+                help=LazyCompletionHelp(),  # type: ignore
+            )
+        finally:
+            # Immediately restore normal validation
+            argparse.ArgumentParser._check_help = original_check_help  # type: ignore
+    else:
+        parser.add_argument(
+            "--shell-completion",
+            "-sc",
+            action="store_true",
+            help=LazyCompletionHelp(),  # type: ignore
+        )
 
     parser.add_argument(
         "--config-path",

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -545,6 +545,13 @@ def get_args_parser() -> argparse.ArgumentParser:
             return f"Install or Uninstall shell completion:\n{_get_completion_help()}"
 
     if sys.version_info >= (3, 14):
+        # Python 3.14+ adds help message validation via ArgumentParser._check_help,
+        # which calls formatter._expand_help(action) to validate that action.help
+        # is a string that can be used in string formatting (e.g., "text %(prog)s").
+        # This breaks our LazyCompletionHelp because `_expand_help` expects an actual
+        # string.
+        # It is safe to disable this validation temporarily because LazyCompletionHelp.
+        # __repr__() returns a plain string (no % formatting)
         original_check_help = argparse.ArgumentParser._check_help  # type: ignore
         argparse.ArgumentParser._check_help = (  # type: ignore
             lambda self, action: None

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,7 @@ from nox.logger import logger
 
 BASE = os.path.abspath(os.path.dirname(__file__))
 
-DEFAULT_PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
+DEFAULT_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 DEFAULT_OS_NAMES = ["Linux", "MacOS", "Windows"]
 
 PYTHON_VERSIONS = os.environ.get(

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -366,14 +366,20 @@ def test_missing_init_py_error(hydra_restore_singletons: Any) -> None:
 
 
 def test_missing_bad_config_dir_error(hydra_restore_singletons: Any) -> None:
+    # Use a platform-appropriate absolute path that doesn't exist
+    if sys.platform == "win32":
+        bad_dir = "C:\\no_way_in_hell_1234567890"
+    else:
+        bad_dir = "/no_way_in_hell_1234567890"
+
     expected = (
         "Primary config directory not found."
-        "\nCheck that the config directory '/no_way_in_hell_1234567890' exists and readable"
+        f"\nCheck that the config directory '{bad_dir}' exists and readable"
     )
 
     with raises(Exception, match=re.escape(expected)):
         with initialize_config_dir(
-            config_dir="/no_way_in_hell_1234567890",
+            config_dir=bad_dir,
             version_base=None,
         ):
             hydra = GlobalHydra.instance().hydra

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1588,7 +1588,7 @@ def test_frozen_primary_config(
                 ^Error executing job with overrides: \[\]\n?
                 Traceback \(most recent call last\):
                   File "\S*[/\\]my_app.py", line 10, in my_app
-                    deprecation_warning\("Feature FooBar is deprecated"\)
+                    deprecation_warning\("Feature FooBar is deprecated"\)(\n    ~~~+\^+)?
                   File "\S*\.py", line 11, in deprecation_warning
                     raise HydraDeprecationError\(.*\)
                 hydra\.errors\.HydraDeprecationError: Feature FooBar is deprecated

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1296,21 +1296,21 @@ def test_app_with_error_exception_sanitized(tmpdir: Any, monkeypatch: Any) -> No
         r"" if sys.version_info != (3, 12) else r". Did you mean: '_return_value'\?"
     )
 
-    # Python 3.13 changed the traceback format for error indicators
-    first_traceback_line = r"foo\(cfg\)"
+    traceback_line = r"foo\(cfg\)"
 
     if sys.version_info >= (3, 13):
-        first_traceback_line += r"\n    ~~~\^\^+\^+"
+        # Python 3.13 changed the traceback format for error indicators
+        traceback_line += r"\n    ~~~\^\^+\^+"
 
     expected_regex = dedent(
         rf"""
         Error executing job with overrides: \[\]
         Traceback \(most recent call last\):
           File ".*my_app\.py", line 13, in my_app
-            {first_traceback_line}
+            {traceback_line}
           File ".*my_app\.py", line 8, in foo
-            cfg\.foo = "bar"  # does not exist in the config
-            \^+
+            cfg\.foo = "bar"  # does not exist in the config(
+            \^+)?
         omegaconf\.errors\.ConfigAttributeError: Key 'foo' is not in struct
             full_key: foo
             object_type=dict{suggestion_suffix}

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1292,7 +1292,7 @@ def test_app_with_error_exception_sanitized(tmpdir: Any, monkeypatch: Any) -> No
     # names for AttributeError. Unfortunately, it suggests private attributes like
     # '_return_value'
     # Python 3.13+ fixes this by not suggesting private attributes.
-    if sys.version_info >= (3, 12) and sys.version_info < (3, 13):
+    if sys.version_info[:2] == (3, 12):
         suggestion_suffix = r". Did you mean: '_return_value'\?"
     else:
         suggestion_suffix = r""

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1287,8 +1287,18 @@ def test_app_with_error_exception_sanitized(tmpdir: Any, monkeypatch: Any) -> No
         f"hydra.sweep.dir={tmpdir}",
         "hydra.job.chdir=True",
     ]
+
+    # Python 3.12 introduced enhanced error messages that suggest similar attribute
+    # names for AttributeError. Unfortunately, it suggests private attributes like
+    # '_return_value'
+    # Python 3.13+ fixes this by not suggesting private attributes.
+    if sys.version_info >= (3, 12) and sys.version_info < (3, 13):
+        suggestion_suffix = r". Did you mean: '_return_value'\?"
+    else:
+        suggestion_suffix = r""
+
     expected_regex = dedent(
-        r"""
+        rf"""
         Error executing job with overrides: \[\]
         Traceback \(most recent call last\):
           File ".*my_app\.py", line 13, in my_app
@@ -1298,7 +1308,7 @@ def test_app_with_error_exception_sanitized(tmpdir: Any, monkeypatch: Any) -> No
             \^+)?
         omegaconf\.errors\.ConfigAttributeError: Key 'foo' is not in struct
             full_key: foo
-            object_type=dict
+            object_type=dict{suggestion_suffix}
 
         Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.
         """

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1292,20 +1292,25 @@ def test_app_with_error_exception_sanitized(tmpdir: Any, monkeypatch: Any) -> No
     # names for AttributeError. Unfortunately, it suggests private attributes like
     # '_return_value'
     # Python 3.13+ fixes this by not suggesting private attributes.
-    if sys.version_info >= (3, 12) and sys.version_info < (3, 13):
-        suggestion_suffix = r". Did you mean: '_return_value'\?"
-    else:
-        suggestion_suffix = r""
+    suggestion_suffix = (
+        r"" if sys.version_info != (3, 12) else r". Did you mean: '_return_value'\?"
+    )
+
+    # Python 3.13 changed the traceback format for error indicators
+    first_traceback_line = r"foo\(cfg\)"
+
+    if sys.version_info >= (3, 13):
+        first_traceback_line += r"\n    ~~~\^\^+\^+"
 
     expected_regex = dedent(
         rf"""
         Error executing job with overrides: \[\]
         Traceback \(most recent call last\):
           File ".*my_app\.py", line 13, in my_app
-            foo\(cfg\)
+            {first_traceback_line}
           File ".*my_app\.py", line 8, in foo
-            cfg\.foo = "bar"  # does not exist in the config(
-            \^+)?
+            cfg\.foo = "bar"  # does not exist in the config
+            \^+
         omegaconf\.errors\.ConfigAttributeError: Key 'foo' is not in struct
             full_key: foo
             object_type=dict{suggestion_suffix}

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1293,7 +1293,7 @@ def test_app_with_error_exception_sanitized(tmpdir: Any, monkeypatch: Any) -> No
     # '_return_value'
     # Python 3.13+ fixes this by not suggesting private attributes.
     suggestion_suffix = (
-        r"" if sys.version_info != (3, 12) else r". Did you mean: '_return_value'\?"
+        r"" if sys.version_info != (3, 12) else r". Did you mean: '_return_value'\?"  # type: ignore
     )
 
     traceback_line = r"foo\(cfg\)"

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1588,7 +1588,7 @@ def test_frozen_primary_config(
                 ^Error executing job with overrides: \[\]\n?
                 Traceback \(most recent call last\):
                   File "\S*[/\\]my_app.py", line 10, in my_app
-                    deprecation_warning\("Feature FooBar is deprecated"\)(\n    ~~~+\^+)?
+                    deprecation_warning\("Feature FooBar is deprecated"\)(\n    [~\^]+)?
                   File "\S*\.py", line 11, in deprecation_warning
                     raise HydraDeprecationError\(.*\)
                 hydra\.errors\.HydraDeprecationError: Feature FooBar is deprecated

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -841,6 +841,24 @@ def test_help(
     assert_text_same(result, expected.format(script=script))
 
 
+def test_shell_completion_help(tmpdir: Path) -> None:
+    """Test that --shell-completion --help works (regression test for Python 3.14+ argparse)."""
+    # This test ensures that the LazyCompletionHelp workaround in utils.py works correctly
+    # In Python 3.14+, argparse validates that help is a string, but we use a lazy callable
+    # The workaround temporarily disables _check_help validation
+    cmd = [
+        "examples/tutorials/basic/your_first_hydra_app/1_simple_cli/my_app.py",
+        f'hydra.run.dir="{str(tmpdir)}"',
+        "hydra.job.chdir=True",
+        "--shell-completion",
+        "--help",
+    ]
+    result, _err = run_python_script(cmd)
+    # When both flags are present, --help takes precedence and shows help text
+    assert "powered by hydra" in result.lower()
+    assert not _err
+
+
 @mark.parametrize(
     "overrides,expected",
     [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -233,7 +233,7 @@ class TestRunAndReport:
                     r"""
                     Traceback \(most recent call last\):
                       File "[^"]+", line \d+, in job_calling_omconf
-                        OmegaConf.resolve\(123\)  # type: ignore(\n    ~~~+\^+)?
+                        OmegaConf.resolve\(123\)  # type: ignore(\n    [~\^]+)?
                     ValueError: Invalid config type \(int\), expected an OmegaConf Container
 
                     Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -233,8 +233,7 @@ class TestRunAndReport:
                     r"""
                     Traceback \(most recent call last\):
                       File "[^"]+", line \d+, in job_calling_omconf
-                        OmegaConf.resolve\(123\)  # type: ignore(
-                        \^+)?
+                        OmegaConf.resolve\(123\)  # type: ignore(\n    ~~~+\^+)?
                     ValueError: Invalid config type \(int\), expected an OmegaConf Container
 
                     Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.


### PR DESCRIPTION
Stacked on top of https://github.com/facebookresearch/hydra/pull/3089

The majority of changes are trivial test updates. An additional hack is needed to continue to support `LazyCompletionHelp` -- temporarily disabling `argparse.ArgumentParser._check_help` -- but this is pretty benign and we add a test to ensure that things still work.