### PR TITLE
Fix LazyCompletionHelp incompatibility with Python 3.14 argparse

### DIFF
--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -544,35 +544,18 @@ def get_args_parser() -> argparse.ArgumentParser:
         def __repr__(self) -> str:
             return f"Install or Uninstall shell completion:\n{_get_completion_help()}"
 
-    if sys.version_info >= (3, 14):
-        # Python 3.14+ adds help message validation via ArgumentParser._check_help,
-        # which calls formatter._expand_help(action) to validate that action.help
-        # is a string that can be used in string formatting (e.g., "text %(prog)s").
-        # This breaks our LazyCompletionHelp because `_expand_help` expects an actual
-        # string.
-        # It is safe to disable this validation temporarily because LazyCompletionHelp.
-        # __repr__() returns a plain string (no % formatting)
-        original_check_help = argparse.ArgumentParser._check_help  # type: ignore
-        argparse.ArgumentParser._check_help = (  # type: ignore
-            lambda self, action: None
-        )
-        try:
-            parser.add_argument(
-                "--shell-completion",
-                "-sc",
-                action="store_true",
-                help=LazyCompletionHelp(),  # type: ignore
-            )
-        finally:
-            # Immediately restore normal validation
-            argparse.ArgumentParser._check_help = original_check_help  # type: ignore
-    else:
-        parser.add_argument(
-            "--shell-completion",
-            "-sc",
-            action="store_true",
-            help=LazyCompletionHelp(),  # type: ignore
-        )
+        def __str__(self) -> str:
+            return repr(self)
+
+        def __contains__(self, item: object) -> bool:
+            return item in str(self)
+
+    parser.add_argument(
+        "--shell-completion",
+        "-sc",
+        action="store_true",
+        help=LazyCompletionHelp(),  # type: ignore
+    )
 
     parser.add_argument(
         "--config-path",


### PR DESCRIPTION
## Motivation

Python 3.14 added a validation step in `ArgumentParser._check_help` (CPython eb2d268) that calls `'%' in help_string` before formatting help text. The `LazyCompletionHelp` class in `hydra/_internal/utils.py` doesn't implement `__contains__`, so this membership test raises a `TypeError`, crashing any Hydra application on Python 3.14 before it even runs.

A previous workaround monkey-patched `argparse.ArgumentParser._check_help` to bypass the check on Python 3.14+, but that approach is fragile and requires a version guard. The cleaner fix is to add `__str__` and `__contains__` methods directly to `LazyCompletionHelp` so it satisfies argparse's expectations while preserving the lazy-evaluation behavior. With these methods in place, the version-specific monkey-patching is no longer needed and has been removed.

## Have you read the Contributing Guidelines?

Yes

## Test Plan

Existing tests cover `get_args_parser()`. To manually verify, run the minimal repro from the issue on Python 3.14:

```python
import hydra

@hydra.main()
def main(cfg) -> None:
    pass

main()
```

It should no longer raise `ValueError: badly formed help string`.

## Related Issues and PRs

Fixes #3121
