### PR TITLE
Fix TypeError when deleting a ListConfig item by index via CLI override

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -7,7 +7,14 @@ import warnings
 from textwrap import dedent
 from typing import Any, List, MutableSequence, Optional, Tuple, Union
 
-from omegaconf import Container, DictConfig, ListConfig, OmegaConf, flag_override, open_dict
+from omegaconf import (
+    Container,
+    DictConfig,
+    ListConfig,
+    OmegaConf,
+    flag_override,
+    open_dict,
+)
 from omegaconf.errors import (
     ConfigAttributeError,
     ConfigKeyError,

--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -5,9 +5,9 @@ import re
 import sys
 import warnings
 from textwrap import dedent
-from typing import Any, List, MutableSequence, Optional, Tuple
+from typing import Any, List, MutableSequence, Optional, Tuple, Union
 
-from omegaconf import Container, DictConfig, OmegaConf, flag_override, open_dict
+from omegaconf import Container, DictConfig, ListConfig, OmegaConf, flag_override, open_dict
 from omegaconf.errors import (
     ConfigAttributeError,
     ConfigKeyError,
@@ -363,7 +363,10 @@ class ConfigLoaderImpl(ConfigLoader):
                             del cfg[key]
                         else:
                             node = OmegaConf.select(cfg, key[0:last_dot])
-                            del node[key[last_dot + 1 :]]
+                            node_key: Union[str, int] = key[last_dot + 1 :]
+                            if isinstance(node, ListConfig):
+                                node_key = int(node_key)
+                            del node[node_key]
 
                 elif override.is_add():
                     if OmegaConf.select(

--- a/news/2477.bugfix
+++ b/news/2477.bugfix
@@ -1,0 +1,1 @@
+Fix TypeError when deleting a ListConfig item by index via CLI override (e.g. `~config.x.0`)

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -732,6 +732,8 @@ def test_complex_defaults(overrides: Any, expected: Any) -> None:
         param({"x": {"y": 10}}, ["~x.y=10"], {"x": {}}, id="delete_strict"),
         param({"x": [1, 2, 3]}, ["~x"], {}, id="delete:list"),
         param({"x": [1, 2, 3]}, ["~x=[1,2,3]"], {}, id="delete:list"),
+        param({"x": [1, 2, 3]}, ["~x.0"], {"x": [2, 3]}, id="delete:list_item"),
+        param({"x": [1, 2, 3]}, ["~x.1"], {"x": [1, 3]}, id="delete:list_item_middle"),
         param(
             {"x": 20},
             ["~z"],


### PR DESCRIPTION
## Motivation

When deleting a list item via a CLI override like `~config.x.0`, the deletion code in `hydra/_internal/config_loader_impl.py` at line 368 extracts the index as a string (`key[last_dot + 1:]`) and passes it directly to `del node[...]`. For `DictConfig` nodes this works fine, but `ListConfig` requires an integer index, causing a `TypeError`.

The fix checks whether the selected node is a `ListConfig` and converts the string key to an integer before deletion. `ListConfig` is imported from omegaconf and `Union` is added to the typing imports to annotate the `node_key` variable.

Two regression tests are added to `tests/test_config_loader.py` covering deletion of the first and middle element of a list via index override.

## Have you read the Contributing Guidelines?

Yes

## Test Plan

Run the existing `test_config_loader.py` test suite with `pytest tests/test_config_loader.py -k delete`. The two new parameterized cases (`delete:list_item` and `delete:list_item_middle`) cover the reported scenario.

## Related Issues and PRs

Fixes #2477
