### PR TITLE
Support deleting config-path defaults

### DIFF
--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -72,25 +72,30 @@ class Overrides:
             if override.is_sweep_override():
                 continue
             is_group = repo.group_exists(override.key_or_group)
+            is_config = repo.config_exists(override.key_or_group)
             value = override.value()
             is_dict = isinstance(override.value(), dict)
-            if is_dict or not is_group:
+            if override.is_delete() and (is_group or is_config):
+                key = override.get_key_element()[1:]
+                if is_group:
+                    if value is not None and not isinstance(value, str):
+                        raise ValueError(
+                            f"Config group override deletion value must be a string : {override}"
+                        )
+                    self.deletions[key] = Deletion(name=value)
+                else:
+                    if value is not None:
+                        raise ValueError(
+                            f"Config path deletion does not support a value : {override}"
+                        )
+                    self.deletions[key] = Deletion(name=None)
+            elif is_dict or not is_group:
                 self.config_overrides.append(override)
             elif override.is_force_add():
                 # This could probably be made to work if there is a compelling use case.
                 raise ConfigCompositionException(
                     f"force-add of config groups is not supported: '{override.input_line}'"
                 )
-            elif override.is_delete():
-                key = override.get_key_element()[1:]
-                value = override.value()
-                if value is not None and not isinstance(value, str):
-                    raise ValueError(
-                        f"Config group override deletion value must be a string : {override}"
-                    )
-
-                self.deletions[key] = Deletion(name=value)
-
             elif not isinstance(value, (str, list)):
                 raise ValueError(
                     f"Config group override must be a string or a list. Got {type(value).__name__}"
@@ -193,22 +198,28 @@ class Overrides:
             self.known_choices_per_group[group].add(key)
 
     def is_deleted(self, default: InputDefault) -> bool:
-        if not isinstance(default, GroupDefault):
-            return False
-        key = default.get_override_key()
-        if key in self.deletions:
-            deletion = self.deletions[key]
-            if deletion.name is None:
-                return True
-            else:
-                return deletion.name == default.get_name()
+        if isinstance(default, GroupDefault):
+            key = default.get_override_key()
+            if key in self.deletions:
+                deletion = self.deletions[key]
+                if deletion.name is None:
+                    return True
+                else:
+                    return deletion.name == default.get_name()
+        elif isinstance(default, ConfigDefault):
+            key = default.get_config_path()
+            if key in self.deletions:
+                return self.deletions[key].name is None
         return False
 
     def delete(self, default: InputDefault) -> None:
-        assert isinstance(default, GroupDefault)
-        default.deleted = True
-
-        key = default.get_override_key()
+        if isinstance(default, GroupDefault):
+            default.deleted = True
+            key = default.get_override_key()
+        else:
+            assert isinstance(default, ConfigDefault)
+            default.deleted = True
+            key = default.get_config_path()
         self.deletions[key].used = True
 
 

--- a/news/2843.bugfix
+++ b/news/2843.bugfix
@@ -1,0 +1,1 @@
+Support deleting non-overridable config-path defaults from the CLI.

--- a/tests/defaults_list/test_defaults_list.py
+++ b/tests/defaults_list/test_defaults_list.py
@@ -1986,6 +1986,19 @@ def test_with_none_primary_with_hydra(
             ],
             id="two_config_items",
         ),
+        param(
+            "two_config_items",
+            ["~group1/file1"],
+            [
+                ResultDefault(
+                    config_path="group1/file2",
+                    package="group1",
+                    parent="two_config_items",
+                ),
+                ResultDefault(config_path="two_config_items", package="", is_self=True),
+            ],
+            id="two_config_items:delete_config_path",
+        ),
     ],
 )
 def test_two_config_items(

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -2269,6 +2269,19 @@ def test_override_nested_to_null(
             id="delete:include_nested_group:group1=wrong",
         ),
         param(
+            "two_config_items",
+            ["~group1/file1"],
+            DefaultsTreeNode(
+                node=ConfigDefault(path="two_config_items"),
+                children=[
+                    ConfigDefault(path="group1/file1", deleted=True),
+                    ConfigDefault(path="group1/file2"),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="delete:two_config_items:group1/file1",
+        ),
+        param(
             "two_group_defaults_different_pkgs",
             [],
             DefaultsTreeNode(
@@ -2984,6 +2997,20 @@ def test_deprecated_package_header_keywords(
                 children=[ConfigDefault(path="_self_")],
             ),
             id="select_multi:override_to_empty_list",
+        ),
+        param(
+            "select_multi",
+            ["~group1/file1"],
+            False,
+            DefaultsTreeNode(
+                node=ConfigDefault(path="select_multi"),
+                children=[
+                    ConfigDefault(path="group1/file1", deleted=True),
+                    ConfigDefault(path="group1/file2"),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="select_multi:delete_config_path",
         ),
         param(
             "select_multi",

--- a/website/docs/advanced/defaults_list.md
+++ b/website/docs/advanced/defaults_list.md
@@ -135,6 +135,11 @@ A Config Group's option can also be overridden via the command line. e.g:
 $ python my_app.py server/db=sqlite
 ```
 
+A non-overridable *CONFIG* entry can also be deleted by exact config path. e.g:
+```
+$ python my_app.py ~server/apache
+```
+
 ## Composition order
 The Defaults List is ordered:
 - If multiple configs define the same value, the last one wins.

--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -11,7 +11,7 @@ You can manipulate your configuration with overrides (via the command line or th
 - Modifying the `Defaults List`
 - Modifying the config object
 
-Overrides matching a config group are modifying the `Defaults List`;
+Overrides matching a config group or a Defaults List config entry are modifying the `Defaults List`;
 The rest are manipulating the config object.
 
 ## Basic examples
@@ -25,6 +25,7 @@ The rest are manipulating the config object.
 - Overriding selected Option: `db=mysql`, `server/db=mysql`
 - Appending to Defaults List: `+db=mysql`, `+server/db=mysql`
 - Deleting from Defaults List: `~db`, `~db=mysql`, `~server/db`, `~server/db=mysql`
+- Deleting a non-overridable Defaults List config entry: `~server/site/fb`
 
 ## Grammar
 Hydra supports a rich [DSL](https://en.wikipedia.org/wiki/Domain-specific_language) in the command line.

--- a/website/docs/patterns/select_multiple_configs_from_config_group.md
+++ b/website/docs/patterns/select_multiple_configs_from_config_group.md
@@ -169,6 +169,9 @@ defaults:
 </div>
 </div>
 
+To delete one of these non-overridable entries from the command line, use the
+exact config path, for example `~site/fb`.
+
 All default package for all the configs in `server/site` is `server.site`.
 This example uses an explicit nesting level inside each of the website configs to prevent them stepping over one another:
 ```yaml title="server/site/amazon.yaml" {1}


### PR DESCRIPTION

Allow command-line delete overrides to match non-overridable CONFIG entries when the override key points to an existing config path. Keep existing group default deletion semantics, and mark matching ConfigDefault nodes deleted so they are omitted from the composed defaults list.

Add focused defaults-tree/defaults-list coverage for deleting config paths from explicit config entries and multi-select expansion. Document the exact-path deletion form in the Defaults List, override grammar, and multi-select docs.

Closes #2843.
