### PR TITLE
Update release tooling and publishing docs

### DIFF
--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -4,7 +4,13 @@
 name: Publish to Test PyPI
 
 on:
-  workflow_dispatch:  # Manual trigger for testing releases
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish to Test PyPI after building artifacts"
+        required: true
+        type: boolean
+        default: false
 
 # Use separate jobs for building and publishing so that write
 # permissions are only accessible minimally.
@@ -34,16 +40,59 @@ jobs:
     - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build
+        pip install -r requirements/requirements.txt build read-version requests twine
 
-    - name: Build distribution
-      run: python -m build
+    - name: Build distributions
+      env:
+        PYTHONPATH: ${{ github.workspace }}
+      run: |
+        python tools/release/release.py \
+          action=build \
+          set=hydra-full-release \
+          repository=testpypi \
+          clean_build_dir=true \
+          require_artifacts=true \
+          build_dir="${{ github.workspace }}/dist"
 
     - name: Verify build artifacts
       run: |
         ls -lah dist/
-        python -m pip install twine
         twine check dist/*
+
+    - name: Write release summary
+      env:
+        PUBLISH_ENABLED: ${{ inputs.publish == true }}
+        TARGET_REPOSITORY: TestPyPI
+      run: |
+        if [[ "${PUBLISH_ENABLED}" == "true" ]]; then
+          mode="publish"
+          outcome="Artifacts will be uploaded to ${TARGET_REPOSITORY}."
+        else
+          mode="dry run"
+          outcome="Artifacts were built and checked only; no upload will run."
+        fi
+
+        {
+          echo "## Release summary"
+          echo
+          echo "- Target repository: ${TARGET_REPOSITORY}"
+          echo "- Mode: ${mode}"
+          echo "- Trigger: ${GITHUB_EVENT_NAME}"
+          echo "- Ref: \`${GITHUB_REF_NAME}\`"
+          echo "- Commit: \`${GITHUB_SHA}\`"
+          echo "- Outcome: ${outcome}"
+          echo
+          echo "### Artifacts"
+          echo
+          echo "| Artifact | Size |"
+          echo "| --- | ---: |"
+          find dist -maxdepth 1 -type f -printf '%f\t%s\n' \
+            | sort \
+            | while IFS=$'\t' read -r artifact bytes; do
+                size="$(numfmt --to=iec --suffix=B "${bytes}")"
+                echo "| \`${artifact}\` | ${size} |"
+              done
+        } >> "${GITHUB_STEP_SUMMARY}"
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -55,6 +104,7 @@ jobs:
   test-pypi-publish:
     needs: build-artifacts
     name: Upload release to Test PyPI
+    if: ${{ inputs.publish == true }}
     runs-on: ubuntu-latest
     environment: test-pypi-publish
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,13 @@ name: Publish to PyPI
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish to PyPI after building artifacts"
+        required: true
+        type: boolean
+        default: false
 
 # Use separate jobs for building and publishing so that write
 # permissions are only accessible minimally.
@@ -35,16 +42,59 @@ jobs:
     - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build
+        pip install -r requirements/requirements.txt build read-version requests twine
 
-    - name: Build distribution
-      run: python -m build
+    - name: Build distributions
+      env:
+        PYTHONPATH: ${{ github.workspace }}
+      run: |
+        python tools/release/release.py \
+          action=build \
+          set=hydra-full-release \
+          repository=pypi \
+          clean_build_dir=true \
+          require_artifacts=true \
+          build_dir="${{ github.workspace }}/dist"
 
     - name: Verify build artifacts
       run: |
         ls -lah dist/
-        python -m pip install twine
         twine check dist/*
+
+    - name: Write release summary
+      env:
+        PUBLISH_ENABLED: ${{ github.event_name == 'release' || inputs.publish == true }}
+        TARGET_REPOSITORY: PyPI
+      run: |
+        if [[ "${PUBLISH_ENABLED}" == "true" ]]; then
+          mode="publish"
+          outcome="Artifacts will be uploaded to ${TARGET_REPOSITORY}."
+        else
+          mode="dry run"
+          outcome="Artifacts were built and checked only; no upload will run."
+        fi
+
+        {
+          echo "## Release summary"
+          echo
+          echo "- Target repository: ${TARGET_REPOSITORY}"
+          echo "- Mode: ${mode}"
+          echo "- Trigger: ${GITHUB_EVENT_NAME}"
+          echo "- Ref: \`${GITHUB_REF_NAME}\`"
+          echo "- Commit: \`${GITHUB_SHA}\`"
+          echo "- Outcome: ${outcome}"
+          echo
+          echo "### Artifacts"
+          echo
+          echo "| Artifact | Size |"
+          echo "| --- | ---: |"
+          find dist -maxdepth 1 -type f -printf '%f\t%s\n' \
+            | sort \
+            | while IFS=$'\t' read -r artifact bytes; do
+                size="$(numfmt --to=iec --suffix=B "${bytes}")"
+                echo "| \`${artifact}\` | ${size} |"
+              done
+        } >> "${GITHUB_STEP_SUMMARY}"
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -56,6 +106,7 @@ jobs:
   pypi-publish:
     needs: build-artifacts
     name: Upload release to PyPI
+    if: ${{ github.event_name == 'release' || inputs.publish == true }}
     runs-on: ubuntu-latest
     environment: pypi-publish
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@ We want to make contributing to this project as easy and transparent as
 possible.
 
 Please see the [developer guide](https://hydra.cc/docs/development/overview/) on the website.
+Maintainers can find the release process in the [release guide](website/docs/development/release.md).
 
 ## Pull Requests
 We welcome your pull requests.

--- a/noxfile.py
+++ b/noxfile.py
@@ -66,15 +66,15 @@ def get_current_os() -> str:
     return current_os
 
 
-print(f"Operating system\t:\t{get_current_os()}")
-print(f"NOX_PYTHON_VERSIONS\t:\t{PYTHON_VERSIONS}")
-print(f"PLUGINS\t\t\t:\t{PLUGINS}")
-print(f"SKIP_PLUGINS\t\t\t:\t{SKIP_PLUGINS}")
-print(f"SKIP_CORE_TESTS\t\t:\t{SKIP_CORE_TESTS}")
-print(f"FIX\t\t\t:\t{FIX}")
-print(f"VERBOSE\t\t\t:\t{VERBOSE}")
-print(f"INSTALL_EDITABLE_MODE\t:\t{INSTALL_EDITABLE_MODE}")
-print(f"USE_OMEGACONF_DEV_VERSION\t:\t{USE_OMEGACONF_DEV_VERSION}")
+logger.info(f"Operating system\t:\t{get_current_os()}")
+logger.info(f"NOX_PYTHON_VERSIONS\t:\t{PYTHON_VERSIONS}")
+logger.info(f"PLUGINS\t\t\t:\t{PLUGINS}")
+logger.info(f"SKIP_PLUGINS\t\t\t:\t{SKIP_PLUGINS}")
+logger.info(f"SKIP_CORE_TESTS\t\t:\t{SKIP_CORE_TESTS}")
+logger.info(f"FIX\t\t\t:\t{FIX}")
+logger.info(f"VERBOSE\t\t\t:\t{VERBOSE}")
+logger.info(f"INSTALL_EDITABLE_MODE\t:\t{INSTALL_EDITABLE_MODE}")
+logger.info(f"USE_OMEGACONF_DEV_VERSION\t:\t{USE_OMEGACONF_DEV_VERSION}")
 
 
 def _upgrade_basic(session: Session) -> None:
@@ -89,11 +89,11 @@ def find_dirs(path: str) -> Iterator[str]:
             yield fullname
 
 
-def print_installed_package_version(session: Session, package_name: str) -> None:
+def log_installed_package_version(session: Session, package_name: str) -> None:
     pip_list: str = session.run("pip", "list", silent=True)
     for line in pip_list.split("\n"):
         if package_name in line:
-            print(f"Installed {package_name} version: {line}")
+            session.log(f"Installed {package_name} version: {line}")
 
 
 def install_hydra(session: Session, cmd: List[str]) -> None:
@@ -104,7 +104,7 @@ def install_hydra(session: Session, cmd: List[str]) -> None:
     if USE_OMEGACONF_DEV_VERSION:
         session.install("--pre", "omegaconf", silent=SILENT)
     session.run(*cmd, ".", silent=SILENT)
-    print_installed_package_version(session, "omegaconf")
+    log_installed_package_version(session, "omegaconf")
     if not SILENT:
         session.install("pipdeptree", silent=SILENT)
         session.run("pipdeptree", "-p", "hydra-core")
@@ -134,7 +134,7 @@ def install_plugin(session: Session, install_cmd: List[str], plugin: Plugin) -> 
 def maybe_install_torch(session: Session, plugin: Plugin) -> None:
     if plugin_requires_torch(plugin):
         install_cpu_torch(session)
-        print_installed_package_version(session, "torch")
+        log_installed_package_version(session, "torch")
 
 
 def plugin_requires_torch(plugin: Plugin) -> bool:
@@ -310,11 +310,54 @@ def _black_cmd() -> List[str]:
     return black
 
 
+def _is_github_actions() -> bool:
+    return os.environ.get("GITHUB_ACTIONS") == "true"
+
+
 def _isort_cmd() -> List[str]:
     isort = ["isort", "."]
     if not FIX:
         isort += ["--check", "--diff"]
+    if _is_github_actions():
+        isort += ["--format-error", "::error::isort {message}"]
     return isort
+
+
+def _flake8_cmd(*paths: str) -> List[str]:
+    flake8 = ["flake8", "--config", ".flake8"]
+    if _is_github_actions():
+        flake8 += [
+            "--format",
+            "::error file=%(path)s,line=%(row)d,col=%(col)d::%(code)s %(text)s",
+        ]
+    flake8.extend(paths)
+    return flake8
+
+
+def _yamllint_cmd() -> List[str]:
+    yamllint = ["yamllint", "--strict", "."]
+    if _is_github_actions():
+        yamllint += ["--format", "github"]
+    return yamllint
+
+
+def _bandit_cmd() -> List[str]:
+    bandit = [
+        "bandit",
+        "--exclude",
+        "./.nox/**,./.sl/**,./website/**",
+        "-ll",
+        "-r",
+        ".",
+    ]
+    if _is_github_actions():
+        bandit += [
+            "--format",
+            "custom",
+            "--msg-template",
+            "::error file={relpath},line={line}::{test_id} {severity}: {msg}",
+        ]
+    return bandit
 
 
 def _pyrefly_cmd(
@@ -329,6 +372,8 @@ def _pyrefly_cmd(
         "--python-interpreter-path",
         "python",
     ]
+    if _is_github_actions():
+        pyrefly.extend(["--output-format", "github"])
     if python_version is not None:
         pyrefly.append(f"--python-version={python_version}")
     if extra_search_paths is not None:
@@ -380,8 +425,8 @@ def lint(session: Session) -> None:
         *_pyrefly_cmd(python_version=session.python),
         silent=SILENT,
     )
-    session.run("flake8", "--config", ".flake8")
-    session.run("yamllint", "--strict", ".")
+    session.run(*_flake8_cmd())
+    session.run(*_yamllint_cmd())
 
     pyrefly_check_subdirs = [
         "examples/advanced",
@@ -416,15 +461,7 @@ def lint(session: Session) -> None:
     lint_plugins_in_dir(session=session, directory="examples/plugins")
 
     # bandit static security analysis
-    session.run(
-        "bandit",
-        "--exclude",
-        "./.nox/**,./.sl/**,./website/**",
-        "-ll",
-        "-r",
-        ".",
-        silent=SILENT,
-    )
+    session.run(*_bandit_cmd(), silent=SILENT)
 
 
 def lint_plugins_in_dir(session: Session, directory: str) -> None:
@@ -451,7 +488,7 @@ def lint_plugin(session: Session, plugin: Plugin) -> None:
 
     install_dev_deps(session)
 
-    session.run("flake8", "--config", ".flake8", plugin.abspath)
+    session.run(*_flake8_cmd(plugin.abspath))
     path = plugin.abspath
     source_dir = plugin.source_dir
     session.chdir(path)
@@ -501,6 +538,10 @@ def test_tools(session: Session) -> None:
             cmd = list(install_cmd) + ["-e", tool_path]
             session.run(*cmd, silent=SILENT)
             session.run("pytest", tool_path)
+        elif any(Path(tool_path).glob("test_*.py")):
+            if tool == "release":
+                session.install("requests", silent=SILENT)
+            session.run("pytest", tool_path, env={"PYTHONPATH": BASE})
 
     session.chdir(BASE)
 

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -1,48 +1,85 @@
-## Release tool.
+## Release tool
 
-A few usage examples:
+This tool keeps Hydra release operations package-aware. It knows about
+`hydra-core`, the bundled plugins, and `hydra-configen`, and can check versions,
+set versions, and build distributions.
 
-Check all plugins against the published versions:
-```text
-$ python tools/release/release.py  action=check set=plugins 
-[2021-03-30 18:21:05,768][__main__][INFO] - Build outputs : /home/omry/dev/hydra/outputs/2021-03-30/18-21-05/build
-[2021-03-30 18:21:05,768][__main__][INFO] - Checking for unpublished packages
-[2021-03-30 18:21:06,258][__main__][INFO] - ❋ : hydra-ax-sweeper : newer (local=1.1.5.dev1 > latest=1.1.0rc2)
-[2021-03-30 18:21:06,746][__main__][INFO] - ❋ : hydra-colorlog : newer (local=1.1.0.dev1 > latest=1.0.1)
-[2021-03-30 18:21:07,232][__main__][INFO] - ❋ : hydra-joblib-launcher : newer (local=1.1.5.dev1 > latest=1.1.2)
-[2021-03-30 18:21:07,708][__main__][INFO] - ❋ : hydra-nevergrad-sweeper : newer (local=1.1.5.dev1 > latest=1.1.0rc2)
-[2021-03-30 18:21:08,161][__main__][INFO] - ❋ : hydra-optuna-sweeper : newer (local=1.1.0.dev1 > latest=0.9.0rc2)
-[2021-03-30 18:21:08,639][__main__][INFO] - ❋ : hydra-ray-launcher : newer (local=1.1.0.dev1 > latest=0.1.4)
-[2021-03-30 18:21:09,122][__main__][INFO] - ❋ : hydra-rq-launcher : newer (local=1.1.0.dev1 > latest=1.0.2)
-[2021-03-30 18:21:09,620][__main__][INFO] - ❋ : hydra-submitit-launcher : newer (local=1.1.5.dev1 > latest=1.1.1)
-```
+Publishing is intentionally handled by GitHub Actions Trusted Publishing, not by
+this local tool. The publish workflows call this tool to build artifacts, then
+upload them from GitHub Actions.
 
-Check specific packages (hydra and configen) against the published versions
-```text
-$ python tools/release/release.py  action=check packages=[hydra,configen]
-[2021-03-30 18:21:25,423][__main__][INFO] - Build outputs : /home/omry/dev/hydra/outputs/2021-03-30/18-21-25/build
-[2021-03-30 18:21:25,423][__main__][INFO] - Checking for unpublished packages
-[2021-03-30 18:21:26,042][__main__][INFO] - ❋ : hydra-core : newer (local=1.1.0.dev6 > latest=1.1.0.dev5)
-[2021-03-30 18:21:26,497][__main__][INFO] - ❋ : hydra-configen : newer (local=0.9.0.dev8 > latest=0.9.0.dev7)
-```
+### Package sets
 
-Build all plugins:
+- `set=hydra-core`: `hydra-core` only.
+- `set=hydra-plugins`: all bundled Hydra plugins.
+- `set=hydra-full-release`: `hydra-core` plus all bundled Hydra plugins.
+- `set=configen`: `hydra-configen` only.
+- `set=all`: `hydra-core`, `hydra-configen`, and all bundled Hydra plugins.
+
+### Check published versions
+
 ```shell
-$ python tools/release/release.py  action=build set=plugins
-[2021-03-30 18:21:40,426][__main__][INFO] - Build outputs : /home/omry/dev/hydra/outputs/2021-03-30/18-21-40/build
-[2021-03-30 18:21:40,426][__main__][INFO] - Building unpublished packages
-[2021-03-30 18:21:41,280][__main__][INFO] - Building hydra-ax-sweeper
-[2021-03-30 18:21:47,237][__main__][INFO] - Building hydra-colorlog
-[2021-03-30 18:21:52,982][__main__][INFO] - Building hydra-joblib-launcher
-[2021-03-30 18:21:58,833][__main__][INFO] - Building hydra-nevergrad-sweeper
-[2021-03-30 18:22:04,618][__main__][INFO] - Building hydra-optuna-sweeper
-[2021-03-30 18:22:10,511][__main__][INFO] - Building hydra-ray-launcher
-[2021-03-30 18:22:16,487][__main__][INFO] - Building hydra-rq-launcher
-[2021-03-30 18:22:22,302][__main__][INFO] - Building hydra-submitit-launcher
+python tools/release/release.py \
+  action=check \
+  set=hydra-full-release \
+  repository=pypi
 ```
 
-Publish all build articats (sdists and wheels):
+This reports whether each local version already exists on the selected
+repository, with the latest non-yanked wheel shown as context. Use
+`repository=testpypi` when preparing a TestPyPI upload.
+
+### Set an explicit version
+
+```shell
+python tools/release/release.py \
+  action=set_version \
+  set=hydra-full-release \
+  version=1.4.0.dev2
 ```
-$ twine upload /home/omry/dev/hydra/outputs/2021-03-30/18-21-40/build/*
-...
+
+Use this for coordinated dev releases where `hydra-core` and the bundled plugins
+should share the same version.
+
+### Bump published packages
+
+```shell
+python tools/release/release.py action=bump set=hydra-full-release
 ```
+
+This increments only packages whose local version exactly matches the latest
+published version on PyPI. It is useful for continuing an existing release
+series, but less useful when aligning multiple packages to a specific version.
+
+### Build artifacts
+
+Build only packages whose local version has not already been published to PyPI:
+
+```shell
+python tools/release/release.py \
+  action=build \
+  set=hydra-full-release \
+  repository=pypi \
+  clean_build_dir=true \
+  require_artifacts=true \
+  build_dir="${PWD}/dist"
+```
+
+Use `repository=testpypi` to compare against TestPyPI instead.
+
+Build every package in a set, ignoring repository state:
+
+```shell
+python tools/release/release.py \
+  action=build \
+  set=hydra-full-release \
+  build_policy=all \
+  clean_build_dir=true \
+  build_dir="${PWD}/dist"
+```
+
+The GitHub publish workflows use the repository-aware form so already-published
+files are not uploaded again.
+
+The workflows also write a release summary listing the target repository,
+publish mode, trigger, ref, commit, and every artifact that was built.

--- a/tools/release/conf/config.yaml
+++ b/tools/release/conf/config.yaml
@@ -1,6 +1,6 @@
 defaults:
   - config_schema
-  - set: all
+  - set: hydra-full-release
   - _self_
 
 hydra:

--- a/tools/release/conf/packages/configen.yaml
+++ b/tools/release/conf/packages/configen.yaml
@@ -1,2 +1,3 @@
 configen:
   path: tools/${.name}
+  version_type: SETUP

--- a/tools/release/conf/set/configen.yaml
+++ b/tools/release/conf/set/configen.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+defaults:
+  - /packages:
+      - configen

--- a/tools/release/conf/set/hydra-core.yaml
+++ b/tools/release/conf/set/hydra-core.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+defaults:
+  - /packages:
+      - hydra

--- a/tools/release/conf/set/hydra-full-release.yaml
+++ b/tools/release/conf/set/hydra-full-release.yaml
@@ -1,0 +1,12 @@
+# @package _global_
+defaults:
+  - /packages:
+      - hydra
+      - hydra_ax_sweeper
+      - hydra_colorlog
+      - hydra_joblib_launcher
+      - hydra_nevergrad_sweeper
+      - hydra_optuna_sweeper
+      - hydra_ray_launcher
+      - hydra_rq_launcher
+      - hydra_submitit_launcher

--- a/tools/release/conf/set/hydra-plugins.yaml
+++ b/tools/release/conf/set/hydra-plugins.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+defaults:
+  - /packages:
+      - hydra_ax_sweeper
+      - hydra_colorlog
+      - hydra_joblib_launcher
+      - hydra_nevergrad_sweeper
+      - hydra_optuna_sweeper
+      - hydra_ray_launcher
+      - hydra_rq_launcher
+      - hydra_submitit_launcher

--- a/tools/release/release.py
+++ b/tools/release/release.py
@@ -7,10 +7,10 @@ from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import hydra
-import requests
+import requests  # type: ignore[import-untyped]
 from hydra.core.config_store import ConfigStore
 from hydra.test_utils.test_utils import find_parent_dir_containing, run_python_script
 from omegaconf import II, MISSING, SI, DictConfig, OmegaConf
@@ -23,6 +23,17 @@ class Action(Enum):
     check = 1
     build = 2
     bump = 3
+    set_version = 4
+
+
+class BuildPolicy(Enum):
+    unpublished = 1
+    all = 2
+
+
+class Repository(Enum):
+    pypi = 1
+    testpypi = 2
 
 
 class VersionType(Enum):
@@ -46,36 +57,68 @@ class Config:
     packages: Dict[str, Package] = MISSING
     build_targets: Tuple[str, ...] = ("--sdist", "--wheel")
     build_dir: str = "build"
+    build_policy: BuildPolicy = BuildPolicy.unpublished
+    clean_build_dir: bool = False
+    repository: Repository = Repository.pypi
+    require_artifacts: bool = False
+    version: Optional[str] = None
 
 
 ConfigStore.instance().store(name="config_schema", node=Config)
 
 
 @lru_cache()
-def get_metadata(package_name: str) -> DictConfig:
-    url = f"https://pypi.org/pypi/{package_name}/json"
+def get_metadata(repository: Repository, package_name: str) -> Optional[DictConfig]:
+    host = {
+        Repository.pypi: "pypi.org",
+        Repository.testpypi: "test.pypi.org",
+    }[repository]
+    url = f"https://{host}/pypi/{package_name}/json"
     with requests.get(url, timeout=10) as response:
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
         ret = OmegaConf.create(response.content.decode("utf-8"))
     response.close()
     assert isinstance(ret, DictConfig)
     return ret
 
 
-def get_releases(metadata: DictConfig) -> List[Version]:
+def get_latest_release(metadata: Optional[DictConfig]) -> Optional[Version]:
+    if metadata is None:
+        return None
     ret: List[Version] = []
     for ver, files in metadata.releases.items():
         for file in files:
             if file.packagetype == "bdist_wheel" and file.yanked is not True:
                 v = parse_version(ver)
                 ret.append(v)
-    return sorted(ret)
+    if len(ret) == 0:
+        return None
+    return sorted(ret)[-1]
+
+
+def is_version_published(metadata: Optional[DictConfig], version: Version) -> bool:
+    if metadata is None:
+        return False
+    for ver in metadata.releases:
+        if parse_version(ver) == version:
+            return True
+    return False
 
 
 @dataclass
 class PackageInfo:
     name: str
     local_version: Version
-    latest_version: Version
+    latest_version: Optional[Version]
+    local_version_published: bool
+
+
+@dataclass
+class LocalPackageInfo:
+    name: str
+    local_version: Version
 
 
 def parse_version(ver: str) -> Version:
@@ -84,7 +127,14 @@ def parse_version(ver: str) -> Version:
     return v
 
 
-def get_package_info(path: str) -> PackageInfo:
+def _last_output_line(out: str) -> str:
+    lines = [line.strip() for line in out.splitlines() if line.strip()]
+    if not lines:
+        raise ValueError("Expected command output")
+    return lines[-1]
+
+
+def get_local_package_info(path: str) -> LocalPackageInfo:
     try:
         prev = os.getcwd()
         path = os.path.abspath(path)
@@ -92,25 +142,48 @@ def get_package_info(path: str) -> PackageInfo:
         out, _err = run_python_script(
             cmd=[f"{path}/setup.py", "--version"], allow_warnings=True
         )
-        local_version: Version = parse_version(out)
         package_name, _err = run_python_script(
             cmd=[f"{path}/setup.py", "--name"], allow_warnings=True
         )
     finally:
         os.chdir(prev)
 
-    remote_metadata = get_metadata(package_name)
-    latest = get_releases(remote_metadata)[-1]
-    return PackageInfo(
-        name=package_name, local_version=local_version, latest_version=latest
+    return LocalPackageInfo(
+        name=_last_output_line(package_name),
+        local_version=parse_version(_last_output_line(out)),
     )
+
+
+def get_package_info(repository: Repository, path: str) -> PackageInfo:
+    local = get_local_package_info(path)
+    remote_metadata = get_metadata(repository, local.name)
+    latest = get_latest_release(remote_metadata)
+    return PackageInfo(
+        name=local.name,
+        local_version=local.local_version,
+        latest_version=latest,
+        local_version_published=is_version_published(
+            remote_metadata, local.local_version
+        ),
+    )
+
+
+def is_publishable(info: PackageInfo) -> bool:
+    return not info.local_version_published
+
+
+def format_latest_version(version: Optional[Version]) -> str:
+    if version is None:
+        return "<not published>"
+    return str(version)
 
 
 def build_package(cfg: Config, pkg_path: str, build_dir: str) -> None:
     try:
         prev = os.getcwd()
         os.chdir(pkg_path)
-        log.info(f"Building {get_package_info('.').name}")
+        local = get_local_package_info(".")
+        log.info(f"Building {local.name} ({local.local_version})")
         shutil.rmtree("dist", ignore_errors=True)
         cmd = ["-m", "build", "-o", build_dir, *cfg.build_targets]
         run_python_script(
@@ -119,6 +192,17 @@ def build_package(cfg: Config, pkg_path: str, build_dir: str) -> None:
         )
     finally:
         os.chdir(prev)
+
+
+def prepare_build_dir(cfg: Config, build_dir_path: Path) -> None:
+    if cfg.clean_build_dir and build_dir_path.exists():
+        shutil.rmtree(build_dir_path)
+    elif build_dir_path.exists() and any(build_dir_path.iterdir()):
+        raise ValueError(
+            f"Build directory {build_dir_path} is not empty. "
+            "Use clean_build_dir=true or choose an empty build_dir."
+        )
+    build_dir_path.mkdir(parents=True, exist_ok=True)
 
 
 def _next_version(version: str) -> str:
@@ -145,7 +229,9 @@ def _next_version(version: str) -> str:
     return str(new_version)
 
 
-def bump_version_in_file(cfg: Config, name: str, ver_file: Path) -> None:
+def bump_version_in_file(
+    cfg: Config, name: str, ver_file: Path, target_version: Optional[str] = None
+) -> None:
     loaded = ver_file.read_text("utf-8")
     # https://regex101.com/r/DoxaSI/1
     regex = r"((?:__)?version(?:__)?\s*=\s*)((?:\"|\')(.*?)(?:\"|\'))"
@@ -153,23 +239,29 @@ def bump_version_in_file(cfg: Config, name: str, ver_file: Path) -> None:
     matches = re.search(regex, loaded)
 
     if matches:
-        new_version = _next_version(matches.group(3))
-        log.info(f"Bumping version of {name} from {matches.group(2)} to {new_version}")
+        new_version = target_version or _next_version(matches.group(3))
+        parse_version(new_version)
+        log.info(f"Setting version of {name} from {matches.group(3)} to {new_version}")
         subst = f'{matches.group(1)}"{new_version}"'
-        result = re.sub(regex, subst, loaded, 0)
+        result = re.sub(regex, subst, loaded, count=0)
         if not cfg.dry_run:
             ver_file.write_text(result)
     else:
         raise ValueError(f"Could not find version in {ver_file}")
 
 
-def bump_version(cfg: Config, package: Package, hydra_root: str) -> None:
+def bump_version(
+    cfg: Config,
+    package: Package,
+    hydra_root: str,
+    target_version: Optional[str] = None,
+) -> None:
     if package.version_type == VersionType.SETUP:
         ver_file = Path(hydra_root) / package.path / "setup.py"
-        bump_version_in_file(cfg, package.name, ver_file)
+        bump_version_in_file(cfg, package.name, ver_file, target_version)
     elif package.version_type == VersionType.FILE:
         ver_file = Path(hydra_root) / package.path / package.version_file
-        bump_version_in_file(cfg, package.name, ver_file)
+        bump_version_in_file(cfg, package.name, ver_file, target_version)
     else:
         raise ValueError()
 
@@ -180,38 +272,74 @@ OmegaConf.register_new_resolver("parent_key", lambda _parent_: _parent_._key())
 @hydra.main(version_base=None, config_path="conf", config_name="config")
 def main(cfg: Config) -> None:
     hydra_root = find_parent_dir_containing(target="ATTRIBUTION")
-    build_dir = f"{os.getcwd()}/{cfg.build_dir}"
-    Path(build_dir).mkdir(parents=True)
+    build_dir_path = Path(cfg.build_dir).expanduser()
+    if not build_dir_path.is_absolute():
+        build_dir_path = Path(os.getcwd()) / build_dir_path
+    if cfg.action == Action.build:
+        prepare_build_dir(cfg, build_dir_path)
+    else:
+        build_dir_path.mkdir(parents=True, exist_ok=True)
+    build_dir = str(build_dir_path)
     log.info(f"Build outputs : {build_dir}")
     if cfg.action == Action.check:
-        log.info("Checking for unpublished packages")
+        log.info(f"Checking for unpublished packages on {cfg.repository.name}")
         for package in cfg.packages.values():
             pkg_path = os.path.normpath(os.path.join(hydra_root, package.path))
-            ret = get_package_info(pkg_path)
-            if ret.local_version == ret.latest_version:
+            ret = get_package_info(cfg.repository, pkg_path)
+            if ret.local_version_published and ret.local_version == ret.latest_version:
                 log.info(f"\U0000274a : {ret.name} : match ({ret.latest_version})")
-            elif ret.local_version > ret.latest_version:
+            elif ret.local_version_published:
+                latest_version = format_latest_version(ret.latest_version)
                 log.info(
-                    f"\U0000274b : {ret.name} : newer (local={ret.local_version} > latest={ret.latest_version})"
+                    f"\U0000274a : {ret.name} : already published "
+                    f"(local={ret.local_version}, latest={latest_version})"
                 )
             else:
+                latest_version = format_latest_version(ret.latest_version)
                 log.info(
-                    f"\U0000274c : {ret.name} : older (local={ret.local_version} < latest={ret.latest_version})"
+                    f"\U0000274b : {ret.name} : unpublished "
+                    f"(local={ret.local_version}, latest={latest_version})"
                 )
     elif cfg.action == Action.build:
-        log.info("Building unpublished packages")
+        log.info(
+            f"Building packages with policy {cfg.build_policy.name} against {cfg.repository.name}"
+        )
+        built_any = False
         for package in cfg.packages.values():
             pkg_path = os.path.normpath(os.path.join(hydra_root, package.path))
-            ret = get_package_info(pkg_path)
-            if ret.local_version > ret.latest_version:
+            if cfg.build_policy == BuildPolicy.all:
                 build_package(cfg, pkg_path, build_dir)
+                built_any = True
+            else:
+                ret = get_package_info(cfg.repository, pkg_path)
+                if is_publishable(ret):
+                    build_package(cfg, pkg_path, build_dir)
+                    built_any = True
+                else:
+                    latest_version = format_latest_version(ret.latest_version)
+                    log.info(
+                        f"Skipping {ret.name} ({ret.local_version}); "
+                        f"version already exists on {cfg.repository.name} "
+                        f"(latest={latest_version})"
+                    )
+        if cfg.require_artifacts and not built_any:
+            raise ValueError(
+                f"No publishable artifacts were built for {cfg.repository.name}"
+            )
     elif cfg.action == Action.bump:
-        log.info("Bumping version of published packages")
+        log.info(f"Bumping version of packages published on {cfg.repository.name}")
         for package in cfg.packages.values():
             pkg_path = os.path.normpath(os.path.join(hydra_root, package.path))
-            ret = get_package_info(pkg_path)
+            ret = get_package_info(cfg.repository, pkg_path)
             if ret.local_version == ret.latest_version:
                 bump_version(cfg, package, hydra_root)
+    elif cfg.action == Action.set_version:
+        if cfg.version is None:
+            raise ValueError("action=set_version requires version=<target version>")
+        parse_version(cfg.version)
+        log.info(f"Setting package versions to {cfg.version}")
+        for package in cfg.packages.values():
+            bump_version(cfg, package, hydra_root, target_version=cfg.version)
 
     else:
         raise ValueError("Unexpected action type")

--- a/tools/release/test_release.py
+++ b/tools/release/test_release.py
@@ -1,0 +1,24 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from tools.release.release import PackageInfo, is_publishable, parse_version
+
+
+def test_publishable_when_local_version_is_older_than_latest_but_unpublished() -> None:
+    info = PackageInfo(
+        name="hydra-core",
+        local_version=parse_version("1.3.5"),
+        latest_version=parse_version("1.4.0"),
+        local_version_published=False,
+    )
+
+    assert is_publishable(info)
+
+
+def test_not_publishable_when_local_version_is_already_published() -> None:
+    info = PackageInfo(
+        name="hydra-core",
+        local_version=parse_version("1.3.5"),
+        latest_version=parse_version("1.4.0"),
+        local_version_published=True,
+    )
+
+    assert not is_publishable(info)

--- a/website/docs/development/release.md
+++ b/website/docs/development/release.md
@@ -4,14 +4,137 @@ title: Release process
 sidebar_label: Release process
 ---
 
-The release process may be automated in the future.
+Hydra publishes Python packages through GitHub Actions Trusted Publishing.
+Maintainers use the local release tool to set versions, compare local packages
+against PyPI or TestPyPI, and build artifacts. GitHub Actions performs the
+actual upload.
 
-- Checkout main
-- Update the Hydra version in `hydra/__init__.py`
-- Update NEWS.md with towncrier
-- Create a wheel and source dist for hydra-core: `python -m build`
-- Upload pip package: `python -m twine upload dist/*`
-- Update the link to the latest stable release in `website/docs/intro.md`
-- If you are creating a new release branch:
-  - [tag a new versioned copy of the docs using docusaurus](https://docusaurus.io/docs/versioning#tagging-a-new-version)
-  - update `website/docusaurus.config.js` with a pointer to the new release branch on github
+Do not run `twine upload` locally for Hydra releases.
+
+## Package sets
+
+The release tool is package-set aware:
+
+- `set=hydra-core`: `hydra-core` only.
+- `set=hydra-plugins`: bundled Hydra plugins only.
+- `set=hydra-full-release`: `hydra-core` plus bundled Hydra plugins.
+- `set=configen`: `hydra-configen` only.
+- `set=all`: `hydra-core`, bundled Hydra plugins, and `hydra-configen`.
+
+The default Hydra release set is `hydra-full-release`. `hydra-configen` remains
+a supported target, but it is not included in the default Hydra package release.
+
+## Versioning
+
+The Hydra core version is defined in `hydra/__init__.py`. Plugin versions are
+defined in each plugin package's `hydra_plugins/<plugin>/__init__.py`.
+
+For coordinated Hydra releases, set the core and bundled plugin versions
+together:
+
+```shell
+python tools/release/release.py \
+  action=set_version \
+  set=hydra-full-release \
+  version=1.4.0.dev2
+```
+
+Use PEP 440 version spelling, such as `1.4.0.dev2`, `1.4.0rc1`, or `1.4.0`.
+
+## Local checks
+
+Before publishing, compare the selected packages against the target repository:
+
+```shell
+python tools/release/release.py \
+  action=check \
+  set=hydra-full-release \
+  repository=pypi
+```
+
+Use `repository=testpypi` when preparing a TestPyPI upload.
+
+To build only artifacts whose exact local version is not already published to
+the selected repository:
+
+```shell
+python tools/release/release.py \
+  action=build \
+  set=hydra-full-release \
+  repository=pypi \
+  clean_build_dir=true \
+  require_artifacts=true \
+  build_dir="${PWD}/dist"
+twine check "${PWD}/dist"/*
+```
+
+Use `build_policy=all` only for local smoke tests where you intentionally want
+to ignore repository state.
+
+## TestPyPI
+
+Use TestPyPI to rehearse a release without touching real PyPI.
+
+- Check out the branch or commit to test.
+- Set the intended version with `tools/release/release.py`.
+- Push the branch.
+- Run the `Publish to Test PyPI` workflow manually.
+- Select the branch containing the version bump.
+- Use `publish=false` for a dry run. This builds and checks artifacts, then
+  skips the upload job.
+- Use `publish=true` to upload the checked artifacts to TestPyPI.
+- Approve the `test-pypi-publish` environment if prompted.
+- Review the workflow release summary for the exact artifacts that were, or
+  would be, uploaded.
+- After `publish=true`, install from TestPyPI in a clean environment and smoke
+  test the packages.
+
+## PyPI
+
+Use the PyPI workflow for real dev, release-candidate, and stable releases.
+
+- Check out `main`, or the release branch for a maintenance release.
+- Set the intended version with `tools/release/release.py`.
+- For stable releases, update `NEWS.md` with towncrier.
+- Commit and push the release changes.
+- For a dry run, run the `Publish to PyPI` workflow manually with
+  `publish=false`.
+- Review the workflow release summary for the exact artifacts that would be
+  uploaded.
+- To publish, create a GitHub release for the tag, for example `v1.4.0.dev2` or
+  `v1.4.0`.
+- Mark dev and release-candidate GitHub releases as prereleases.
+- Approve the `pypi-publish` environment if prompted.
+
+The `Publish to PyPI` workflow runs automatically when a GitHub release is
+created. It builds artifacts whose local versions are newer than PyPI, checks
+them, and publishes them through Trusted Publishing.
+
+The PyPI workflow can also be triggered manually. Manual runs default to
+`publish=false`; set `publish=true` only when intentionally publishing from that
+manual run.
+
+## Release summaries
+
+Both publish workflows write a release summary to the GitHub Actions run. The
+summary includes:
+
+- target repository,
+- publish mode,
+- trigger,
+- ref,
+- commit,
+- outcome,
+- the full list of artifacts in `dist/`.
+
+Use the summary as the maintainer-facing answer to "what would this publish?"
+
+## Stable documentation
+
+For a new stable release line, also update the website:
+
+- Update the link to the latest stable release in `website/docs/intro.md`.
+- If creating a new release branch, tag a new versioned copy of the docs using
+  Docusaurus.
+- Update `website/docusaurus.config.js` with a pointer to the new release
+  branch on GitHub.


### PR DESCRIPTION

Add package-set aware release tooling for checking, setting versions, and
building artifacts for hydra-core, bundled plugins, full Hydra releases, and
configen.

Update the PyPI and TestPyPI workflows to build through the release tool,
support dry-run publish mode, and write a release summary listing the target
repository, trigger, ref, commit, outcome, and artifacts.

Document the maintainer release process and link it from CONTRIBUTING.md.

After this lands, smoke-test from main before any real publish:

- Run tools/release/release.py action=check set=hydra-full-release
  repository=pypi.
- Run tools/release/release.py action=set_version set=hydra-full-release
  version=1.4.0.dev2 dry_run=true.
- Trigger Publish to Test PyPI manually with publish=false and verify the
  release summary and artifact list.
- Only then consider a TestPyPI publish=true rehearsal.
