### PR TITLE
Support deleting null config values

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -18,6 +18,7 @@ from omegaconf import (
 from omegaconf.errors import (
     ConfigAttributeError,
     ConfigKeyError,
+    MissingMandatoryValue,
     OmegaConfBaseException,
 )
 
@@ -374,31 +375,62 @@ class ConfigLoaderImpl(ConfigLoader):
             value = override.value()
             try:
                 if override.is_delete():
-                    config_val = OmegaConf.select(cfg, key, throw_on_missing=False)
-                    if config_val is None:
+                    config_val_not_found = object()
+                    config_val_missing = object()
+                    last_dot = key.rfind(".")
+                    parent: Container = cfg
+                    parent_missing = False
+                    if last_dot != -1:
+                        parent_key = key[0:last_dot]
+                        selected_parent = OmegaConf.select(
+                            cfg,
+                            parent_key,
+                            default=config_val_not_found,
+                            throw_on_missing=False,
+                        )
+                        if isinstance(selected_parent, Container):
+                            parent = selected_parent
+                        else:
+                            parent_missing = True
+
+                    try:
+                        config_val = OmegaConf.select(
+                            cfg,
+                            key,
+                            default=config_val_not_found,
+                            throw_on_missing=True,
+                        )
+                    except MissingMandatoryValue:
+                        config_val = config_val_missing
+
+                    if parent_missing or config_val is config_val_not_found:
                         # Bandit mistakes this user-facing message for a SQL snippet.
                         raise ConfigCompositionException(
                             f"Could not delete from config. '{override.key_or_group}'"  # nosec B608
                             " does not exist."
                         )
-                    elif value is not None and value != config_val:
+                    config_val_for_match = (
+                        "???" if config_val is config_val_missing else config_val
+                    )
+                    if (
+                        override.value_type is not None
+                        and value != config_val_for_match
+                    ):
                         # Bandit mistakes this user-facing message for a SQL snippet.
                         raise ConfigCompositionException(
                             "Could not delete from config. The value of"  # nosec B608
-                            f" '{override.key_or_group}' is {config_val} and not"
+                            f" '{override.key_or_group}' is {config_val_for_match} and not"
                             f" {value}."
                         )
 
-                    last_dot = key.rfind(".")
                     with open_dict(cfg):
                         if last_dot == -1:
                             del cfg[key]
                         else:
-                            node = OmegaConf.select(cfg, key[0:last_dot])
                             node_key: Union[str, int] = key[last_dot + 1 :]
-                            if isinstance(node, ListConfig):
+                            if isinstance(parent, ListConfig):
                                 node_key = int(node_key)
-                            del node[node_key]
+                            del parent[node_key]
 
                 elif override.is_add():
                     if OmegaConf.select(

--- a/news/2829.bugfix
+++ b/news/2829.bugfix
@@ -1,0 +1,1 @@
+Support deleting config keys with null or missing values.

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/_impl.py
@@ -132,20 +132,25 @@ def create_optuna_distribution_from_override(override: Override) -> Any:
 
 def create_params_from_overrides(
     arguments: List[str],
-) -> Tuple[Dict[str, BaseDistribution], Dict[str, Any]]:
+) -> Tuple[Dict[str, BaseDistribution], Dict[str, Any], List[str]]:
     parser = OverridesParser.create()
     parsed = parser.parse_overrides(arguments)
     search_space_distributions = dict()
     fixed_params = dict()
+    fixed_overrides = []
 
     for override in parsed:
+        if override.is_delete():
+            assert override.input_line is not None
+            fixed_overrides.append(override.input_line)
+            continue
         param_name = override.get_key_element()
         value = create_optuna_distribution_from_override(override)
         if isinstance(value, BaseDistribution):
             search_space_distributions[param_name] = value
         else:
             fixed_params[param_name] = value
-    return search_space_distributions, fixed_params
+    return search_space_distributions, fixed_params, fixed_overrides
 
 
 class OptunaSweeperImpl(Sweeper):
@@ -232,6 +237,7 @@ class OptunaSweeperImpl(Sweeper):
         trials: List[Trial],
         search_space_distributions: Dict[str, BaseDistribution],
         fixed_params: Dict[str, Any],
+        fixed_overrides: List[str],
     ) -> Sequence[Sequence[str]]:
         overrides = []
         for trial in trials:
@@ -254,7 +260,10 @@ class OptunaSweeperImpl(Sweeper):
             params = dict(trial.params)
             params.update(fixed_params)
 
-            overrides.append(tuple(f"{name}={val}" for name, val in params.items()))
+            overrides.append(
+                tuple(f"{name}={val}" for name, val in params.items())
+                + tuple(fixed_overrides)
+            )
         return overrides
 
     def _parse_sweeper_params_config(self) -> List[str]:
@@ -296,6 +305,7 @@ class OptunaSweeperImpl(Sweeper):
         (
             override_search_space_distributions,
             fixed_params,
+            fixed_overrides,
         ) = create_params_from_overrides(params_conf)
 
         search_space_distributions = dict()
@@ -345,7 +355,7 @@ class OptunaSweeperImpl(Sweeper):
 
             trials = [study.ask() for _ in range(batch_size)]
             overrides = self._configure_trials(
-                trials, search_space_distributions, fixed_params
+                trials, search_space_distributions, fixed_params, fixed_overrides
             )
 
             returns = self.launcher.launch(overrides, initial_job_idx=self.job_idx)

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -119,11 +119,11 @@ def test_create_optuna_distribution_from_override(input: Any, expected: Any) -> 
 @mark.parametrize(
     "input, expected",
     [
-        (["key=choice(1,2)"], ({"key": CategoricalDistribution([1, 2])}, {})),
-        (["key=5"], ({}, {"key": "5"})),
+        (["key=choice(1,2)"], ({"key": CategoricalDistribution([1, 2])}, {}, [])),
+        (["key=5"], ({}, {"key": "5"}, [])),
         (
             ["key1=choice(1,2)", "key2=5"],
-            ({"key1": CategoricalDistribution([1, 2])}, {"key2": "5"}),
+            ({"key1": CategoricalDistribution([1, 2])}, {"key2": "5"}, []),
         ),
         (
             ["key1=choice(1,2)", "key2=5", "key3=range(1,3)"],
@@ -133,8 +133,11 @@ def test_create_optuna_distribution_from_override(input: Any, expected: Any) -> 
                     "key3": IntUniformDistribution(1, 3),
                 },
                 {"key2": "5"},
+                [],
             ),
         ),
+        (["~z"], ({}, {}, ["~z"])),
+        (["~z=10"], ({}, {}, ["~z=10"])),
     ],
 )
 def test_create_params_from_overrides(input: Any, expected: Any) -> None:

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -734,6 +734,26 @@ def test_complex_defaults(overrides: Any, expected: Any) -> None:
         param({"x": [1, 2, 3]}, ["~x=[1,2,3]"], {}, id="delete:list"),
         param({"x": [1, 2, 3]}, ["~x.0"], {"x": [2, 3]}, id="delete:list_item"),
         param({"x": [1, 2, 3]}, ["~x.1"], {"x": [1, 3]}, id="delete:list_item_middle"),
+        param({"x": [None, 1]}, ["~x.0"], {"x": [1]}, id="delete:list_item_null"),
+        param(
+            {"x": [None, 1]},
+            ["~x.0=null"],
+            {"x": [1]},
+            id="delete:list_item_null_strict",
+        ),
+        param({"x": [MISSING, 1]}, ["~x.0"], {"x": [1]}, id="delete:list_item_missing"),
+        param(
+            {"x": [MISSING, 1]},
+            ["~x.0=???"],
+            {"x": [1]},
+            id="delete:list_item_missing_strict",
+        ),
+        param({"x": None}, ["~x"], {}, id="delete:null"),
+        param({"x": {"y": None}}, ["~x.y"], {"x": {}}, id="delete:null_nested"),
+        param({"x": None}, ["~x=null"], {}, id="delete:null_strict"),
+        param({"x": MISSING}, ["~x=???"], {}, id="delete:missing_strict"),
+        param({"x": MISSING}, ["~x"], {}, id="delete:missing"),
+        param({"x": {"y": MISSING}}, ["~x.y"], {"x": {}}, id="delete:missing_nested"),
         param(
             {"x": 20},
             ["~z"],
@@ -742,6 +762,24 @@ def test_complex_defaults(overrides: Any, expected: Any) -> None:
                 match=re.escape("Could not delete from config. 'z' does not exist."),
             ),
             id="delete_error_key",
+        ),
+        param(
+            {"x": MISSING},
+            ["~x.y"],
+            raises(
+                HydraException,
+                match=re.escape("Could not delete from config. 'x.y' does not exist."),
+            ),
+            id="delete_error_missing_parent",
+        ),
+        param(
+            {"x": None},
+            ["~x.y"],
+            raises(
+                HydraException,
+                match=re.escape("Could not delete from config. 'x.y' does not exist."),
+            ),
+            id="delete_error_null_parent",
         ),
         param(
             {"x": 20},
@@ -753,6 +791,17 @@ def test_complex_defaults(overrides: Any, expected: Any) -> None:
                 ),
             ),
             id="delete_error_value",
+        ),
+        param(
+            {"x": 20},
+            ["~x=null"],
+            raises(
+                HydraException,
+                match=re.escape(
+                    "Could not delete from config. The value of 'x' is 20 and not None."
+                ),
+            ),
+            id="delete_error_value_null",
         ),
         param(
             {"x": 20},

--- a/tests/test_config_repository.py
+++ b/tests/test_config_repository.py
@@ -8,6 +8,7 @@ from pytest import mark, param, raises
 
 from hydra._internal.config_repository import ConfigRepository
 from hydra._internal.config_search_path_impl import ConfigSearchPathImpl
+from hydra._internal.core_plugins import importlib_resources_config_source
 from hydra._internal.core_plugins.file_config_source import FileConfigSource
 from hydra._internal.core_plugins.importlib_resources_config_source import (
     ImportlibResourcesConfigSource,
@@ -227,8 +228,8 @@ def test_importlib_resource_checks_do_not_require_exists(monkeypatch: Any) -> No
         provider="foo", path="pkg://hydra.conf"
     )
     monkeypatch.setattr(
-        "hydra._internal.core_plugins.importlib_resources_config_source"
-        ".resources.files",
+        importlib_resources_config_source.resources,
+        "files",
         lambda _: TraversableWithoutExists(),
     )
 


### PR DESCRIPTION

Allow delete overrides to remove config keys whose values are null or mandatory missing. Preserve missing-target errors for nested deletes through non-container parents, and keep strict delete value checks working for null and missing values.

Add focused config-loader coverage for dict and list deletions involving null and missing values.

Closes #2829.
