### PR TITLE
Add guarded dev release automation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,6 @@
 name: Publish to PyPI
 
 on:
-  release:
-    types: [created]
   workflow_dispatch:
     inputs:
       package_set:
@@ -24,11 +22,6 @@ on:
         required: false
         type: string
         default: ""
-      github_release_tag:
-        description: "Optional draft GitHub Release tag to promote after publishing"
-        required: false
-        type: string
-        default: ""
       publish:
         description: "Publish to PyPI after building artifacts"
         required: true
@@ -38,10 +31,10 @@ on:
 permissions:
   contents: read
 
-# Use separate jobs for building and publishing so that write
-# permissions are only accessible minimally.
+# Use separate jobs for planning, building, and publishing so that write
+# permissions are only accessible to the publishing job.
 #
-# Both jobs are run under the pypi-publish environment,
+# Artifact building and publishing run under the pypi-publish environment,
 # which is configured to require review and approval from authorized
 # maintainers.
 jobs:
@@ -53,56 +46,33 @@ jobs:
       expected_version: ${{ steps.plan.outputs.expected_version }}
       package_set: ${{ steps.plan.outputs.package_set }}
       publish_enabled: ${{ steps.plan.outputs.publish_enabled }}
-      release_is_draft: ${{ steps.plan.outputs.release_is_draft }}
-      release_tag: ${{ steps.plan.outputs.release_tag }}
     steps:
     - name: Derive publish plan
       id: plan
       env:
-        EVENT_NAME: ${{ github.event_name }}
         REF_NAME: ${{ github.ref_name }}
         INPUT_PACKAGE_SET: ${{ inputs.package_set }}
         INPUT_EXPECTED_VERSION: ${{ inputs.expected_version }}
-        INPUT_GITHUB_RELEASE_TAG: ${{ inputs.github_release_tag }}
         INPUT_PUBLISH: ${{ inputs.publish }}
-        RELEASE_TAG: ${{ github.event.release.tag_name }}
-        RELEASE_IS_DRAFT: ${{ github.event.release.draft }}
       run: |
         python <<'PY'
         import os
         import re
         import sys
 
-        event_name = os.environ["EVENT_NAME"]
         ref_name = os.environ["REF_NAME"]
         input_package_set = os.environ["INPUT_PACKAGE_SET"].strip()
         input_expected_version = os.environ["INPUT_EXPECTED_VERSION"].strip()
-        input_github_release_tag = os.environ["INPUT_GITHUB_RELEASE_TAG"].strip()
         input_publish = os.environ["INPUT_PUBLISH"].strip()
-        release_tag = os.environ["RELEASE_TAG"].strip()
-        release_is_draft = os.environ["RELEASE_IS_DRAFT"].strip()
 
         def fail(message: str) -> None:
             print(f"::error::{message}")
             sys.exit(1)
 
-        if event_name == "release":
-            package_set = "hydra-full-release"
-            if not release_tag:
-                fail("Release event did not include a tag name")
-            checkout_ref = release_tag
-            expected_version = release_tag[1:] if release_tag.startswith("v") else release_tag
-            publish_enabled = "true"
-            draft = release_is_draft.lower() == "true"
-        else:
-            package_set = input_package_set or "hydra-full-release"
-            release_tag = input_github_release_tag
-            checkout_ref = release_tag or ref_name
-            expected_version = input_expected_version
-            if not expected_version and release_tag:
-                expected_version = release_tag[1:] if release_tag.startswith("v") else release_tag
-            publish_enabled = "true" if input_publish.lower() == "true" else "false"
-            draft = False
+        package_set = input_package_set or "hydra-full-release"
+        checkout_ref = ref_name
+        expected_version = input_expected_version
+        publish_enabled = "true" if input_publish.lower() == "true" else "false"
 
         if expected_version and not re.fullmatch(
             r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
@@ -119,8 +89,6 @@ jobs:
             print(f"expected_version={expected_version}", file=output)
             print(f"package_set={package_set}", file=output)
             print(f"publish_enabled={publish_enabled}", file=output)
-            print(f"release_is_draft={'true' if draft else 'false'}", file=output)
-            print(f"release_tag={release_tag}", file=output)
 
         with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
             print("## Publish plan", file=summary)
@@ -130,10 +98,6 @@ jobs:
             version = expected_version or "<not provided>"
             print(f"- Expected version: `{version}`", file=summary)
             print(f"- Publish enabled: `{publish_enabled}`", file=summary)
-            if release_tag:
-                print(f"- GitHub Release tag: `{release_tag}`", file=summary)
-            if event_name == "release":
-                print(f"- Release draft: `{'true' if draft else 'false'}`", file=summary)
         PY
 
   build-artifacts:
@@ -263,21 +227,3 @@ jobs:
 
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-
-  promote-github-release:
-    needs:
-      - release-plan
-      - pypi-publish
-    name: Promote draft GitHub Release
-    if: ${{ needs.release-plan.outputs.release_tag != '' && (github.event_name == 'workflow_dispatch' || needs.release-plan.outputs.release_is_draft == 'true') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-    - name: Publish draft release
-      env:
-        GH_TOKEN: ${{ github.token }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
-        RELEASE_TAG: ${{ needs.release-plan.outputs.release_tag }}
-      run: |
-        gh release edit "${RELEASE_TAG}" --draft=false --repo "${GITHUB_REPOSITORY}"

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -94,6 +94,41 @@ files are not uploaded again.
 The workflows also write a release summary listing the target repository,
 publish mode, trigger, ref, commit, and every artifact that was built.
 
+### Dev release
+
+Run a dry run for a coordinated dev release:
+
+```shell
+python tools/release/release.py \
+  action=dev_release \
+  set=hydra-full-release \
+  version=1.4.0.dev3
+```
+
+The dry run prints the selected packages, current local versions, target
+versions, PyPI status for the target version, and the exact publish workflow
+dispatch that would run. It also builds artifacts in a temporary release
+workspace, runs `twine check`, and smoke-installs the built wheels without
+dependencies. It does not commit, push, dispatch GitHub Actions, create or edit
+a GitHub Release, or upload anything to PyPI.
+
+To publish the dev release:
+
+```shell
+python tools/release/release.py \
+  action=dev_release \
+  set=hydra-full-release \
+  version=1.4.0.dev3 \
+  publish=true
+```
+
+Publishing requires a clean working tree whose current commit matches
+`remote/<workflow_ref>`. The command applies the version bump, commits and
+pushes it when the bump changes files, and dispatches `Publish to PyPI` with the
+selected package set and expected version. It uses `workflow_ref=main` by
+default; use `workflow_ref=<branch-or-tag>` for unusual cases such as publishing
+a dev release from an already-published release line.
+
 ### Prepare and publish workflow responsibilities
 
 Hydra release automation is split into prepare and publish phases.
@@ -108,7 +143,13 @@ Prepare release should:
 - produce a release-validation matrix;
 - run release-only checks such as the core suite with all selected compatible
   plugins installed;
-- create or update release-prep PRs and draft GitHub Releases when needed.
+- create or update release-prep PRs when needed.
+
+For release candidates, stable releases, and patch releases, generated
+release-prep PRs are the maintainer approval surface for publishing. The PR body
+must state clearly what happens when the PR is merged. Once release-prep PR
+automation exists, merging such a PR should trigger PyPI publishing, and the PR
+body must list the exact package set and version that will be published.
 
 Publish should:
 
@@ -117,15 +158,17 @@ Publish should:
 - check built artifacts;
 - publish only selected package artifacts through GitHub Actions Trusted
   Publishing;
-- promote prepared draft GitHub Releases after successful publishing when a
-  release tag is supplied.
+- eventually create or update the GitHub Release as a record of the published
+  release.
 
 The local release tool owns package metadata, version checks, repository
-comparison, and artifact building. GitHub Actions owns release validation,
-Trusted Publishing, and GitHub Release state transitions.
+comparison, and artifact building. GitHub Actions owns release validation and
+Trusted Publishing. GitHub Release state transitions are intended release
+automation work, but are not wired into the current publish workflow.
 
 The current `Prepare Release` workflow implements the validation part of this
 split: it derives release kind and target branch, applies the target version
 inside the disposable workflow checkout, checks selected packages against PyPI,
-builds artifacts, and runs release validation. Release-prep PR and draft GitHub
-Release automation are planned but not implemented yet.
+builds artifacts, and runs release validation. The current `Publish to PyPI`
+workflow is manual-only. GitHub Release creation or edits do not trigger
+publishing. Release-prep PR automation is planned but not implemented yet.

--- a/tools/release/release.py
+++ b/tools/release/release.py
@@ -3,6 +3,9 @@ import logging
 import os
 import re
 import shutil
+import subprocess
+import sys
+import tempfile
 from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
@@ -12,6 +15,7 @@ from typing import Dict, List, Optional, Tuple
 import hydra
 import requests  # type: ignore[import-untyped]
 from hydra.core.config_store import ConfigStore
+from hydra.core.hydra_config import HydraConfig
 from hydra.test_utils.test_utils import find_parent_dir_containing, run_python_script
 from omegaconf import II, MISSING, SI, DictConfig, OmegaConf
 from packaging.version import Version, parse
@@ -25,6 +29,7 @@ class Action(Enum):
     bump = 3
     set_version = 4
     validate_versions = 5
+    dev_release = 6
 
 
 class BuildPolicy(Enum):
@@ -63,6 +68,8 @@ class Config:
     repository: Repository = Repository.pypi
     require_artifacts: bool = False
     version: Optional[str] = None
+    publish: bool = False
+    workflow_ref: str = "main"
 
 
 ConfigStore.instance().store(name="config_schema", node=Config)
@@ -120,6 +127,15 @@ class PackageInfo:
 class LocalPackageInfo:
     name: str
     local_version: Version
+
+
+@dataclass
+class DevReleasePackageInfo:
+    name: str
+    local_version: Version
+    target_version: Version
+    latest_version: Optional[Version]
+    target_version_published: bool
 
 
 def parse_version(ver: str) -> Version:
@@ -184,6 +200,78 @@ def format_latest_version(version: Optional[Version]) -> str:
     if version is None:
         return "<not published>"
     return str(version)
+
+
+def validate_dev_version(version: Version) -> None:
+    if not version.is_devrelease:
+        raise ValueError(f"Dev releases require a .devN version; got {version}")
+
+
+def collect_dev_release_package_info(
+    repository: Repository,
+    packages: Dict[str, Package],
+    hydra_root: str,
+    target_version: Version,
+) -> List[DevReleasePackageInfo]:
+    ret = []
+    for package in packages.values():
+        pkg_path = os.path.normpath(os.path.join(hydra_root, package.path))
+        local = get_local_package_info(pkg_path)
+        remote_metadata = get_metadata(repository, local.name)
+        ret.append(
+            DevReleasePackageInfo(
+                name=local.name,
+                local_version=local.local_version,
+                target_version=target_version,
+                latest_version=get_latest_release(remote_metadata),
+                target_version_published=is_version_published(
+                    remote_metadata, target_version
+                ),
+            )
+        )
+    return ret
+
+
+def format_dev_release_package_table(infos: List[DevReleasePackageInfo]) -> str:
+    rows = [
+        (
+            "Package",
+            "Current local version",
+            "Target version",
+            "PyPI status",
+            "Latest PyPI version",
+        )
+    ]
+    for info in infos:
+        status = (
+            "already published" if info.target_version_published else "not published"
+        )
+        rows.append(
+            (
+                info.name,
+                str(info.local_version),
+                str(info.target_version),
+                status,
+                format_latest_version(info.latest_version),
+            )
+        )
+
+    widths = [max(len(row[idx]) for row in rows) for idx in range(len(rows[0]))]
+    lines = []
+    for index, row in enumerate(rows):
+        lines.append("  ".join(cell.ljust(widths[col]) for col, cell in enumerate(row)))
+        if index == 0:
+            lines.append("  ".join("-" * width for width in widths))
+    return "\n".join(lines)
+
+
+def fail_if_any_target_version_published(infos: List[DevReleasePackageInfo]) -> None:
+    published = [info.name for info in infos if info.target_version_published]
+    if published:
+        packages = ", ".join(sorted(published))
+        raise ValueError(
+            f"Target version is already published for selected packages: {packages}"
+        )
 
 
 def build_package(cfg: Config, pkg_path: str, build_dir: str) -> None:
@@ -274,12 +362,257 @@ def bump_version(
         raise ValueError()
 
 
+def set_package_versions(cfg: Config, hydra_root: str, target_version: str) -> None:
+    for package in cfg.packages.values():
+        bump_version(cfg, package, hydra_root, target_version=target_version)
+
+
+def _run_checked(cmd: List[str], cwd: Optional[str] = None) -> str:
+    log.info("Running: %s", " ".join(cmd))
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        check=True,
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if result.stdout:
+        log.info(result.stdout.rstrip())
+    return result.stdout
+
+
+def _python_bin(venv_path: Path) -> Path:
+    if os.name == "nt":
+        return venv_path / "Scripts" / "python.exe"
+    return venv_path / "bin" / "python"
+
+
+def check_build_artifacts(build_dir_path: Path) -> None:
+    artifacts = sorted(path for path in build_dir_path.iterdir() if path.is_file())
+    if not artifacts:
+        raise ValueError(f"No artifacts found in {build_dir_path}")
+
+    _run_checked([sys.executable, "-m", "twine", "check", *map(str, artifacts)])
+
+    wheels = [path for path in artifacts if path.suffix == ".whl"]
+    if not wheels:
+        raise ValueError(f"No wheels found in {build_dir_path}")
+
+    with tempfile.TemporaryDirectory(prefix="hydra-release-smoke-") as tmp:
+        venv_path = Path(tmp) / "venv"
+        _run_checked([sys.executable, "-m", "venv", str(venv_path)])
+        smoke_python = _python_bin(venv_path)
+        _run_checked(
+            [
+                str(smoke_python),
+                "-m",
+                "pip",
+                "install",
+                "--no-deps",
+                *map(str, wheels),
+            ]
+        )
+
+
+def validate_dev_release_artifacts(
+    cfg: Config, hydra_root: str, build_dir_path: Path, target_version: Version
+) -> None:
+    prepare_build_dir(cfg, build_dir_path)
+    set_package_versions(cfg, hydra_root, str(target_version))
+    for package in cfg.packages.values():
+        pkg_path = os.path.normpath(os.path.join(hydra_root, package.path))
+        build_package(cfg, pkg_path, str(build_dir_path))
+    check_build_artifacts(build_dir_path)
+
+
+def copy_release_workspace(hydra_root: str, destination: Path) -> Path:
+    workspace = destination / "hydra"
+    shutil.copytree(
+        hydra_root,
+        workspace,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".sl",
+            ".venv",
+            ".nox",
+            ".mypy_cache",
+            ".pytest_cache",
+            "build",
+            "dist",
+            "node_modules",
+            "temp",
+        ),
+    )
+    return workspace
+
+
+def detect_vcs(hydra_root: str) -> str:
+    root = Path(hydra_root)
+    if (root / ".sl").exists():
+        return "sl"
+    if (root / ".git").exists():
+        return "git"
+    raise ValueError(f"Could not find a supported VCS checkout at {hydra_root}")
+
+
+def ensure_clean_worktree(hydra_root: str, vcs: str) -> None:
+    status = get_worktree_status(hydra_root, vcs)
+    if status:
+        raise ValueError(
+            "Working tree must be clean before publishing a dev release. "
+            f"Found:\n{status}"
+        )
+
+
+def _single_line(cmd: List[str], cwd: str) -> str:
+    value = _run_checked(cmd, cwd=cwd).strip()
+    if not value:
+        raise ValueError(f"Command did not produce output: {' '.join(cmd)}")
+    return value.splitlines()[-1].strip()
+
+
+def ensure_publish_base_matches_ref(hydra_root: str, vcs: str, workflow_ref: str) -> None:
+    if vcs == "sl":
+        current = _single_line(["sl", "log", "-r", ".", "-T", "{node}"], hydra_root)
+        expected = _single_line(
+            ["sl", "log", "-r", f"remote/{workflow_ref}", "-T", "{node}"],
+            hydra_root,
+        )
+    else:
+        current = _single_line(["git", "rev-parse", "HEAD"], hydra_root)
+        expected = _single_line(["git", "rev-parse", f"origin/{workflow_ref}"], hydra_root)
+
+    if current != expected:
+        raise ValueError(
+            "Publishing requires the current commit to match "
+            f"remote/{workflow_ref} before the version bump. "
+            "Update to the target branch before publishing."
+        )
+
+
+def get_worktree_status(hydra_root: str, vcs: str) -> str:
+    cmd = [vcs, "status"] if vcs == "sl" else ["git", "status", "--porcelain"]
+    return _run_checked(cmd, cwd=hydra_root).strip()
+
+
+def commit_dev_release(hydra_root: str, vcs: str, target_version: Version) -> None:
+    message = f"Prepare Hydra {target_version}"
+    if vcs == "sl":
+        _run_checked(["sl", "commit", "-m", message], cwd=hydra_root)
+    else:
+        _run_checked(["git", "commit", "-am", message], cwd=hydra_root)
+
+
+def push_current_ref(hydra_root: str, vcs: str, workflow_ref: str) -> None:
+    if vcs == "sl":
+        _run_checked(["sl", "push", "--to", workflow_ref, "-r", "."], cwd=hydra_root)
+    else:
+        _run_checked(["git", "push", "origin", f"HEAD:{workflow_ref}"], cwd=hydra_root)
+
+
+def ensure_publish_tools(hydra_root: str, vcs: str) -> None:
+    _run_checked([vcs, "--version"], cwd=hydra_root)
+    _run_checked(["gh", "--version"], cwd=hydra_root)
+
+
+def dispatch_publish_workflow(
+    hydra_root: str, package_set: str, target_version: Version, workflow_ref: str
+) -> None:
+    _run_checked(
+        [
+            "gh",
+            "workflow",
+            "run",
+            "publish.yml",
+            "--ref",
+            workflow_ref,
+            "-f",
+            f"package_set={package_set}",
+            "-f",
+            f"expected_version={target_version}",
+            "-f",
+            "publish=true",
+        ],
+        cwd=hydra_root,
+    )
+
+
+def selected_package_set_name() -> str:
+    choices = HydraConfig.get().runtime.choices
+    selected = choices.get("set", "hydra-full-release")
+    return str(selected)
+
+
+def run_dev_release(
+    cfg: Config, hydra_root: str, build_dir_path: Path, package_set: str
+) -> None:
+    if not cfg.version:
+        raise ValueError("action=dev_release requires version=<target version>")
+    if cfg.dry_run:
+        raise ValueError(
+            "action=dev_release uses publish=false for dry runs; "
+            "do not set dry_run=true"
+        )
+    target_version = parse_version(cfg.version)
+    validate_dev_version(target_version)
+
+    vcs = None
+    if cfg.publish:
+        vcs = detect_vcs(hydra_root)
+        ensure_publish_tools(hydra_root, vcs)
+        ensure_clean_worktree(hydra_root, vcs)
+
+    infos = collect_dev_release_package_info(
+        cfg.repository, cfg.packages, hydra_root, target_version
+    )
+    log.info("Dev release package plan:\n%s", format_dev_release_package_table(infos))
+    fail_if_any_target_version_published(infos)
+
+    with tempfile.TemporaryDirectory(prefix="hydra-dev-release-") as tmp:
+        workspace = copy_release_workspace(hydra_root, Path(tmp))
+        validate_dev_release_artifacts(
+            cfg, str(workspace), build_dir_path, target_version
+        )
+
+    workflow_ref = cfg.workflow_ref.strip()
+    if not workflow_ref:
+        raise ValueError("workflow_ref must not be empty")
+    if cfg.publish:
+        assert vcs is not None
+        ensure_publish_base_matches_ref(hydra_root, vcs, workflow_ref)
+    log.info(
+        "Would dispatch Publish to PyPI: ref=%s package_set=%s "
+        "expected_version=%s publish=true",
+        workflow_ref,
+        package_set,
+        target_version,
+    )
+
+    if not cfg.publish:
+        log.info(
+            "Dry run complete. No commit, push, GitHub workflow dispatch, "
+            "GitHub Release, or PyPI upload was performed."
+        )
+        return
+
+    assert vcs is not None
+    set_package_versions(cfg, hydra_root, str(target_version))
+    if get_worktree_status(hydra_root, vcs):
+        commit_dev_release(hydra_root, vcs, target_version)
+        push_current_ref(hydra_root, vcs, workflow_ref)
+    else:
+        log.info("Selected packages are already at %s; skipping commit", target_version)
+    dispatch_publish_workflow(hydra_root, package_set, target_version, workflow_ref)
+
+
 OmegaConf.register_new_resolver("parent_key", lambda _parent_: _parent_._key())
 
 
 @hydra.main(version_base=None, config_path="conf", config_name="config")
 def main(cfg: Config) -> None:
     hydra_root = find_parent_dir_containing(target="ATTRIBUTION")
+    package_set = selected_package_set_name()
     build_dir_path = Path(cfg.build_dir).expanduser()
     if not build_dir_path.is_absolute():
         build_dir_path = Path(os.getcwd()) / build_dir_path
@@ -360,6 +693,8 @@ def main(cfg: Config) -> None:
             local = get_local_package_info(pkg_path)
             validate_local_version(local, expected_version)
             log.info(f"\U0000274a : {local.name} : {local.local_version}")
+    elif cfg.action == Action.dev_release:
+        run_dev_release(cfg, hydra_root, build_dir_path, package_set)
 
     else:
         raise ValueError("Unexpected action type")

--- a/tools/release/test_release.py
+++ b/tools/release/test_release.py
@@ -2,10 +2,14 @@
 import pytest
 
 from tools.release.release import (
+    DevReleasePackageInfo,
     LocalPackageInfo,
     PackageInfo,
+    fail_if_any_target_version_published,
+    format_dev_release_package_table,
     is_publishable,
     parse_version,
+    validate_dev_version,
     validate_local_version,
 )
 
@@ -46,3 +50,56 @@ def test_validate_local_version_rejects_unexpected_version() -> None:
         match="hydra-core version is 1.4.0; expected 1.4.1",
     ):
         validate_local_version(info, parse_version("1.4.1"))
+
+
+def test_validate_dev_version_accepts_dev_version() -> None:
+    validate_dev_version(parse_version("1.4.0.dev3"))
+
+
+def test_validate_dev_version_rejects_non_dev_version() -> None:
+    with pytest.raises(
+        ValueError,
+        match="Dev releases require a \\.devN version; got 1.4.0",
+    ):
+        validate_dev_version(parse_version("1.4.0"))
+
+
+def test_format_dev_release_package_table_includes_publish_plan() -> None:
+    table = format_dev_release_package_table(
+        [
+            DevReleasePackageInfo(
+                name="hydra-core",
+                local_version=parse_version("1.4.0.dev2"),
+                target_version=parse_version("1.4.0.dev3"),
+                latest_version=parse_version("1.4.0.dev2"),
+                target_version_published=False,
+            )
+        ]
+    )
+
+    assert "Package" in table
+    assert "Current local version" in table
+    assert "Target version" in table
+    assert "PyPI status" in table
+    assert "hydra-core" in table
+    assert "1.4.0.dev2" in table
+    assert "1.4.0.dev3" in table
+    assert "not published" in table
+
+
+def test_fail_if_any_target_version_published_rejects_published_package() -> None:
+    infos = [
+        DevReleasePackageInfo(
+            name="hydra-core",
+            local_version=parse_version("1.4.0.dev2"),
+            target_version=parse_version("1.4.0.dev3"),
+            latest_version=parse_version("1.4.0.dev3"),
+            target_version_published=True,
+        )
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match="Target version is already published for selected packages: hydra-core",
+    ):
+        fail_if_any_target_version_published(infos)

--- a/website/docs/development/release.md
+++ b/website/docs/development/release.md
@@ -91,8 +91,15 @@ artifacts for that version, and runs the release validation matrix.
 
 Prepare release must not upload artifacts to PyPI. The current workflow is a
 validation step. It applies target versions only inside the disposable workflow
-checkout. Creating release-prep PRs and draft GitHub Releases is part of the
-intended prepare phase but is not automated yet.
+checkout. Creating release-prep PRs is part of the intended prepare phase but is
+not automated yet.
+
+For release candidates, stable releases, and patch releases, the generated
+release-prep PR is the maintainer approval surface for publishing. The PR body
+must say clearly what happens when the PR is merged. Once release-prep PR
+automation exists, merging such a PR should trigger publishing to PyPI, and the
+PR body must list the package set and exact version that will be published. Dev
+releases may use a lighter manual publish flow and do not require a prepare PR.
 
 ## Local checks and artifact builds
 
@@ -136,6 +143,38 @@ python tools/release/release.py \
 
 Use the PyPI workflow for real dev, release-candidate, and stable releases.
 
+For dev releases, use the release tool's dev-release action. By default this is
+a dry run: it shows the selected packages and versions, checks PyPI for the
+target version, builds artifacts in a temporary release workspace, runs
+`twine check`, smoke-installs the wheels without dependencies, and prints the
+exact publish workflow dispatch that would run:
+
+```shell
+python tools/release/release.py \
+  action=dev_release \
+  set=hydra-full-release \
+  version=1.4.0.dev3
+```
+
+To publish the dev release, rerun with `publish=true`. This requires a clean
+working tree whose current commit matches `remote/<workflow_ref>`, applies the
+version bump, commits and pushes it when the bump changes files, and dispatches
+`Publish to PyPI` with the selected package set and expected version:
+
+```shell
+python tools/release/release.py \
+  action=dev_release \
+  set=hydra-full-release \
+  version=1.4.0.dev3 \
+  publish=true
+```
+
+The dev-release action uses `workflow_ref=main` by default. Use
+`workflow_ref=<branch-or-tag>` for unusual cases such as publishing a dev release
+from an already-published release line.
+
+For release candidates, stable releases, and patch releases:
+
 - Run prepare release for the target release line and package set.
 - Check out the prepared target branch.
 - Set the intended version with `tools/release/release.py`.
@@ -145,12 +184,10 @@ Use the PyPI workflow for real dev, release-candidate, and stable releases.
   `publish=false`, selecting the package set and optional expected version.
 - Review the workflow release summary for the exact artifacts that would be
   uploaded.
-- To publish, use the prepared draft GitHub Release or create a GitHub Release
-  for the tag, for example `v1.4.0.dev2` or `v1.4.0`.
-- For manual publishing from a prepared draft GitHub Release, pass the release
-  tag as `github_release_tag` so the workflow builds that tag, infers the
-  expected version when needed, and promotes the draft after PyPI publishing
-  succeeds.
+- Dispatch `Publish to PyPI` manually after the prepared release state is
+  merged. The intended next step is to replace this with generated release-prep
+  PRs where merging the PR triggers publishing to PyPI for the package set and
+  version named in the PR body.
 - Mark dev and release-candidate GitHub releases as prereleases.
 - Approve the `pypi-publish` environment if prompted.
 
@@ -159,12 +196,10 @@ expected version is provided, builds artifacts whose local versions are newer
 than PyPI, checks them, smoke-installs built wheels without dependencies, and
 publishes them through Trusted Publishing.
 
-The PyPI workflow can also be triggered manually. Manual runs default to
-`publish=false`; set `publish=true` only when intentionally publishing from that
-manual run. GitHub Release-triggered runs infer the expected version from the
-release tag and use the default `hydra-full-release` package set. Manual runs
-can build and promote a draft GitHub Release after publishing when
-`github_release_tag` is provided.
+The PyPI workflow is manual-only. Manual runs default to `publish=false`; set
+`publish=true` only when intentionally publishing from that manual run. Direct
+GitHub Release creation or edits are not treated as publish approval and do not
+trigger publishing.
 
 ## Release summaries
 


### PR DESCRIPTION

Add a dev_release action that dry-runs coordinated dev releases by showing the package/version publish table, checking PyPI, building artifacts, running twine check, and smoke-installing wheels without mutating GitHub or PyPI.

When publish=true, require a clean checkout at the target remote ref before applying the version bump, committing, pushing, and dispatching the PyPI publish workflow. Make the publish workflow manual-only and document the current dev-release and release-prep behavior.
