### PR TITLE
ci: declare least-privilege workflow-level contents: read

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
       - '*_branch'
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+
+permissions:
+  contents: read
+
 jobs:
   deploy:
 


### PR DESCRIPTION
This PR adds a workflow-level `permissions: contents: read` to 2 workflow(s) that currently have no `permissions:` block (and therefore get the default broad read-write token). Each affected workflow was inspected and only reads repository contents; no publish/release/push/comment paths, so the change is non-functional in steady state and just shrinks the blast radius.

GitHub's documented Actions security recommendation. Happy to split per-file or adjust naming if preferred.