### PR TITLE
Add pypi publish workflows, using trusted publishers

### DIFF
--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,0 +1,72 @@
+# This workflow uploads Hydra to Test PyPI using Trusted Publishers
+# Basics: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+# Security model: https://docs.pypi.org/trusted-publishers/security-model/
+name: Publish to Test PyPI
+
+on:
+  workflow_dispatch:  # Manual trigger for testing releases
+
+# Use separate jobs for building and publishing so that write
+# permissions are only accessible minimally.
+#
+# Both jobs are run under the test-pypi-publish environment,
+# which is configured to require review and approval from authorized
+# maintainers.
+jobs:
+  build-artifacts:
+    name: Build distribution artifacts
+    runs-on: ubuntu-latest
+    environment: test-pypi-publish
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+
+    - name: Set up Java
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build distribution
+      run: python -m build
+
+    - name: Verify build artifacts
+      run: |
+        ls -lah dist/
+        python -m pip install twine
+        twine check dist/*
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: dist/
+        retention-days: 0
+
+  test-pypi-publish:
+    needs: build-artifacts
+    name: Upload release to Test PyPI
+    runs-on: ubuntu-latest
+    environment: test-pypi-publish
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v5
+      with:
+        name: dist
+        path: dist/
+
+    - name: Publish package distributions to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,71 @@
+# This workflow uploads Hydra to PyPI using Trusted Publishers
+# Basics: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+# Security model: https://docs.pypi.org/trusted-publishers/security-model/
+name: Publish to PyPI
+
+on:
+  release:
+    types: [created]
+
+# Use separate jobs for building and publishing so that write
+# permissions are only accessible minimally.
+#
+# Both jobs are run under the pypi-publish environment,
+# which is configured to require review and approval from authorized
+# maintainers.
+jobs:
+  build-artifacts:
+    name: Build distribution artifacts
+    runs-on: ubuntu-latest
+    environment: pypi-publish
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+
+    - name: Set up Java
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build distribution
+      run: python -m build
+
+    - name: Verify build artifacts
+      run: |
+        ls -lah dist/
+        python -m pip install twine
+        twine check dist/*
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: dist/
+        retention-days: 0
+
+  pypi-publish:
+    needs: build-artifacts
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi-publish
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v5
+      with:
+        name: dist
+        path: dist/
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Add Automated PyPI Publishing with GitHub Actions

## What This Does

This PR replaces the manual twine upload release process with automated GitHub Actions workflows. When you create a GitHub release, the package is automatically built and published to PyPI—no API tokens needed, no local setup required.

### One-Time Setup (for maintainers)

1. Configure PyPI Trusted Publisher (5 minutes, project owner only)
- Go to https://pypi.org/manage/project/hydra-core/settings/publishing/     
- Click "Add a new publisher"
- Fill in:
  - PyPI Project Name: hydra-core
  - Owner: facebookresearch (the GitHub organization)
  - Repository name: hydra
  - Workflow filename: publish.yml
  - Environment name: pypi-publish
- Save

2. Set up GitHub Environment Protection
- Go to Repository Settings → Environments
- Create environment named pypi-publish
- Add protection rules:
  - ✓ Required reviewers (add trusted maintainers)
  - This ensures releases require explicit approval before publishing       

3. Repeat for TestPyPI (for testing releases)
- Go to https://test.pypi.org/manage/project/hydra-core/settings/publishing/
- Same settings as above, but use:
  - Workflow filename: publish-test.yml
  - Environment name: test-pypi-publish
- Create a corresponding test-pypi-publish environment in GitHub

That's it! Setup is complete. Once this is done, you can also delete any additional auth tokens that you have generated for this PyPI project. You can also remove access to
  the PyPI project for non-active/less-trusted maintainers and instead make people workflow approvers, which is lower-trust.

## How Releases Work Now

Normal Release to PyPI:

1. Update `hydra/__init__.py` with new version
2. Update `NEWS.md` (run `towncrier build --version X.Y.Z`)
3. Commit and push to main branch
4. Go to https://github.com/facebookresearch/hydra/releases/new
5. Create a new tag (e.g., v1.4.0) and publish the release
6. That's it! GitHub Actions automatically:
  - Builds the package (with Java/ANTLR setup)
  - Verifies artifacts with twine check
  - Waits for maintainer approval (if environment protection is enabled)    
  - Publishes to PyPI

Testing a Release (using TestPyPI):
- Go to Actions tab → "Publish to Test PyPI" → Click "Run workflow"

### What Changed

Before:
- Maintainer runs python `setup.py sdist bdist_wheel` locally
- Maintainer runs twine upload `dist/*` with stored API token
- Risk of token leakage, inconsistent build environments

After:
- GitHub Actions builds everything in a clean environment
- No API tokens—uses secure OIDC authentication
- Approval gate before publishing
- TestPyPI workflow for validating releases