### PR TITLE
Replace pkg_resources with importlib.metadata for Python 3.13+ compatibility

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -504,7 +504,6 @@ def test_core(session: Session) -> None:
             session,
             "build_helpers",
             "tests",
-            "-W ignore:pkg_resources is deprecated as an API:DeprecationWarning",
             *session.posargs,
         )
     else:

--- a/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_aws_launcher.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, Generator, Optional
 
 import boto3  # type: ignore
-import pkg_resources
+from importlib.metadata import version as get_pkg_version
 from botocore.exceptions import (  # type: ignore
     ClientError,
     NoCredentialsError,
@@ -201,7 +201,7 @@ def validate_lib_version(connect_config: Dict[Any, Any]) -> None:
     # a few lib versions that we care about
     libs = ["ray", "cloudpickle", "pickle5"]
     for lib in libs:
-        local_version = f"{pkg_resources.get_distribution(lib).version}"
+        local_version = get_pkg_version(lib)
         out = sdk.run_on_cluster(
             connect_config, cmd=f"pip show {lib} | grep Version", with_output=True
         ).decode()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # type: ignore
 import pathlib
 
-import pkg_resources
 from setuptools import find_namespace_packages, setup
 
 from build_helpers.build_helpers import (
@@ -16,8 +15,9 @@ from build_helpers.build_helpers import (
 
 with pathlib.Path("requirements/requirements.txt").open() as requirements_txt:
     install_requires = [
-        str(requirement)
-        for requirement in pkg_resources.parse_requirements(requirements_txt)
+        line.strip()
+        for line in requirements_txt
+        if line.strip() and not line.startswith("#")
     ]
 
 


### PR DESCRIPTION
## Motivation

Python 3.13+ and setuptools >= v82 no longer ship `pkg_resources`, causing `ModuleNotFoundError` when installing Hydra from source. This PR removes all `pkg_resources` usage in favor of stdlib alternatives.

## Changes

- **setup.py**: Replace `pkg_resources.parse_requirements()` with direct line-by-line reading of `requirements.txt`. The requirements file is simple enough that full PEP 508 parsing is unnecessary.
- **ray launcher tests**: Replace `pkg_resources.get_distribution(lib).version` with `importlib.metadata.version(lib)` (available since Python 3.8).
- **noxfile.py**: Remove the `pkg_resources` deprecation warning filter, since the import no longer exists.

## Why not `pip._internal`?

The issue description suggests `from pip._internal.req import parse_requirements` as a fix. This is a private API with no stability guarantees -- pip explicitly warns against importing from `pip._internal`. The stdlib `importlib.metadata` module is the correct replacement.

## Test plan

- Verified `requirements/requirements.txt` parses correctly with the new approach (no complex markers or URL-based requirements that would need full PEP 508 parsing).
- `importlib.metadata.version()` is a drop-in replacement for `pkg_resources.get_distribution().version` and has been available since Python 3.8.

Closes #3131