### PR TITLE
Prepare Hydra 1.4.0.dev2

### DIFF
--- a/hydra/__init__.py
+++ b/hydra/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 # Source of truth for Hydra's version
-__version__ = "1.4.0.dev1"
+__version__ = "1.4.0.dev2"
 from hydra import utils
 from hydra.errors import MissingConfigException
 from hydra.main import main

--- a/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/__init__.py
+++ b/plugins/hydra_ax_sweeper/hydra_plugins/hydra_ax_sweeper/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.4.0.dev0"
+__version__ = "1.4.0.dev2"

--- a/plugins/hydra_colorlog/hydra_plugins/hydra_colorlog/__init__.py
+++ b/plugins/hydra_colorlog/hydra_plugins/hydra_colorlog/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.4.0.dev1"
+__version__ = "1.4.0.dev2"

--- a/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/__init__.py
+++ b/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.4.0.dev1"
+__version__ = "1.4.0.dev2"

--- a/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/__init__.py
+++ b/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.4.0.dev0"
+__version__ = "1.4.0.dev2"

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/__init__.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.4.0.dev0"
+__version__ = "1.4.0.dev2"

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/__init__.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.4.0.dev0"
+__version__ = "1.4.0.dev2"

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/__init__.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.4.0.dev0"
+__version__ = "1.4.0.dev2"

--- a/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/__init__.py
+++ b/plugins/hydra_submitit_launcher/hydra_plugins/hydra_submitit_launcher/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "1.4.0.dev0"
+__version__ = "1.4.0.dev2"


### PR DESCRIPTION
## Summary

Prepare the Hydra 1.4.0.dev2 dev release by aligning `hydra-core` and all bundled Hydra plugin package versions to `1.4.0.dev2`.

Package set prepared by this PR: `hydra-full-release`.

Prepared packages:

- `hydra-core`
- `hydra-ax-sweeper`
- `hydra-colorlog`
- `hydra-joblib-launcher`
- `hydra-nevergrad-sweeper`
- `hydra-optuna-sweeper`
- `hydra-ray-launcher`
- `hydra-rq-launcher`
- `hydra-submitit-launcher`

## Release consequence

Merging this PR does not publish to PyPI by itself. It prepares `main` so the next explicit maintainer publish action can publish `hydra-full-release==1.4.0.dev2` through the `Publish to PyPI` workflow.

After merge, publish with `package_set=hydra-full-release`, `expected_version=1.4.0.dev2`, and `publish=true`, or create the corresponding prerelease/tag from the prepared commit if using the release-event path.

## Local validation

- Built all `hydra-full-release` artifacts into `/tmp/hydra-1.4.0.dev2-dist`.
- Ran `twine check /tmp/hydra-1.4.0.dev2-dist/*`.
- Smoke-installed all built wheels with `pip install --no-deps`.
