### PR TITLE
Fix sort() of a range() that does not land exactly on stop

### DIFF
--- a/hydra/_internal/grammar/grammar_functions.py
+++ b/hydra/_internal/grammar/grammar_functions.py
@@ -361,21 +361,18 @@ def _sort_sweep(
     elif isinstance(sweep, RangeSweep):
         assert sweep.start is not None
         assert sweep.stop is not None
-        if not reverse:
-            # ascending
-            if sweep.start > sweep.stop:
-                start = sweep.stop + abs(sweep.step)
-                stop = sweep.start + abs(sweep.step)
-                sweep.start = start
-                sweep.stop = stop
-                sweep.step = -sweep.step
-        else:
-            # descending
-            if sweep.start < sweep.stop:
-                start = sweep.stop - abs(sweep.step)
-                stop = sweep.start - abs(sweep.step)
-                sweep.start = start
-                sweep.stop = stop
+        # Reverse the range only when its natural direction (ascending when
+        # step > 0) does not already match the requested order. The previous
+        # implementation derived the new endpoints from ``stop``, which is
+        # exclusive and need not coincide with the last element, so it produced
+        # wrong values for ranges that do not land exactly on ``stop`` (e.g.
+        # ``sort(range(0, 5, 2))`` yielded ``[3, 1, -1]`` instead of
+        # ``[4, 2, 0]``). Derive them from the actual first and last elements.
+        if (sweep.step > 0) == reverse:
+            elements = list(sweep.range())
+            if len(elements) > 1:
+                sweep.start = elements[-1]
+                sweep.stop = elements[0] - sweep.step
                 sweep.step = -sweep.step
         return sweep
     else:

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -12,6 +12,7 @@ except ImportError:
 from pytest import mark, param, raises, warns
 
 from hydra import version
+from hydra._internal.grammar import grammar_functions
 from hydra._internal.grammar.functions import Functions
 from hydra._internal.grammar.utils import escape_special_characters
 from hydra.core.override_parser.overrides_parser import (
@@ -1411,6 +1412,22 @@ def test_tag_sweep(value: str, expected: str) -> None:
             RangeSweep(start=1.5, stop=-0.5, step=-0.5),
             id="range:sort:reverse)",
         ),
+        # ranges that do not land exactly on ``stop`` (last element != stop - step)
+        param(
+            "sort(range(0,5,2),reverse=True)",
+            RangeSweep(start=4, stop=-2, step=-2),
+            id="sort:range:non_landing:reverse",
+        ),
+        param(
+            "sort(range(4,-1,-2))",
+            RangeSweep(start=0, stop=6, step=2),
+            id="sort:range:non_landing:ascending",
+        ),
+        param(
+            "sort(range(7,0,-3))",
+            RangeSweep(start=1, stop=10, step=3),
+            id="sort:range:non_landing:ascending2",
+        ),
         param(
             "shuffle(range(1, 10))",
             RangeSweep(start=1, stop=10, step=1, shuffle=True),
@@ -1421,6 +1438,30 @@ def test_tag_sweep(value: str, expected: str) -> None:
 def test_sort(value: str, expected: str) -> None:
     ret = parse_rule(value, "function")
     assert ret == expected
+
+
+@mark.parametrize(
+    "start, stop, step",
+    [
+        param(0, 5, 2, id="int:non_landing"),
+        param(4, -1, -2, id="int:non_landing:neg_step"),
+        param(7, 0, -3, id="int:non_landing:neg_step2"),
+        param(1, 10, 1, id="int:landing"),
+        param(0, 2, 0.5, id="float:landing"),
+        param(0, 1.3, 0.5, id="float:non_landing"),
+    ],
+)
+def test_sort_range_materializes_to_sorted_values(
+    start: float, stop: float, step: float
+) -> None:
+    # A sorted RangeSweep must expand to exactly the sorted original elements,
+    # even when the range does not land exactly on ``stop``.
+    original = list(grammar_functions.range(start, stop, step).range())
+    for reverse in (False, True):
+        sweep = grammar_functions.sort(
+            grammar_functions.range(start, stop, step), reverse=reverse
+        )
+        assert list(sweep.range()) == sorted(original, reverse=reverse)
 
 
 @mark.parametrize(


### PR DESCRIPTION

`sort()` over a `RangeSweep` derived the reversed range's endpoints from
`stop`, which is exclusive and need not coincide with the last element.
For any range whose last element != stop - step (e.g. `range(0, 5, 2)`,
elements `[0, 2, 4]` but `stop=5`), this produced wrong values:

    sort(range(0, 5, 2), reverse=True)  ->  [3, 1, -1]   # expected [4, 2, 0]
    sort(range(4, -1, -2))              ->  [1, 3, 5]     # expected [0, 2, 4]

The existing tests only exercised ranges that land exactly on `stop`
(`range(1, 10)`, `range(0, 2, 0.5)`), where the old formula coincidentally
gives the right answer, so the defect went unnoticed.

Derive the reversed range from the actual first and last elements instead,
flipping only when the range's natural direction does not match the
requested order. All existing sort cases are preserved.
