### PR TITLE
fix overrides dropped when --multirun flag appears between them

### DIFF
--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -619,7 +619,29 @@ def get_args_parser() -> argparse.ArgumentParser:
 
 
 def get_args(args: Optional[Sequence[str]] = None) -> Any:
-    return get_args_parser().parse_args(args=args)
+    return _parse_args(get_args_parser(), args)
+
+
+def _parse_args(
+    parser: argparse.ArgumentParser, args: Optional[Sequence[str]] = None
+) -> argparse.Namespace:
+    """Parse arguments, handling overrides that appear after optional flags.
+
+    Python's argparse does not correctly collect positional arguments
+    (nargs="*") when an optional flag like ``--multirun`` appears between
+    them.  For example::
+
+        python app.py task=1 --multirun db=mysql
+
+    would only see ``task=1`` as an override, leaving ``db=mysql`` as
+    unrecognised.  This helper uses ``parse_known_args`` and appends the
+    remaining tokens to the ``overrides`` list so that flag ordering no
+    longer matters.
+    """
+    parsed, remaining = parser.parse_known_args(args=args)
+    if remaining:
+        parsed.overrides.extend(remaining)
+    return parsed
 
 
 def get_column_widths(matrix: List[List[str]]) -> List[int]:

--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -619,29 +619,7 @@ def get_args_parser() -> argparse.ArgumentParser:
 
 
 def get_args(args: Optional[Sequence[str]] = None) -> Any:
-    return _parse_args(get_args_parser(), args)
-
-
-def _parse_args(
-    parser: argparse.ArgumentParser, args: Optional[Sequence[str]] = None
-) -> argparse.Namespace:
-    """Parse arguments, handling overrides that appear after optional flags.
-
-    Python's argparse does not correctly collect positional arguments
-    (nargs="*") when an optional flag like ``--multirun`` appears between
-    them.  For example::
-
-        python app.py task=1 --multirun db=mysql
-
-    would only see ``task=1`` as an override, leaving ``db=mysql`` as
-    unrecognised.  This helper uses ``parse_known_args`` and appends the
-    remaining tokens to the ``overrides`` list so that flag ordering no
-    longer matters.
-    """
-    parsed, remaining = parser.parse_known_args(args=args)
-    if remaining:
-        parsed.overrides.extend(remaining)
-    return parsed
+    return get_args_parser().parse_intermixed_args(args=args)
 
 
 def get_column_widths(matrix: List[List[str]]) -> List[int]:

--- a/hydra/main.py
+++ b/hydra/main.py
@@ -11,7 +11,7 @@ from omegaconf import DictConfig, open_dict, read_write
 
 from . import version
 from ._internal.deprecation_warning import deprecation_warning
-from ._internal.utils import _run_hydra, get_args_parser
+from ._internal.utils import _parse_args, _run_hydra, get_args_parser
 from .core.hydra_config import HydraConfig
 from .core.utils import _flush_loggers, configure_log
 from .types import TaskFunction
@@ -83,7 +83,7 @@ def main(
                 return task_function(cfg_passthrough)
             else:
                 args_parser = get_args_parser()
-                args = args_parser.parse_args()
+                args = _parse_args(args_parser)
                 if args.experimental_rerun is not None:
                     cfg = _get_rerun_conf(args.experimental_rerun, args.overrides)
                     task_function(cfg)

--- a/hydra/main.py
+++ b/hydra/main.py
@@ -11,7 +11,7 @@ from omegaconf import DictConfig, open_dict, read_write
 
 from . import version
 from ._internal.deprecation_warning import deprecation_warning
-from ._internal.utils import _run_hydra, get_args_parser
+from ._internal.utils import _parse_args, _run_hydra, get_args_parser
 from .core.hydra_config import HydraConfig
 from .core.utils import _flush_loggers, configure_log
 from .types import TaskFunction
@@ -81,7 +81,7 @@ def main(
                 return task_function(cfg_passthrough)
             else:
                 args_parser = get_args_parser()
-                args = args_parser.parse_args()
+                args = _parse_args(args_parser)
                 if args.experimental_rerun is not None:
                     cfg = _get_rerun_conf(args.experimental_rerun, args.overrides)
                     task_function(cfg)

--- a/hydra/main.py
+++ b/hydra/main.py
@@ -11,7 +11,7 @@ from omegaconf import DictConfig, open_dict, read_write
 
 from . import version
 from ._internal.deprecation_warning import deprecation_warning
-from ._internal.utils import _parse_args, _run_hydra, get_args_parser
+from ._internal.utils import _run_hydra, get_args_parser
 from .core.hydra_config import HydraConfig
 from .core.utils import _flush_loggers, configure_log
 from .types import TaskFunction
@@ -81,7 +81,7 @@ def main(
                 return task_function(cfg_passthrough)
             else:
                 args_parser = get_args_parser()
-                args = _parse_args(args_parser)
+                args = args_parser.parse_intermixed_args()
                 if args.experimental_rerun is not None:
                     cfg = _get_rerun_conf(args.experimental_rerun, args.overrides)
                     task_function(cfg)

--- a/news/3053.bugfix
+++ b/news/3053.bugfix
@@ -1,0 +1,1 @@
+Allow overrides on both sides of Hydra command-line flags.

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1824,6 +1824,17 @@ def test_hydra_resolver_in_output_dir(tmpdir: Path, multirun: bool) -> None:
             id="multi_run_commandline",
         ),
         param(
+            ["x=1", "--multirun", "hydra.mode=MULTIRUN"],
+            dedent("""\
+                [HYDRA] Launching 1 jobs locally
+                [HYDRA] \t#0 : x=1
+                RunMode.MULTIRUN"""),
+            False,
+            False,
+            None,
+            id="multi_run_commandline_between_overrides",
+        ),
+        param(
             [],
             dedent("""\
                 RunMode.RUN"""),

--- a/tests/test_internal_utils.py
+++ b/tests/test_internal_utils.py
@@ -5,6 +5,7 @@ from omegaconf import DictConfig, OmegaConf
 from pytest import mark, param
 
 from hydra._internal import utils
+from hydra._internal.utils import get_args
 from tests import data
 
 
@@ -53,3 +54,46 @@ def test_detect_calling_file_or_module_from_task_function(
     file, module = utils.detect_calling_file_or_module_from_task_function(task_function)
     assert file == expected_file
     assert module == expected_module
+
+
+@mark.parametrize(
+    "args, expected_overrides, expected_multirun",
+    [
+        param(
+            ["--multirun", "task=1", "db=mysql"],
+            ["task=1", "db=mysql"],
+            True,
+            id="multirun-first",
+        ),
+        param(
+            ["task=1", "db=mysql", "--multirun"],
+            ["task=1", "db=mysql"],
+            True,
+            id="multirun-last",
+        ),
+        param(
+            ["task=1", "--multirun", "db=mysql"],
+            ["task=1", "db=mysql"],
+            True,
+            id="multirun-between-overrides",
+        ),
+        param(
+            ["task=1", "-m", "db=mysql"],
+            ["task=1", "db=mysql"],
+            True,
+            id="short-flag-between-overrides",
+        ),
+        param(
+            ["task=1", "db=mysql"],
+            ["task=1", "db=mysql"],
+            False,
+            id="no-multirun",
+        ),
+    ],
+)
+def test_get_args_override_ordering(
+    args: Any, expected_overrides: Any, expected_multirun: bool
+) -> None:
+    parsed = get_args(args)
+    assert parsed.overrides == expected_overrides
+    assert parsed.multirun == expected_multirun

--- a/tests/test_internal_utils.py
+++ b/tests/test_internal_utils.py
@@ -2,7 +2,7 @@
 from typing import Any, Callable, Optional
 
 from omegaconf import DictConfig, OmegaConf
-from pytest import mark, param
+from pytest import mark, param, raises
 
 from hydra._internal import utils
 from hydra._internal.utils import get_args
@@ -97,3 +97,8 @@ def test_get_args_override_ordering(
     parsed = get_args(args)
     assert parsed.overrides == expected_overrides
     assert parsed.multirun == expected_multirun
+
+
+def test_get_args_rejects_unknown_option() -> None:
+    with raises(SystemExit):
+        get_args(["task=1", "--bad-flag", "db=mysql"])


### PR DESCRIPTION
When `--multirun` (or any optional flag) is placed between override arguments on the command line, argparse only sees the overrides before the flag and rejects the rest as unrecognized. For example:

```
python app.py task=1 --multirun db=mysql
# error: unrecognized arguments: db=mysql
```

This happens because `nargs="*"` positional args stop consuming tokens as soon as argparse encounters an optional flag. The overrides after the flag never get picked up.

Fixed by switching from `parse_args()` to `parse_known_args()` and merging any remaining tokens back into the overrides list. All orderings now work:

```
python app.py --multirun task=1 db=mysql    # works (already worked)
python app.py task=1 db=mysql --multirun    # works (already worked)
python app.py task=1 --multirun db=mysql    # works (was broken)
```

Fixes #3053