### PR TITLE
Reject swept configs that override multirun controller

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -326,6 +326,10 @@ class ConfigLoaderImpl(ConfigLoader):
             overrides=overrides,
             run_mode=RunMode.RUN,
         )
+        ConfigLoaderImpl._ensure_no_sweep_config_controller_override(
+            master_config=master_config,
+            sweep_config=sweep_config,
+        )
 
         # Copy old config cache to ensure we get the same resolved values (for things
         # like timestamps etc). Since `oc.env` does not cache environment variables
@@ -333,6 +337,24 @@ class ConfigLoaderImpl(ConfigLoader):
         OmegaConf.copy_cache(from_config=master_config, to_config=sweep_config)
 
         return sweep_config
+
+    @staticmethod
+    def _ensure_no_sweep_config_controller_override(
+        master_config: DictConfig, sweep_config: DictConfig
+    ) -> None:
+        controller_groups = ("hydra/launcher", "hydra/sweeper")
+        master_choices = master_config.hydra.runtime.choices
+        sweep_choices = sweep_config.hydra.runtime.choices
+        for group in controller_groups:
+            master_choice = master_choices.get(group)
+            sweep_choice = sweep_choices.get(group)
+            if master_choice != sweep_choice:
+                raise ConfigCompositionException(
+                    f"'{group}' must be selected before the sweep starts, "
+                    f"but a swept job config changed it from "
+                    f"'{master_choice}' to '{sweep_choice}'. Select it in "
+                    "the primary config or from the command line."
+                )
 
     def get_search_path(self) -> ConfigSearchPath:
         return self.config_search_path

--- a/news/3231.bugfix
+++ b/news/3231.bugfix
@@ -1,0 +1,1 @@
+Reject swept configs that override the multirun launcher or sweeper.

--- a/tests/test_apps/sweep_hydra_launcher_override/__init__.py
+++ b/tests/test_apps/sweep_hydra_launcher_override/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/tests/test_apps/sweep_hydra_launcher_override/conf/__init__.py
+++ b/tests/test_apps/sweep_hydra_launcher_override/conf/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/tests/test_apps/sweep_hydra_launcher_override/conf/config.yaml
+++ b/tests/test_apps/sweep_hydra_launcher_override/conf/config.yaml
@@ -1,0 +1,3 @@
+# @package _global_
+defaults:
+  - experiment: base

--- a/tests/test_apps/sweep_hydra_launcher_override/conf/experiment/base.yaml
+++ b/tests/test_apps/sweep_hydra_launcher_override/conf/experiment/base.yaml
@@ -1,0 +1,2 @@
+# @package _global_
+experiment: base

--- a/tests/test_apps/sweep_hydra_launcher_override/conf/experiment/custom_launcher.yaml
+++ b/tests/test_apps/sweep_hydra_launcher_override/conf/experiment/custom_launcher.yaml
@@ -1,0 +1,5 @@
+# @package _global_
+defaults:
+  - override /hydra/launcher: custom_launcher
+
+experiment: custom_launcher

--- a/tests/test_apps/sweep_hydra_launcher_override/conf/experiment/custom_sweeper.yaml
+++ b/tests/test_apps/sweep_hydra_launcher_override/conf/experiment/custom_sweeper.yaml
@@ -1,0 +1,5 @@
+# @package _global_
+defaults:
+  - override /hydra/sweeper: custom_sweeper
+
+experiment: custom_sweeper

--- a/tests/test_apps/sweep_hydra_launcher_override/conf/hydra/launcher/custom_launcher.yaml
+++ b/tests/test_apps/sweep_hydra_launcher_override/conf/hydra/launcher/custom_launcher.yaml
@@ -1,0 +1,1 @@
+_target_: hydra._internal.core_plugins.basic_launcher.BasicLauncher

--- a/tests/test_apps/sweep_hydra_launcher_override/conf/hydra/sweeper/custom_sweeper.yaml
+++ b/tests/test_apps/sweep_hydra_launcher_override/conf/hydra/sweeper/custom_sweeper.yaml
@@ -1,0 +1,1 @@
+_target_: hydra._internal.core_plugins.basic_sweeper.BasicSweeper

--- a/tests/test_apps/sweep_hydra_launcher_override/my_app.py
+++ b/tests/test_apps/sweep_hydra_launcher_override/my_app.py
@@ -1,0 +1,13 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from omegaconf import DictConfig
+
+import hydra
+
+
+@hydra.main(version_base=None, config_path="conf", config_name="config")
+def my_app(_: DictConfig) -> None:
+    pass
+
+
+if __name__ == "__main__":
+    my_app()

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -650,6 +650,7 @@ def test_sweep_complex_defaults(
 def test_multirun_rejects_swept_config_hydra_controller_override(
     hydra_restore_singletons: Any,
     hydra_sweep_runner: TSweepRunner,
+    tmpdir: Path,
     controller: str,
     experiment: str,
 ) -> None:
@@ -664,6 +665,7 @@ def test_multirun_rejects_swept_config_hydra_controller_override(
             config_name="config.yaml",
             task_function=None,
             overrides=[f"experiment=base,{experiment}"],
+            temp_dir=tmpdir,
         ):
             pass
 

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -12,6 +12,7 @@ from omegaconf import DictConfig, OmegaConf
 from pytest import mark, param, raises
 
 from hydra import MissingConfigException, version
+from hydra.errors import ConfigCompositionException
 from hydra.test_utils.test_utils import (
     TSweepRunner,
     TTaskRunner,
@@ -637,6 +638,25 @@ def test_sweep_complex_defaults(
         assert sweep.returns is not None and len(sweep.returns[0]) == 2
         assert sweep.returns[0][0].overrides == ["optimizer=adam"]
         assert sweep.returns[0][1].overrides == ["optimizer=nesterov"]
+
+
+def test_multirun_rejects_swept_config_hydra_launcher_override(
+    hydra_restore_singletons: Any,
+    hydra_sweep_runner: TSweepRunner,
+) -> None:
+    with raises(
+        ConfigCompositionException,
+        match="hydra/launcher.*must be selected before the sweep starts",
+    ):
+        with hydra_sweep_runner(
+            calling_file="tests/test_apps/sweep_hydra_launcher_override/my_app.py",
+            calling_module=None,
+            config_path="conf",
+            config_name="config.yaml",
+            task_function=None,
+            overrides=["experiment=base,custom_launcher"],
+        ):
+            pass
 
 
 @mark.parametrize(

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -640,13 +640,22 @@ def test_sweep_complex_defaults(
         assert sweep.returns[0][1].overrides == ["optimizer=nesterov"]
 
 
-def test_multirun_rejects_swept_config_hydra_launcher_override(
+@mark.parametrize(
+    "controller,experiment",
+    [
+        param("hydra/launcher", "custom_launcher", id="launcher"),
+        param("hydra/sweeper", "custom_sweeper", id="sweeper"),
+    ],
+)
+def test_multirun_rejects_swept_config_hydra_controller_override(
     hydra_restore_singletons: Any,
     hydra_sweep_runner: TSweepRunner,
+    controller: str,
+    experiment: str,
 ) -> None:
     with raises(
         ConfigCompositionException,
-        match="hydra/launcher.*must be selected before the sweep starts",
+        match=rf"{re.escape(controller)}.*must be selected before the sweep starts",
     ):
         with hydra_sweep_runner(
             calling_file="tests/test_apps/sweep_hydra_launcher_override/my_app.py",
@@ -654,7 +663,7 @@ def test_multirun_rejects_swept_config_hydra_launcher_override(
             config_path="conf",
             config_name="config.yaml",
             task_function=None,
-            overrides=["experiment=base,custom_launcher"],
+            overrides=[f"experiment=base,{experiment}"],
         ):
             pass
 


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve Hydra -->

## Motivation

Fixes #3231.

A config selected only inside a sweep can currently override `hydra/launcher` in its defaults list. The composed job config then reports the new launcher even though the multirun controller already selected and is using the original launcher. This adds a guard that rejects late per-job changes to controller-level `hydra/launcher` and `hydra/sweeper` choices with a clear composition error.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes

### For non-trivial features, API changes, or behavior changes: is there an issue or design discussion where maintainers agreed on the direction?

#3231

## Test Plan

- `python3 -m venv .venv`
- `.venv/bin/python -m pip install --upgrade pip`
- `.venv/bin/pip install -r requirements/dev.txt`
- `.venv/bin/pip install -e .`
- `.venv/bin/pytest tests/test_hydra.py::test_multirun_rejects_swept_config_hydra_launcher_override -q` (reproduced the pre-fix failure)
- `.venv/bin/pytest tests/test_hydra.py::test_multirun_rejects_swept_config_hydra_launcher_override tests/test_hydra.py::test_app_with_sweep_cfg__override_to_basic_launcher -q`
- `NOX_PYTHON_VERSIONS=3.14 .venv/bin/nox -s test_core -- tests/test_hydra.py::test_multirun_rejects_swept_config_hydra_launcher_override tests/test_hydra.py::test_app_with_sweep_cfg__override_to_basic_launcher`
- `.venv/bin/black --check hydra/_internal/config_loader_impl.py tests/test_hydra.py tests/test_apps/sweep_hydra_launcher_override`
- `.venv/bin/isort --check --diff hydra/_internal/config_loader_impl.py tests/test_hydra.py`
- `.venv/bin/flake8 hydra/_internal/config_loader_impl.py tests/test_hydra.py`
- `git diff --check`
- `git diff --cached --check`

## Related Issues and PRs

Fixes #3231.

AI disclosure: I used Codex to inspect the multirun config-loading path, add the regression fixture, implement the guard, and run the checks listed above. I reviewed the final diff and test output before opening this PR.
