### PR TITLE
Quick (and dirty) fix to be able to install hydra despite pkg_ressources-gate

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,0 @@
-omegaconf>=2.4.0.dev4
-importlib-resources;python_version<'3.9'
-packaging

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 # type: ignore
-import pathlib
 
-import pkg_resources
 from setuptools import find_namespace_packages, setup
 
 from build_helpers.build_helpers import (
@@ -14,11 +12,11 @@ from build_helpers.build_helpers import (
     find_version,
 )
 
-with pathlib.Path("requirements/requirements.txt").open() as requirements_txt:
-    install_requires = [
-        str(requirement)
-        for requirement in pkg_resources.parse_requirements(requirements_txt)
-    ]
+install_requires = [
+    "omegaconf>=2.4.0.dev4",
+    "importlib-resources;python_version<'3.9'",
+    "packaging",
+]
 
 
 with open("README.md") as fh:

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ with open("README.md") as fh:
         packages=find_namespace_packages(include=["hydra", "hydra.*"]),
         include_package_data=True,
         classifiers=[
-            "License :: OSI Approved :: MIT License",
             "Development Status :: 4 - Beta",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",


### PR DESCRIPTION

<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

This is only a quick fix to allow downstream projects to install hydra again :(

Closes #3131  by removing the dependency to` pkg_ressources.parse_requirements` and import the content of `requirements/requirements.txt` directly instead of parsing it.

There might be better way to fix this, such as completely removing `setup.py` and write a fully-fledged `pyproject.toml` instead.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

No

## Test Plan

See minimal example in #3131 

## Related Issues and PRs
#3131 