### PR TITLE
Install Backlog Atlas from backlog_atlas-0.13-0.gec3fb3755b6e-py3-none-any.whl

### DIFF
--- a/.github/backlog-atlas/config.yaml
+++ b/.github/backlog-atlas/config.yaml
@@ -1,0 +1,55 @@
+# Backlog Atlas configuration
+# Set done_expire_days to null to keep done items indefinitely.
+done_expire_days: 365
+
+# Categories control how issues are classified. Each category has:
+#   labels:   GitHub labels that map directly to this category (exact match)
+#   keywords: words/phrases matched against the issue title (word-boundary match)
+# Label match takes priority over keyword match. Within each tier, categories
+# are checked in the order defined in CATEGORY_ORDER (Bug first, then Enhancement, …).
+categories:
+  Bug:
+    labels: [bug]
+    keywords: [bug, error, fail, broken, crash, exception, runtimeerror, assertionerror]
+  Enhancement:
+    labels:
+      - enhancement
+      - good first issue
+      - help wanted
+      - performance
+      - duplicate
+      - invalid
+      - wontfix
+      - discussion
+      - awaiting response
+      - wishlist
+    keywords:
+      - feature
+      - add
+      - support
+      - allow
+      - enable
+      - implement
+      - enhancement
+      - request
+      - wishlist
+      - consider
+      - performance
+      - speed
+      - slow
+      - optimize
+      - memory
+      - cpu
+      - latency
+  Documentation:
+    labels: [documentation]
+    keywords: [doc, documentation, readme, comment, typo, spelling]
+  Question:
+    labels: [question]
+    keywords: [question, "how to", help, confused, unclear, wonder]
+  Refactor:
+    labels: [refactor]
+    keywords: [refactor, cleanup, "clean up", remove, delete, deprecated, modernize]
+  Build:
+    labels: [build, dependencies]
+    keywords: [build, package, release, ci, "github actions", setup.py, pyproject, wheel, packaging]

--- a/.github/backlog-atlas/manifest.json
+++ b/.github/backlog-atlas/manifest.json
@@ -17,15 +17,27 @@
       "remove": "clean"
     },
     {
+      "branch": "default",
+      "optional": true,
+      "path": ".github/backlog-atlas/atlas.yaml",
+      "remove": "clean"
+    },
+    {
+      "branch": "default",
+      "optional": true,
+      "path": ".github/workflows/temporary-backlog-atlas-upgrade-cleanup.yml",
+      "remove": "uninstall"
+    },
+    {
       "branch": "backlog-atlas",
-      "path": ".backlog-atlas/packages/backlog_atlas-0.11-0.g54b213d52759-py3-none-any.whl",
+      "path": ".backlog-atlas/packages/backlog_atlas-0.13-0.gec3fb3755b6e-py3-none-any.whl",
       "remove": "uninstall"
     }
   ],
   "install": {
-    "bundled_wheel_path": ".backlog-atlas/packages/backlog_atlas-0.11-0.g54b213d52759-py3-none-any.whl",
-    "install_source": "backlog-atlas-branch/.backlog-atlas/packages/backlog_atlas-0.11-0.g54b213d52759-py3-none-any.whl",
-    "installed_version": "0.11",
+    "bundled_wheel_path": ".backlog-atlas/packages/backlog_atlas-0.13-0.gec3fb3755b6e-py3-none-any.whl",
+    "install_source": "backlog-atlas-branch/.backlog-atlas/packages/backlog_atlas-0.13-0.gec3fb3755b6e-py3-none-any.whl",
+    "installed_version": "0.13",
     "source_type": "bundled-wheel",
     "workflow_path": ".github/workflows/update-backlog-atlas.yml"
   },

--- a/.github/workflows/temporary-backlog-atlas-upgrade-cleanup.yml
+++ b/.github/workflows/temporary-backlog-atlas-upgrade-cleanup.yml
@@ -1,0 +1,98 @@
+name: Backlog Atlas Upgrade Cleanup
+
+on:
+  push:
+    paths:
+      - .github/workflows/update-backlog-atlas.yml
+      - .github/workflows/temporary-backlog-atlas-upgrade-cleanup.yml
+      - .github/backlog-atlas/manifest.json
+  workflow_dispatch:
+
+concurrency:
+  group: backlog-atlas-upgrade-cleanup
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  BACKLOG_ATLAS_BRANCH: backlog-atlas
+  BACKLOG_ATLAS_CLEANUP_WORKFLOW: ".github/workflows/temporary-backlog-atlas-upgrade-cleanup.yml"
+  BACKLOG_ATLAS_REMOVE_PACKAGES_JSON: '[".backlog-atlas/packages/backlog_atlas-0.11-0.g54b213d52759-py3-none-any.whl"]'
+
+jobs:
+  cleanup:
+    if: github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Remove old bundled install packages
+        run: |
+          python3 - <<'PY' > /tmp/backlog-atlas-remove-packages
+          import json
+          import os
+          from pathlib import PurePosixPath
+
+          def safe(path):
+              if not isinstance(path, str) or "\n" in path or path.startswith("/"):
+                  return False
+              parts = PurePosixPath(path).parts
+              return ".." not in parts and path not in {"", "."}
+
+          try:
+              paths = json.loads(os.environ["BACKLOG_ATLAS_REMOVE_PACKAGES_JSON"])
+          except json.JSONDecodeError:
+              paths = []
+
+          if not isinstance(paths, list):
+              paths = []
+
+          for path in dict.fromkeys(paths):
+              if (
+                  safe(path)
+                  and path.startswith(".backlog-atlas/packages/")
+                  and path.endswith(".whl")
+              ):
+                  print(path)
+          PY
+
+          if ! [ -s /tmp/backlog-atlas-remove-packages ]; then
+            echo "::notice title=Backlog Atlas upgrade cleanup::No old bundled install packages were listed."
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --heads origin "$BACKLOG_ATLAS_BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$BACKLOG_ATLAS_BRANCH"
+            git worktree add ../backlog-atlas-branch FETCH_HEAD
+            cd ../backlog-atlas-branch
+            while IFS= read -r package; do
+              if [ -z "$package" ]; then
+                  continue
+              fi
+              git rm --ignore-unmatch -- "$package"
+            done < /tmp/backlog-atlas-remove-packages
+            if git diff --cached --quiet; then
+              echo "::notice title=Backlog Atlas upgrade cleanup::No old bundled install packages were present."
+            else
+              git commit -m "backlog: remove old bundled install packages [skip ci]"
+              git push origin HEAD:"$BACKLOG_ATLAS_BRANCH"
+              echo "::notice title=Backlog Atlas upgrade cleanup::Removed old bundled install packages from $BACKLOG_ATLAS_BRANCH."
+            fi
+          else
+            echo "::notice title=Backlog Atlas upgrade cleanup::$BACKLOG_ATLAS_BRANCH branch was absent."
+          fi
+      - name: Remove temporary upgrade cleanup workflow
+        run: |
+          git rm --ignore-unmatch "$BACKLOG_ATLAS_CLEANUP_WORKFLOW"
+          if git diff --cached --quiet; then
+            echo "::notice title=Backlog Atlas upgrade cleanup::Temporary cleanup workflow was already absent."
+          else
+            git commit -m "backlog: remove temporary upgrade cleanup workflow [skip ci]"
+            git push
+          fi

--- a/.github/workflows/update-backlog-atlas.yml
+++ b/.github/workflows/update-backlog-atlas.yml
@@ -16,7 +16,7 @@ permissions:
   pull-requests: read
 
 env:
-  BACKLOG_ATLAS_PIP: backlog-atlas-branch/.backlog-atlas/packages/backlog_atlas-0.11-0.g54b213d52759-py3-none-any.whl
+  BACKLOG_ATLAS_PIP: backlog-atlas-branch/.backlog-atlas/packages/backlog_atlas-0.13-0.gec3fb3755b6e-py3-none-any.whl
   BACKLOG_ATLAS_BRANCH: backlog-atlas
 
 jobs:
@@ -85,6 +85,15 @@ jobs:
       - name: Stage web assets on Backlog Atlas branch
         run: |
           backlog-atlas dump-web --output backlog-atlas-branch/index.html
+      - name: Stage multi-repo atlas manifest
+        run: |
+          if [ -f .github/backlog-atlas/atlas.yaml ]; then
+            backlog-atlas dump-atlas \
+              --config .github/backlog-atlas/atlas.yaml \
+              --output backlog-atlas-branch
+          else
+            rm -f backlog-atlas-branch/atlas.json
+          fi
       - name: Commit to Backlog Atlas branch
         run: |
           cd backlog-atlas-branch
@@ -92,6 +101,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git rm --ignore-unmatch BACKLOG.md BACKLOG-UPDATES.md
           git add .backlog-atlas last_snapshot.json backlog.json updates.jsonl index.html
+          if [ -f atlas.json ]; then
+            git add atlas.json
+          else
+            git rm --ignore-unmatch atlas.json
+          fi
           git diff --cached --quiet && exit 0
           COMMIT_MSG=$(cat /tmp/backlog_commit_msg.txt 2>/dev/null || echo "backlog: sync [skip ci]")
           git commit -m "$COMMIT_MSG"


### PR DESCRIPTION
Adds the Backlog Atlas workflow.

Installs Backlog Atlas 0.13 from bundled wheel .backlog-atlas/packages/backlog_atlas-0.13-0.gec3fb3755b6e-py3-none-any.whl.

Install source: `backlog-atlas-branch/.backlog-atlas/packages/backlog_atlas-0.13-0.gec3fb3755b6e-py3-none-any.whl`