### PR TITLE
Fix defaults list interpolation inside config groups

### DIFF
--- a/hydra/core/default_element.py
+++ b/hydra/core/default_element.py
@@ -421,8 +421,11 @@ class ConfigDefault(InputDefault):
         return node._is_interpolation()
 
     def resolve_interpolation(self, known_choices: DictConfig) -> None:
-        path = self.get_config_path()
-        self.path = self._resolve_interpolation_impl(known_choices, path)
+        assert self.path is not None
+        absolute = self.path.startswith("/")
+        path = self.path[1:] if absolute else self.path
+        resolved = self._resolve_interpolation_impl(known_choices, path)
+        self.path = f"/{resolved.lstrip('/')}" if absolute else resolved
 
     def is_missing(self) -> bool:
         return self.get_name() == "???"

--- a/news/3036.bugfix
+++ b/news/3036.bugfix
@@ -1,0 +1,1 @@
+Fixed defaults list interpolation inside config groups.

--- a/tests/defaults_list/data/group1/config_default_absolute_interpolation.yaml
+++ b/tests/defaults_list/data/group1/config_default_absolute_interpolation.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - /${group2}

--- a/tests/defaults_list/data/group1/config_default_interpolation.yaml
+++ b/tests/defaults_list/data/group1/config_default_interpolation.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - ${group2}

--- a/tests/defaults_list/data/interpolation_config_default_absolute_in_nested.yaml
+++ b/tests/defaults_list/data/interpolation_config_default_absolute_in_nested.yaml
@@ -1,0 +1,3 @@
+defaults:
+  - group1: config_default_absolute_interpolation
+  - group2: file1

--- a/tests/defaults_list/data/interpolation_config_default_in_nested.yaml
+++ b/tests/defaults_list/data/interpolation_config_default_in_nested.yaml
@@ -1,0 +1,3 @@
+defaults:
+  - group1: config_default_interpolation
+  - group2: file1

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -2013,6 +2013,51 @@ def test_placeholder(
             id="interpolation_config_default",
         ),
         param(
+            "interpolation_config_default_in_nested",
+            [],
+            DefaultsTreeNode(
+                node=ConfigDefault(path="interpolation_config_default_in_nested"),
+                children=[
+                    DefaultsTreeNode(
+                        node=GroupDefault(
+                            group="group1", value="config_default_interpolation"
+                        ),
+                        children=[
+                            ConfigDefault(path="file1"),
+                            ConfigDefault(path="_self_"),
+                        ],
+                    ),
+                    GroupDefault(group="group2", value="file1"),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="interpolation_config_default_in_nested",
+        ),
+        param(
+            "interpolation_config_default_absolute_in_nested",
+            [],
+            DefaultsTreeNode(
+                node=ConfigDefault(
+                    path="interpolation_config_default_absolute_in_nested"
+                ),
+                children=[
+                    DefaultsTreeNode(
+                        node=GroupDefault(
+                            group="group1",
+                            value="config_default_absolute_interpolation",
+                        ),
+                        children=[
+                            ConfigDefault(path="/file1"),
+                            ConfigDefault(path="_self_"),
+                        ],
+                    ),
+                    GroupDefault(group="group2", value="file1"),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="interpolation_config_default_absolute_in_nested",
+        ),
+        param(
             "interpolation_bad_key",
             [],
             raises(


### PR DESCRIPTION

Resolve ConfigDefault interpolation before applying the containing config
group's path. This prevents defaults list interpolation entries inside config
groups from being expanded with the group path twice.

Add a regression test covering interpolation in a defaults list loaded from a
config group, plus a news fragment.

Closes #3036
