### PR TITLE
feat(submitit): add wait_for_completion option for fire-and-forget job submission

### DIFF
--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/config.py
@@ -27,6 +27,12 @@ class BaseQueueConf:
     name: str = "${hydra.job.name}"
     # redirect stderr to stdout
     stderr_to_stdout: bool = False
+    # _________________________________ NEW PARAMETER _________________________________ #
+    # Whether to wait for job completion before returning
+    # If False, jobs are submitted and the launcher returns immediately
+    # with JobStatus.UNKNOWN
+    wait_for_completion: bool = True
+    # _________________________________________________________________________________ #
 
 
 @dataclass
@@ -38,7 +44,7 @@ class SlurmQueueConf(BaseQueueConf):
     )
 
     # Params are used to configure sbatch, for more info check:
-    # https://github.com/facebookincubator/submitit/blob/main/submitit/slurm/slurm.py
+    # https://github.com/facebookincubator/submitit/blob/master/submitit/slurm/slurm.py
 
     # Following parameters are slurm specific
     # More information: https://slurm.schedmd.com/sbatch.html
@@ -64,7 +70,7 @@ class SlurmQueueConf(BaseQueueConf):
     # Change this only after you confirmed your code can handle re-submission
     # by properly resuming from the latest stored checkpoint.
     # check the following for more info on slurm_max_num_timeout
-    # https://github.com/facebookincubator/submitit/blob/main/docs/checkpointing.md
+    # https://github.com/facebookincubator/submitit/blob/master/docs/checkpointing.md
     max_num_timeout: int = 0
     # Useful to add parameters which are not currently available in the plugin.
     # Eg: {"mail-user": "blublu@fb.com", "mail-type": "BEGIN"}
@@ -73,8 +79,6 @@ class SlurmQueueConf(BaseQueueConf):
     array_parallelism: int = 256
     # A list of commands to run in sbatch befure running srun
     setup: Optional[List[str]] = None
-    # Any additional arguments that should be passed to srun
-    srun_args: Optional[List[str]] = None
 
 
 @dataclass

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/submitit_launcher.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 
 
 class BaseSubmititLauncher(Launcher):
+
     _EXECUTOR = "abstract"
 
     def __init__(self, **params: Any) -> None:
@@ -89,7 +90,12 @@ class BaseSubmititLauncher(Launcher):
         import submitit
 
         assert self.config is not None
-
+        
+        # ___________________________ NEW wait_for_completion logic ___________________________ #
+        # I pop it out of the params dict to avoid passing it to the executor, which would cause
+        # an error.
+        wait_for_completion = self.params.pop("wait_for_completion")
+        # _____________________________________________________________________________________ #
         num_jobs = len(job_overrides)
         assert num_jobs > 0
         params = self.params
@@ -142,6 +148,31 @@ class BaseSubmititLauncher(Launcher):
             )
 
         jobs = executor.map_array(self, *zip(*job_params))
+        
+        # ___________________________ NEW wait_for_completion logic ___________________________ #
+        if not wait_for_completion:
+            # I'm lazy importing these, though there's no real reason to avoid importing them at
+            # the top level since they don't have any heavy dependencies. I just want to avoid
+            # importing them if we're waiting for completion, since we won't be using them in
+            # that case.
+            from hydra.core.utils import JobReturn, JobStatus
+            results = []
+            for idx, (job, overrides) in enumerate(zip(jobs, job_overrides)):
+                log.info(f"Submitted job {job.job_id}")
+                log.info(f"  stdout: {job.paths.stdout}")
+                log.info(f"  stderr: {job.paths.stderr}")
+                results.append(JobReturn(
+                    overrides=list(overrides),
+                    # We don't have the actual job status or return value at this point,
+                    # so this is a bit of a lie. We could define a new JobStatus like SUBMITTED.
+                    # For simplicity I'll just use COMPLETED placeholders for now.
+                    # NOTE: JobStatus.UNKNOWN throws an error. See the JobReturn class in
+                    # hydra/core/utils.py.
+                    status=JobStatus.COMPLETED,
+                    _return_value={"job_id": job.job_id},
+                ))
+            return results
+        # _____________________________________________________________________________________ #
         return [j.results()[0] for j in jobs]
 
 


### PR DESCRIPTION
## Summary

Adds a `wait_for_completion` config option to the submitit launcher. When set to `False`, jobs are submitted and the launcher returns immediately without waiting for results.

## Motivation

This is useful for long-running jobs (e.g., model training) when we don't want the submitting process to block.

## Usage

```yaml
hydra:
  launcher:
    wait_for_completion: false
```

## Example output
```
[HYDRA] Submitted job 16136162
[HYDRA]   stdout: /path/to/.submitit/16136162/16136162_0_log.out
[HYDRA]   stderr: /path/to/.submitit/16136162/16136162_0_log.err
```

## Design consideration

It seems like this feature was requested a few times and my approach is suspiciously simple, so I guess I'm missing something.

For now, I wanted this PR to be non-invasive. It does not require modifications to Hydra core. The thing is, as noted in #2479, "Hydra's BasicSweeper collects the returned values from each job in the sweep". Thus, I chose to return placeholders values, such as  `JobStatus.COMPLETED`. A more invasive, perhaps cleaner way, of doing things would be to create a new JobStatus, like SUBMITTED or INPROGRESS ?

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

## Test Plan

I guess a simple test with `wait_for_completion=True` is enough. I'll add it later if we agree on the usefulness and design.

## Related Issues and PRs

- #2479: feature request 
- #2965: closed, unmerged
- #3017: closed, unmerged
