### PR TITLE
fix: log multirun failures to job files

### DIFF
--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -75,6 +75,21 @@ def _save_config(cfg: DictConfig, filename: str, output_dir: Path) -> None:
         file.write(OmegaConf.to_yaml(cfg))
 
 
+def _log_job_error_to_file() -> None:
+    record = log.makeRecord(
+        name=log.name,
+        level=logging.ERROR,
+        fn=__file__,
+        lno=0,
+        msg="Job failed",
+        args=(),
+        exc_info=sys.exc_info(),
+    )
+    for handler in logging.getLogger().handlers:
+        if isinstance(handler, logging.FileHandler) and record.levelno >= handler.level:
+            handler.handle(record)
+
+
 def filter_overrides(overrides: Sequence[str]) -> Sequence[str]:
     """
     :param overrides: overrides list
@@ -190,6 +205,7 @@ def run_job(
                 ret.return_value = task_function(task_cfg)
                 ret.status = JobStatus.COMPLETED
             except Exception as e:
+                _log_job_error_to_file()
                 ret.return_value = e
                 ret.status = JobStatus.FAILED
             except KeyboardInterrupt as e:

--- a/news/3215.bugfix
+++ b/news/3215.bugfix
@@ -1,0 +1,1 @@
+Log multirun failures in each job's log file.

--- a/tests/test_basic_sweeper.py
+++ b/tests/test_basic_sweeper.py
@@ -71,6 +71,7 @@ def test_partial_failure(
         "--multirun",
         "+divisor=1,0",
         f'hydra.run.dir="{str(tmpdir)}"',
+        f'hydra.sweep.dir="{str(tmpdir)}"',
         "hydra.job.chdir=True",
         "hydra.hydra_logging.formatters.simple.format='[HYDRA] %(message)s'",
     ]
@@ -86,6 +87,7 @@ def test_partial_failure(
     )
 
     assert_multiline_regex_search(expected_out_regex, out)
+    assert "Job failed" not in out
 
     expected_err_regex = dedent(r"""
         Error executing job with overrides: \['\+divisor=0'\](
@@ -100,6 +102,11 @@ def test_partial_failure(
         """).strip()
 
     assert_multiline_regex_search(expected_err_regex, err)
+
+    job_log = tmpdir / "1" / "my_app.log"
+    log_content = job_log.read()
+    assert "Job failed" in log_content
+    assert "ZeroDivisionError: division by zero" in log_content
 
 
 def test_glob_uses_primary_config_searchpath(tmpdir: Any) -> None:

--- a/tests/test_basic_sweeper.py
+++ b/tests/test_basic_sweeper.py
@@ -109,6 +109,32 @@ def test_partial_failure(
     assert "ZeroDivisionError: division by zero" in log_content
 
 
+def test_multiple_failures_log_to_own_job_files(
+    tmpdir: Any,
+) -> None:
+    cmd = [
+        sys.executable,
+        "tests/test_apps/app_can_fail/my_app.py",
+        "--multirun",
+        "+divisor=0,1,x",
+        f'hydra.run.dir="{str(tmpdir)}"',
+        f'hydra.sweep.dir="{str(tmpdir)}"',
+        "hydra.job.chdir=True",
+    ]
+    run_process(cmd=cmd, print_error=False, raise_exception=False)
+
+    succeeded_log = (tmpdir / "1" / "my_app.log").read()
+    assert "Job failed" not in succeeded_log
+
+    zero_division_log = (tmpdir / "0" / "my_app.log").read()
+    assert "Job failed" in zero_division_log
+    assert "ZeroDivisionError: division by zero" in zero_division_log
+
+    type_error_log = (tmpdir / "2" / "my_app.log").read()
+    assert "Job failed" in type_error_log
+    assert "TypeError" in type_error_log
+
+
 def test_glob_uses_primary_config_searchpath(tmpdir: Any) -> None:
     cmd = [
         sys.executable,


### PR DESCRIPTION
## Problem

Failed jobs in a basic multirun sweep were captured in JobReturn without being written while the job logging configuration was active. This left per-job log files empty and made failures other than the first one difficult to diagnose.

## Solution

I added a focused file-handler path that records the active exception in the job log without emitting another traceback to the console. I also extended the partial-failure regression test and added a bugfix news fragment.

Fixes #3215

## Testing

- `.venv/Scripts/python -m pytest tests/test_basic_sweeper.py tests/test_basic_launcher.py tests/test_callbacks.py -q` (42 passed)
- Black, isort, Flake8, and Pyrefly checks for the touched Python files
- `git diff --check`