### PR TITLE
Add nested defaults tutorial config

### DIFF
--- a/examples/tutorials/basic/your_first_hydra_app/5_defaults/conf/db/mysql/engine/innodb.yaml
+++ b/examples/tutorials/basic/your_first_hydra_app/5_defaults/conf/db/mysql/engine/innodb.yaml
@@ -1,0 +1,1 @@
+name: innodb

--- a/tests/test_examples/test_tutorials_basic.py
+++ b/tests/test_examples/test_tutorials_basic.py
@@ -184,7 +184,21 @@ def test_tutorial_config_groups(
 @mark.parametrize(
     "args,expected",
     [
-        ([], {"db": {"driver": "mysql", "pass": "secret", "user": "omry"}}),
+        (
+            [],
+            {"db": {"driver": "mysql", "pass": "secret", "user": "omry"}},
+        ),
+        (
+            ["+db/mysql/engine=innodb"],
+            {
+                "db": {
+                    "driver": "mysql",
+                    "pass": "secret",
+                    "mysql": {"engine": {"name": "innodb"}},
+                    "user": "omry",
+                }
+            },
+        ),
         (
             ["db=postgresql"],
             {


### PR DESCRIPTION

Add the missing innodb nested config group used by the defaults list tutorial's illustrative nested config-group example. Cover selecting db/mysql/engine=innodb in the basic tutorial example test so the referenced subgroup stays loadable.

Fixes #3065
