### PR TITLE
make multirun behaves more like run

### DIFF
--- a/hydra/_internal/core_plugins/basic_sweeper.py
+++ b/hydra/_internal/core_plugins/basic_sweeper.py
@@ -108,12 +108,15 @@ class BasicSweeper(Sweeper):
 
         def check_primitive(x: Any) -> bool:
             return isinstance(x, (int, float, bool)) or isinstance(x, QuotedString)
+
         for i, override in enumerate(overrides):
             if override.is_sweep_override():
                 if override.is_discrete_sweep():
                     key = override.get_key_element()
                     is_primitive[i] = all(override.sweep_iterator(check_primitive))
-                    is_dict[i] = any(override.sweep_iterator(lambda x: isinstance(x, dict)))
+                    is_dict[i] = any(
+                        override.sweep_iterator(lambda x: isinstance(x, dict))
+                    )
                     if is_primitive[i]:
                         last_primitive[key] = i
                     if is_dict[i]:
@@ -129,7 +132,9 @@ class BasicSweeper(Sweeper):
 
         for i, override in enumerate(overrides):
             key = override.get_key_element()
-            if is_primitive.get(i, False) and (last_primitive.get(key, -1) != i or last_dict.get(key, -1) > i):
+            if is_primitive.get(i, False) and (
+                last_primitive.get(key, -1) != i or last_dict.get(key, -1) > i
+            ):
                 continue
             if is_dict.get(i, False) and last_primitive.get(key, -1) > i:
                 continue

--- a/hydra/_internal/core_plugins/basic_sweeper.py
+++ b/hydra/_internal/core_plugins/basic_sweeper.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 from omegaconf import DictConfig, OmegaConf
+from omegaconf._utils import is_structured_config
 
 from hydra.core.config_store import ConfigStore
 from hydra.core.override_parser.overrides_parser import OverridesParser
@@ -97,38 +98,57 @@ class BasicSweeper(Sweeper):
     def simplify_overrides(
         overrides: List[Override],
     ) -> List[Override]:
+        # this would simplify the overrides by removing those that are overridden later
+        # in the list.
+        # e.g. a=1 and later a=10 would remove the first override.
         lists = []
         # NOTE: key -> index of last override with no dict value. (e.g. a=1,2,3)
         # any override for key before this would be skipped.
         last_primitive = {}
         last_dict = {}
-        # track if a key ends up to be a dict override
-        is_primitive = {}
-        is_dict = {}
+        last_defaults: Dict[str, int] = {}
 
-        def check_primitive(x: Any) -> bool:
-            return isinstance(x, (int, float, bool)) or isinstance(x, QuotedString)
+        is_defaults: Dict[int, bool] = {}
+        is_primitive: Dict[int, bool] = {}
+        has_dict: Dict[int, bool] = {}
+
+        # check value should override earlier ones
+        # TODO: handle extend_list
+        def check_write_override(x: Any):
+            return (
+                isinstance(x, (str, int, float, bool, list, QuotedString)) or x is None
+            )
+
+        def check_has_dict(x: Any):
+            return isinstance(x, dict) or is_structured_config(x)
 
         for i, override in enumerate(overrides):
+            if override.config_loader is None:
+                continue
+            is_group = len(override.config_loader.get_group_options(override.key_or_group)) > 0
+
+            key = override.get_key_element()
+            _write = False
+            _has_dict = False
             if override.is_sweep_override():
                 if override.is_discrete_sweep():
-                    key = override.get_key_element()
-                    is_primitive[i] = all(override.sweep_iterator(check_primitive))
-                    is_dict[i] = any(
-                        override.sweep_iterator(lambda x: isinstance(x, dict))
-                    )
-                    if is_primitive[i]:
-                        last_primitive[key] = i
-                    if is_dict[i]:
-                        last_dict[key] = i
+                    _write = all(override.sweep_iterator(check_write_override))
+                    _has_dict = any(override.sweep_iterator(check_has_dict))
             else:
-                key = override.get_key_element()
-                is_primitive[i] = check_primitive(override.value())
-                is_dict[i] = isinstance(override.value(), dict)
-                if is_primitive[i]:
+                _write = check_write_override(override.value())
+                _has_dict = check_has_dict(override.value())
+
+            if _write:
+                if is_group:
+                    is_defaults[i] = True
+                    if override.is_change():
+                        last_defaults[key] = i
+                else:
+                    is_primitive[i] = True
                     last_primitive[key] = i
-                if is_dict[i]:
-                    last_dict[key] = i
+            if _has_dict:
+                has_dict[i] = True
+                last_dict[key] = i
 
         for i, override in enumerate(overrides):
             key = override.get_key_element()
@@ -136,7 +156,9 @@ class BasicSweeper(Sweeper):
                 last_primitive.get(key, -1) != i or last_dict.get(key, -1) > i
             ):
                 continue
-            if is_dict.get(i, False) and last_primitive.get(key, -1) > i:
+            if has_dict.get(i, False) and last_primitive.get(key, -1) > i:
+                continue
+            if is_defaults.get(i, False) and last_defaults.get(key, -1) > i:
                 continue
             lists.append(override)
 

--- a/hydra/_internal/core_plugins/basic_sweeper.py
+++ b/hydra/_internal/core_plugins/basic_sweeper.py
@@ -108,13 +108,22 @@ class BasicSweeper(Sweeper):
         overrides: List[Override], max_batch_size: Optional[int]
     ) -> List[List[List[str]]]:
         lists = []
-        final_overrides = OrderedDict()
-        for override in overrides:
+        # NOTE: key -> index of last override with no dict value. (e.g. a=1,2,3)
+        # any override for key before this would be skipped.
+        skip_to = {}
+        # track if a key ends up to be a dict override
+        contains_dict = {}
+        list_overrides = []
+        for i, override in enumerate(overrides):
             if override.is_sweep_override():
                 if override.is_discrete_sweep():
                     key = override.get_key_element()
                     sweep = [f"{key}={val}" for val in override.sweep_string_iterator()]
-                    final_overrides[key] = sweep
+                    has_dict = any(override.sweep_iterator(lambda x: isinstance(x, dict)))
+                    if not has_dict:
+                        skip_to[key] = i
+                    contains_dict[key] = has_dict
+                    list_overrides.append((key, sweep))
                 else:
                     assert override.value_type is not None
                     raise HydraException(
@@ -123,11 +132,16 @@ class BasicSweeper(Sweeper):
             else:
                 key = override.get_key_element()
                 value = override.get_value_element_as_str()
-                final_overrides[key] = [f"{key}={value}"]
+                has_dict = isinstance(override.value(), dict)
+                if not has_dict:
+                    skip_to[key] = i
+                contains_dict[key] = has_dict
+                list_overrides.append((key, [f"{key}={value}"]))
 
-        for _, v in final_overrides.items():
-            lists.append(v)
-
+        for i, (k, v) in enumerate(list_overrides):
+            s = skip_to.get(k, -1)
+            if i > s or (i == s and not contains_dict[k]):
+                lists.append(v)
         all_batches = [list(x) for x in itertools.product(*lists)]
         assert max_batch_size is None or max_batch_size > 0
         if max_batch_size is None:

--- a/hydra/_internal/core_plugins/basic_sweeper.py
+++ b/hydra/_internal/core_plugins/basic_sweeper.py
@@ -125,7 +125,9 @@ class BasicSweeper(Sweeper):
         for i, override in enumerate(overrides):
             if override.config_loader is None:
                 continue
-            is_group = len(override.config_loader.get_group_options(override.key_or_group)) > 0
+            is_group = (
+                len(override.config_loader.get_group_options(override.key_or_group)) > 0
+            )
 
             key = override.get_key_element()
             _write = False

--- a/hydra/_internal/core_plugins/basic_sweeper.py
+++ b/hydra/_internal/core_plugins/basic_sweeper.py
@@ -28,7 +28,7 @@ from omegaconf import DictConfig, OmegaConf
 
 from hydra.core.config_store import ConfigStore
 from hydra.core.override_parser.overrides_parser import OverridesParser
-from hydra.core.override_parser.types import Override
+from hydra.core.override_parser.types import Override, QuotedString
 from hydra.core.utils import JobReturn
 from hydra.errors import HydraException
 from hydra.plugins.launcher import Launcher
@@ -94,6 +94,50 @@ class BasicSweeper(Sweeper):
         )
 
     @staticmethod
+    def simplify_overrides(
+        overrides: List[Override],
+    ) -> List[Override]:
+        lists = []
+        # NOTE: key -> index of last override with no dict value. (e.g. a=1,2,3)
+        # any override for key before this would be skipped.
+        last_primitive = {}
+        last_dict = {}
+        # track if a key ends up to be a dict override
+        is_primitive = {}
+        is_dict = {}
+
+        def check_primitive(x: Any) -> bool:
+            return isinstance(x, (int, float, bool)) or isinstance(x, QuotedString)
+        for i, override in enumerate(overrides):
+            if override.is_sweep_override():
+                if override.is_discrete_sweep():
+                    key = override.get_key_element()
+                    is_primitive[i] = all(override.sweep_iterator(check_primitive))
+                    is_dict[i] = any(override.sweep_iterator(lambda x: isinstance(x, dict)))
+                    if is_primitive[i]:
+                        last_primitive[key] = i
+                    if is_dict[i]:
+                        last_dict[key] = i
+            else:
+                key = override.get_key_element()
+                is_primitive[i] = check_primitive(override.value())
+                is_dict[i] = isinstance(override.value(), dict)
+                if is_primitive[i]:
+                    last_primitive[key] = i
+                if is_dict[i]:
+                    last_dict[key] = i
+
+        for i, override in enumerate(overrides):
+            key = override.get_key_element()
+            if is_primitive.get(i, False) and (last_primitive.get(key, -1) != i or last_dict.get(key, -1) > i):
+                continue
+            if is_dict.get(i, False) and last_primitive.get(key, -1) > i:
+                continue
+            lists.append(override)
+
+        return lists
+
+    @staticmethod
     def split_overrides_to_chunks(
         lst: List[List[str]], n: Optional[int]
     ) -> Iterable[List[List[str]]]:
@@ -108,22 +152,13 @@ class BasicSweeper(Sweeper):
         overrides: List[Override], max_batch_size: Optional[int]
     ) -> List[List[List[str]]]:
         lists = []
-        # NOTE: key -> index of last override with no dict value. (e.g. a=1,2,3)
-        # any override for key before this would be skipped.
-        skip_to = {}
-        # track if a key ends up to be a dict override
-        contains_dict = {}
-        list_overrides = []
-        for i, override in enumerate(overrides):
+        overrides = BasicSweeper.simplify_overrides(overrides)
+        for override in overrides:
             if override.is_sweep_override():
                 if override.is_discrete_sweep():
                     key = override.get_key_element()
                     sweep = [f"{key}={val}" for val in override.sweep_string_iterator()]
-                    has_dict = any(override.sweep_iterator(lambda x: isinstance(x, dict)))
-                    if not has_dict:
-                        skip_to[key] = i
-                    contains_dict[key] = has_dict
-                    list_overrides.append((key, sweep))
+                    lists.append(sweep)
                 else:
                     assert override.value_type is not None
                     raise HydraException(
@@ -132,16 +167,8 @@ class BasicSweeper(Sweeper):
             else:
                 key = override.get_key_element()
                 value = override.get_value_element_as_str()
-                has_dict = isinstance(override.value(), dict)
-                if not has_dict:
-                    skip_to[key] = i
-                contains_dict[key] = has_dict
-                list_overrides.append((key, [f"{key}={value}"]))
+                lists.append([f"{key}={value}"])
 
-        for i, (k, v) in enumerate(list_overrides):
-            s = skip_to.get(k, -1)
-            if i > s or (i == s and not contains_dict[k]):
-                lists.append(v)
         all_batches = [list(x) for x in itertools.product(*lists)]
         assert max_batch_size is None or max_batch_size > 0
         if max_batch_size is None:

--- a/hydra/core/override_parser/types.py
+++ b/hydra/core/override_parser/types.py
@@ -274,6 +274,12 @@ class Override:
     # Configs repo
     config_loader: Optional[ConfigLoader] = None
 
+    def is_change(self) -> bool:
+        """
+        :return: True if this override represents a change of a config value or config group option
+        """
+        return self.type == OverrideType.CHANGE
+
     def is_delete(self) -> bool:
         """
         :return: True if this override represents a deletion of a config value or config group option

--- a/tests/test_basic_sweeper.py
+++ b/tests/test_basic_sweeper.py
@@ -48,6 +48,26 @@ from hydra.test_utils.test_utils import assert_multiline_regex_search, run_proce
         ),
         param(["a=range(0,3)"], None, [[["a=0"], ["a=1"], ["a=2"]]], id="range"),
         param(["a=range(3)"], None, [[["a=0"], ["a=1"], ["a=2"]]], id="range_no_start"),
+        param(["a=1,2,3", "a=20"], None, [[["a=20"]]], id="override_same_key1"),
+        param(["a=2", "a=10,20"], None, [[["a=10"], ["a=20"]]], id="override_same_key2"),
+        param(["a=1,2,3", "a=10,20"], None, [[["a=10"], ["a=20"]]], id="override_same_key3"),
+        param(["a={x:1},{x:2}"], None, [[["a={x:1}"], ["a={x:2}"]]], id="dicts"),
+        param(
+            ["a={x:1},{x:2}", "+a={y:10},{y:20}"],
+            None,
+            [[["a={x:1}", "+a={y:10}"], ["a={x:1}", "+a={y:20}"], ["a={x:2}", "+a={y:10}"], ["a={x:2}", "+a={y:20}"]]],
+            id="dicts_multiple_with_plus",
+        ),
+        param(
+            ["a={x:1},{x:2}", "a={y:10},{y:20}"],
+            None,
+            [[["a={x:1}", "a={y:10}"], ["a={x:1}", "a={y:20}"], ["a={x:2}", "a={y:10}"], ["a={x:2}", "a={y:20}"]]],
+            id="dicts_multiple",
+        ),
+        param(["a=1,2,3", "a={x:1}"], None, [[["a={x:1}"]]], id="override_with_dict1"),
+        param(["a=1,2,3", "a={x:1},{x:2}"], None, [[["a={x:1}"], ["a={x:2}"]]], id="override_with_dict2"),
+        param(["a={x:1}", "a=1,2,3"], None, [[["a=1"], ["a=2"], ["a=3"]]], id="override_with_dict3"),
+        param(["a={x:1},{x:2}", "a=1"], None, [[["a=1"]]], id="override_with_dict4"),
     ],
 )
 def test_split(

--- a/tests/test_basic_sweeper.py
+++ b/tests/test_basic_sweeper.py
@@ -49,24 +49,55 @@ from hydra.test_utils.test_utils import assert_multiline_regex_search, run_proce
         param(["a=range(0,3)"], None, [[["a=0"], ["a=1"], ["a=2"]]], id="range"),
         param(["a=range(3)"], None, [[["a=0"], ["a=1"], ["a=2"]]], id="range_no_start"),
         param(["a=1,2,3", "a=20"], None, [[["a=20"]]], id="override_same_key1"),
-        param(["a=2", "a=10,20"], None, [[["a=10"], ["a=20"]]], id="override_same_key2"),
-        param(["a=1,2,3", "a=10,20"], None, [[["a=10"], ["a=20"]]], id="override_same_key3"),
+        param(
+            ["a=2", "a=10,20"], None, [[["a=10"], ["a=20"]]], id="override_same_key2"
+        ),
+        param(
+            ["a=1,2,3", "a=10,20"],
+            None,
+            [[["a=10"], ["a=20"]]],
+            id="override_same_key3",
+        ),
         param(["a={x:1},{x:2}"], None, [[["a={x:1}"], ["a={x:2}"]]], id="dicts"),
         param(
             ["a={x:1},{x:2}", "+a={y:10},{y:20}"],
             None,
-            [[["a={x:1}", "+a={y:10}"], ["a={x:1}", "+a={y:20}"], ["a={x:2}", "+a={y:10}"], ["a={x:2}", "+a={y:20}"]]],
+            [
+                [
+                    ["a={x:1}", "+a={y:10}"],
+                    ["a={x:1}", "+a={y:20}"],
+                    ["a={x:2}", "+a={y:10}"],
+                    ["a={x:2}", "+a={y:20}"],
+                ]
+            ],
             id="dicts_multiple_with_plus",
         ),
         param(
             ["a={x:1},{x:2}", "a={y:10},{y:20}"],
             None,
-            [[["a={x:1}", "a={y:10}"], ["a={x:1}", "a={y:20}"], ["a={x:2}", "a={y:10}"], ["a={x:2}", "a={y:20}"]]],
+            [
+                [
+                    ["a={x:1}", "a={y:10}"],
+                    ["a={x:1}", "a={y:20}"],
+                    ["a={x:2}", "a={y:10}"],
+                    ["a={x:2}", "a={y:20}"],
+                ]
+            ],
             id="dicts_multiple",
         ),
         param(["a=1,2,3", "a={x:1}"], None, [[["a={x:1}"]]], id="override_with_dict1"),
-        param(["a=1,2,3", "a={x:1},{x:2}"], None, [[["a={x:1}"], ["a={x:2}"]]], id="override_with_dict2"),
-        param(["a={x:1}", "a=1,2,3"], None, [[["a=1"], ["a=2"], ["a=3"]]], id="override_with_dict3"),
+        param(
+            ["a=1,2,3", "a={x:1},{x:2}"],
+            None,
+            [[["a={x:1}"], ["a={x:2}"]]],
+            id="override_with_dict2",
+        ),
+        param(
+            ["a={x:1}", "a=1,2,3"],
+            None,
+            [[["a=1"], ["a=2"], ["a=3"]]],
+            id="override_with_dict3",
+        ),
         param(["a={x:1},{x:2}", "a=1"], None, [[["a=1"]]], id="override_with_dict4"),
     ],
 )
@@ -80,22 +111,35 @@ def test_split(
     lret = [list(x) for x in ret]
     assert lret == expected
 
+
 @mark.parametrize(
     "args,expected",
     [
         param(["a=1", "b=2", "a=3"], ["b=2", "a=3"], id="simple_override"),
         param(["a=1,2", "a=3,4"], ["a=3,4"], id="override_split"),
-        param(["a=1", "b=2", "+a={x:10}", "+a={y:20}"], ["a=1", "b=2", "+a={x:10}", "+a={y:20}"], id="override_plus"),
-        param(["a=1", "b=2", "a={x:10}", "a={y:20}"], ["b=2", "a={x:10}", "a={y:20}"], id="override_plus"),
+        param(
+            ["a=1", "b=2", "+a={x:10}", "+a={y:20}"],
+            ["a=1", "b=2", "+a={x:10}", "+a={y:20}"],
+            id="override_plus",
+        ),
+        param(
+            ["a=1", "b=2", "a={x:10}", "a={y:20}"],
+            ["b=2", "a={x:10}", "a={y:20}"],
+            id="override_plus",
+        ),
         param(["a={x:1}", "a={y:2}"], ["a={x:1}", "a={y:2}"], id="override_dict"),
-        param(["a=1,2", "+a={x:10},{y:20}", "a=3,4"], ["+a={x:10},{y:20}", "a=3,4"], id="override_mixed"),
+        param(
+            ["a=1,2", "+a={x:10},{y:20}", "a=3,4"],
+            ["+a={x:10},{y:20}", "a=3,4"],
+            id="override_mixed",
+        ),
         param(["a=1,2", "a={x:10},{y:20}", "a=3,4"], ["a=3,4"], id="override_mixed"),
-        param(["+a=xx,yy", "+a=[zz]"], ["+a=xx,yy", "+a=[zz]"], id="override_plus_list"),
-    ]
+        param(
+            ["+a=xx,yy", "+a=[zz]"], ["+a=xx,yy", "+a=[zz]"], id="override_plus_list"
+        ),
+    ],
 )
-def test_simplify(
-    args: List[str], expected: List[str]
-) -> None:
+def test_simplify(args: List[str], expected: List[str]) -> None:
     parser = OverridesParser.create()
     overrides = parser.parse_overrides(args)
     simplified = BasicSweeper.simplify_overrides(overrides)

--- a/tests/test_basic_sweeper.py
+++ b/tests/test_basic_sweeper.py
@@ -6,7 +6,9 @@ from typing import Any, List, Optional
 
 from pytest import mark, param
 
+from hydra._internal.config_loader_impl import ConfigLoaderImpl
 from hydra._internal.core_plugins.basic_sweeper import BasicSweeper
+from hydra._internal.utils import create_config_search_path
 from hydra.core.override_parser.overrides_parser import OverridesParser
 from hydra.test_utils.test_utils import assert_multiline_regex_search, run_process
 
@@ -104,7 +106,9 @@ from hydra.test_utils.test_utils import assert_multiline_regex_search, run_proce
 def test_split(
     args: List[str], max_batch_size: Optional[int], expected: List[List[List[str]]]
 ) -> None:
-    parser = OverridesParser.create()
+
+    config_loader = ConfigLoaderImpl(config_search_path=create_config_search_path(None))
+    parser = OverridesParser.create(config_loader)
     ret = BasicSweeper.split_arguments(
         parser.parse_overrides(args), max_batch_size=max_batch_size
     )
@@ -135,12 +139,13 @@ def test_split(
         ),
         param(["a=1,2", "a={x:10},{y:20}", "a=3,4"], ["a=3,4"], id="override_mixed"),
         param(
-            ["+a=xx,yy", "+a=[zz]"], ["+a=xx,yy", "+a=[zz]"], id="override_plus_list"
+            ["+a=xx,yy", "+a=[zz]"], ["+a=[zz]"], id="override_plus_list"
         ),
     ],
 )
 def test_simplify(args: List[str], expected: List[str]) -> None:
-    parser = OverridesParser.create()
+    config_loader = ConfigLoaderImpl(config_search_path=create_config_search_path(None))
+    parser = OverridesParser.create(config_loader)
     overrides = parser.parse_overrides(args)
     simplified = BasicSweeper.simplify_overrides(overrides)
     expected_overrides = parser.parse_overrides(expected)

--- a/tests/test_basic_sweeper.py
+++ b/tests/test_basic_sweeper.py
@@ -80,6 +80,28 @@ def test_split(
     lret = [list(x) for x in ret]
     assert lret == expected
 
+@mark.parametrize(
+    "args,expected",
+    [
+        param(["a=1", "b=2", "a=3"], ["b=2", "a=3"], id="simple_override"),
+        param(["a=1,2", "a=3,4"], ["a=3,4"], id="override_split"),
+        param(["a=1", "b=2", "+a={x:10}", "+a={y:20}"], ["a=1", "b=2", "+a={x:10}", "+a={y:20}"], id="override_plus"),
+        param(["a=1", "b=2", "a={x:10}", "a={y:20}"], ["b=2", "a={x:10}", "a={y:20}"], id="override_plus"),
+        param(["a={x:1}", "a={y:2}"], ["a={x:1}", "a={y:2}"], id="override_dict"),
+        param(["a=1,2", "+a={x:10},{y:20}", "a=3,4"], ["+a={x:10},{y:20}", "a=3,4"], id="override_mixed"),
+        param(["a=1,2", "a={x:10},{y:20}", "a=3,4"], ["a=3,4"], id="override_mixed"),
+        param(["+a=xx,yy", "+a=[zz]"], ["+a=xx,yy", "+a=[zz]"], id="override_plus_list"),
+    ]
+)
+def test_simplify(
+    args: List[str], expected: List[str]
+) -> None:
+    parser = OverridesParser.create()
+    overrides = parser.parse_overrides(args)
+    simplified = BasicSweeper.simplify_overrides(overrides)
+    expected_overrides = parser.parse_overrides(expected)
+    assert simplified == expected_overrides
+
 
 def test_partial_failure(
     tmpdir: Any,

--- a/tests/test_basic_sweeper.py
+++ b/tests/test_basic_sweeper.py
@@ -138,9 +138,7 @@ def test_split(
             id="override_mixed",
         ),
         param(["a=1,2", "a={x:10},{y:20}", "a=3,4"], ["a=3,4"], id="override_mixed"),
-        param(
-            ["+a=xx,yy", "+a=[zz]"], ["+a=[zz]"], id="override_plus_list"
-        ),
+        param(["+a=xx,yy", "+a=[zz]"], ["+a=[zz]"], id="override_plus_list"),
     ],
 )
 def test_simplify(args: List[str], expected: List[str]) -> None:

--- a/tests/test_examples/test_basic_sweep.py
+++ b/tests/test_examples/test_basic_sweep.py
@@ -37,9 +37,9 @@ chdir_hydra_root()
             dedent(
                 """\
                 [HYDRA] Launching 2 jobs locally
-                [HYDRA] \t#0 : db=mysql db.timeout=5
+                [HYDRA] \t#0 : db.timeout=5 db=mysql
                 driver=mysql, timeout=5
-                [HYDRA] \t#1 : db=mysql db.timeout=10
+                [HYDRA] \t#1 : db.timeout=10 db=mysql
                 driver=mysql, timeout=10"""
             ),
         ),
@@ -48,13 +48,13 @@ chdir_hydra_root()
             dedent(
                 """\
                 [HYDRA] Launching 4 jobs locally
-                [HYDRA] \t#0 : db=mysql db.timeout=5 db.user=one
+                [HYDRA] \t#0 : db.timeout=5 db=mysql db.user=one
                 driver=mysql, timeout=5
-                [HYDRA] \t#1 : db=mysql db.timeout=5 db.user=two
+                [HYDRA] \t#1 : db.timeout=5 db=mysql db.user=two
                 driver=mysql, timeout=5
-                [HYDRA] \t#2 : db=mysql db.timeout=10 db.user=one
+                [HYDRA] \t#2 : db.timeout=10 db=mysql db.user=one
                 driver=mysql, timeout=10
-                [HYDRA] \t#3 : db=mysql db.timeout=10 db.user=two
+                [HYDRA] \t#3 : db.timeout=10 db=mysql db.user=two
                 driver=mysql, timeout=10"""
             ),
         ),


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Before this PR, `BasicSweeper.split_arguments` would keep only last override for the same key.
in case `a=1,2,3 a=10,20,30` it works well, but in case `a={x:10} a={y:20}` it would have different behavior between `MULTI_RUN` and `RUN`.

This PR introduce `BasicSweeper.simplify_overrides` that would try its best to remove duplicated key override.
1. it would automatically test if key is a group
2. for group it would keep last override (that is `OverrideType.CHANGE`)
3. for non-group, it would check if the value is dict or primitive `(str, int, bool, float, list)`
4. dict and primitive is exclusive, only one will wins
5. if value type is changed to dict, it would keep all dict till end
6. if value type is changed to primitive, it would only keep last value

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

fixes #3106 
(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
