### PR TITLE
Add hydra_override_dirname resolver

### DIFF
--- a/examples/configure_hydra/job_override_dirname/config.yaml
+++ b/examples/configure_hydra/job_override_dirname/config.yaml
@@ -1,12 +1,7 @@
 hydra:
   sweep:
     dir: multirun
-    subdir: ${hydra.job.override_dirname}/seed=${seed}
-  job:
-    config:
-      override_dirname:
-        exclude_keys:
-          - seed
+    subdir: '${hydra_override_dirname:{exclude_keys: [seed]}}/seed=${seed}'
 
 learning_rate: 0.1
 batch_size: 32

--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -1,7 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import copy
 import os
-import re
 import sys
 import warnings
 from textwrap import dedent
@@ -280,13 +279,11 @@ class ConfigLoaderImpl(ConfigLoader):
 
         # Apply command line overrides after enabling strict flag
         ConfigLoaderImpl._apply_overrides_to_config(config_overrides, cfg)
-        app_overrides = []
         for override in parsed_overrides:
             if override.is_hydra_override():
                 cfg.hydra.overrides.hydra.append(override.input_line)
             else:
                 cfg.hydra.overrides.task.append(override.input_line)
-                app_overrides.append(override)
 
         with open_dict(cfg.hydra):
             cfg.hydra.runtime.choices.update(defaults_list.overrides.known_choices)
@@ -305,12 +302,6 @@ class ConfigLoaderImpl(ConfigLoader):
         if "name" not in cfg.hydra.job:
             cfg.hydra.job.name = JobRuntime().get("name")
 
-        cfg.hydra.job.override_dirname = get_overrides_dirname(
-            overrides=app_overrides,
-            kv_sep=cfg.hydra.job.config.override_dirname.kv_sep,
-            item_sep=cfg.hydra.job.config.override_dirname.item_sep,
-            exclude_keys=cfg.hydra.job.config.override_dirname.exclude_keys,
-        )
         cfg.hydra.job.config_name = config_name
 
         return cfg
@@ -647,18 +638,3 @@ class ConfigLoaderImpl(ConfigLoader):
             skip_missing=run_mode == RunMode.MULTIRUN,
         )
         return defaults_list
-
-
-def get_overrides_dirname(
-    overrides: List[Override], exclude_keys: List[str], item_sep: str, kv_sep: str
-) -> str:
-    lines = []
-    for override in overrides:
-        if override.key_or_group not in exclude_keys:
-            line = override.input_line
-            assert line is not None
-            lines.append(line)
-
-    lines.sort()
-    ret = re.sub(pattern="[=]", repl=kv_sep, string=item_sep.join(lines))
-    return ret

--- a/hydra/conf/__init__.py
+++ b/hydra/conf/__init__.py
@@ -51,11 +51,8 @@ class JobConf:
     # Will be non-optional and default to False in Hydra 1.3
     chdir: Optional[bool] = None
 
-    # Populated automatically by Hydra.
-    # Concatenation of job overrides that can be used as a part
-    # of the directory name.
-    # This can be configured via hydra.job.config.override_dirname
-    override_dirname: str = MISSING
+    # Deprecated. Use the hydra_override_dirname resolver instead.
+    override_dirname: str = "${hydra_override_dirname:}"
 
     # Job ID in underlying scheduling system
     id: str = MISSING
@@ -75,7 +72,7 @@ class JobConf:
     @dataclass
     class JobConfig:
         @dataclass
-        # configuration for the ${hydra.job.override_dirname} runtime variable
+        # Default configuration for the ${hydra_override_dirname:} resolver.
         class OverrideDirname:
             kv_sep: str = "="
             item_sep: str = ","

--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -5,13 +5,13 @@ import os
 import re
 import sys
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from os.path import splitext
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Dict, Optional, Sequence, Union, cast
+from typing import Any, Dict, List, Optional, Sequence, Union, cast
 
 from omegaconf import DictConfig, OmegaConf, open_dict, read_write
 
@@ -205,8 +205,157 @@ def get_valid_filename(s: str) -> str:
     return re.sub(r"(?u)[^-\w.]", "", s)
 
 
+@dataclass
+class OverrideDirnameOptions:
+    kv_sep: str = "="
+    item_sep: str = ","
+    exclude_keys: List[str] = field(default_factory=list)
+    element_resolver: Optional[str] = None
+
+
+def _get_override_dirname_options(
+    options: Optional[Union[Dict[str, Any], DictConfig]], hydra_conf: DictConfig
+) -> OverrideDirnameOptions:
+    if options is None:
+        old = hydra_conf.job.config.override_dirname
+        if not isinstance(old.kv_sep, str):
+            raise TypeError("hydra_override_dirname kv_sep must be a string")
+        if not isinstance(old.item_sep, str):
+            raise TypeError("hydra_override_dirname item_sep must be a string")
+        if not OmegaConf.is_list(old.exclude_keys):
+            raise TypeError("hydra_override_dirname exclude_keys must be a list")
+        if not all(isinstance(key, str) for key in old.exclude_keys):
+            raise TypeError("hydra_override_dirname exclude_keys must contain strings")
+        return OverrideDirnameOptions(
+            kv_sep=old.kv_sep,
+            item_sep=old.item_sep,
+            exclude_keys=list(old.exclude_keys),
+        )
+
+    if isinstance(options, DictConfig):
+        options = cast(Dict[str, Any], OmegaConf.to_container(options, resolve=True))
+
+    if not isinstance(options, dict):
+        raise TypeError("hydra_override_dirname options must be a dictionary")
+
+    kv_sep = options.get("kv_sep", "=")
+    if not isinstance(kv_sep, str):
+        raise TypeError("hydra_override_dirname kv_sep must be a string")
+
+    item_sep = options.get("item_sep", ",")
+    if not isinstance(item_sep, str):
+        raise TypeError("hydra_override_dirname item_sep must be a string")
+
+    exclude_keys = options.get("exclude_keys", [])
+    if not isinstance(exclude_keys, (list, tuple)) and not OmegaConf.is_list(
+        exclude_keys
+    ):
+        raise TypeError("hydra_override_dirname exclude_keys must be a list")
+    if not all(isinstance(key, str) for key in exclude_keys):
+        raise TypeError("hydra_override_dirname exclude_keys must contain strings")
+
+    element_resolver = options.get("element_resolver")
+    if element_resolver is not None and not isinstance(element_resolver, str):
+        raise TypeError("hydra_override_dirname element_resolver must be a string")
+
+    return OverrideDirnameOptions(
+        kv_sep=kv_sep,
+        item_sep=item_sep,
+        exclude_keys=list(exclude_keys),
+        element_resolver=element_resolver,
+    )
+
+
+def _resolve_override_dirname_item(item: str, root: DictConfig) -> str:
+    if "${" not in item:
+        return item
+
+    key = "_hydra_override_dirname_item"
+    cfg = copy.deepcopy(root)
+    with open_dict(cfg):
+        cfg[key] = item
+    resolved = OmegaConf.select(cfg, key)
+    assert resolved is not None
+    return str(resolved)
+
+
+def hydra_override_dirname(
+    options: Optional[Union[Dict[str, Any], DictConfig]] = None,
+    *,
+    _root_: DictConfig,
+    _parent_: DictConfig,
+    _node_: Any,
+) -> str:
+    hydra_root = _root_
+    hydra_conf = OmegaConf.select(hydra_root, "hydra", default=None)
+    if hydra_conf is None:
+        hydra_conf = cast(DictConfig, HydraConfig.get())
+    assert isinstance(hydra_conf, DictConfig)
+
+    opts = _get_override_dirname_options(options, hydra_conf)
+
+    element_resolver = None
+    if opts.element_resolver is not None:
+        if not OmegaConf.has_resolver(opts.element_resolver):
+            raise ValueError(f"Unknown OmegaConf resolver '{opts.element_resolver}'")
+        element_resolver = OmegaConf._get_resolver(opts.element_resolver)
+        assert element_resolver is not None
+
+    task_overrides = OmegaConf.to_container(
+        hydra_conf.overrides.task,
+        resolve=False,
+    )
+    assert isinstance(task_overrides, list)
+
+    from hydra.core.override_parser.overrides_parser import OverridesParser
+
+    parsed_overrides = OverridesParser.create().parse_overrides(task_overrides)
+    exclude_keys = set(opts.exclude_keys)
+    items = []
+    for override in parsed_overrides:
+        if override.key_or_group in exclude_keys:
+            continue
+
+        assert override.input_line is not None
+        items.append(override.input_line)
+
+    items.sort()
+    for idx, item in enumerate(items):
+        item = re.sub(pattern="[=]", repl=opts.kv_sep, string=item)
+        item = _resolve_override_dirname_item(item, _root_)
+        if element_resolver is not None:
+            item = str(element_resolver(_root_, _parent_, _node_, (item,), (item,)))
+        items[idx] = item
+
+    return opts.item_sep.join(items)
+
+
+def hydra_deprecated_override_dirname(
+    *,
+    _root_: DictConfig,
+    _parent_: DictConfig,
+    _node_: Any,
+) -> str:
+    deprecation_warning(
+        "hydra.job.override_dirname is deprecated. "
+        "Use ${hydra_override_dirname:} instead.",
+        stacklevel=3,
+    )
+    return hydra_override_dirname(_root_=_root_, _parent_=_parent_, _node_=_node_)
+
+
 def setup_globals() -> None:
     # please add documentation when you add a new resolver
+    OmegaConf.register_new_resolver(
+        "hydra_override_dirname",
+        hydra_override_dirname,
+        replace=True,
+    )
+    OmegaConf.register_new_resolver(
+        "hydra_deprecated_override_dirname",
+        hydra_deprecated_override_dirname,
+        replace=True,
+    )
     OmegaConf.register_new_resolver(
         "now",
         lambda pattern: datetime.now().strftime(pattern),

--- a/hydra/test_utils/launcher_common_tests.py
+++ b/hydra/test_utils/launcher_common_tests.py
@@ -558,7 +558,7 @@ class IntegrationTestSuite:
                     "hydra": {
                         "sweep": {
                             "dir": "hydra_cfg",
-                            "subdir": "${hydra.job.override_dirname}",
+                            "subdir": "${hydra_override_dirname:}",
                         }
                     },
                     "a": "hello",
@@ -574,7 +574,7 @@ class IntegrationTestSuite:
                     "hydra": {
                         "sweep": {
                             "dir": "hydra_cfg",
-                            "subdir": "${hydra.job.override_dirname}",
+                            "subdir": "${hydra_override_dirname:}",
                         },
                         "job": {
                             "config": {

--- a/news/3018.api_change
+++ b/news/3018.api_change
@@ -1,0 +1,1 @@
+Deprecate hydra.job.override_dirname in favor of hydra_override_dirname.

--- a/tests/test_apps/hydra_to_cfg_interpolation/config.yaml
+++ b/tests/test_apps/hydra_to_cfg_interpolation/config.yaml
@@ -1,3 +1,3 @@
 a: 10
 b: 20
-c: override_${hydra:job.override_dirname}
+c: override_${hydra_override_dirname:}

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 from typing import Any, List, cast
 
 from omegaconf import MISSING, DictConfig, OmegaConf, ValidationError, open_dict
+from omegaconf.errors import InterpolationResolutionError
 from pytest import mark, param, raises, warns
 
 from hydra import version
@@ -934,3 +935,184 @@ def test_hydra_choices(config: str, overrides: Any, expected_choices: Any) -> No
         config_name=config, overrides=overrides, run_mode=RunMode.RUN
     )
     assert cfg.hydra.runtime.choices == expected_choices
+
+
+def test_hydra_override_dirname_resolver_defaults(
+    hydra_restore_singletons: Any,
+) -> None:
+    setup_globals()
+    config_loader = ConfigLoaderImpl(
+        config_search_path=create_config_search_path("hydra/test_utils/configs")
+    )
+
+    cfg = config_loader.load_configuration(
+        config_name="config.yaml",
+        overrides=["+b=2", "+a=1"],
+        run_mode=RunMode.RUN,
+    )
+    with open_dict(cfg.hydra.sweep):
+        cfg.hydra.sweep.subdir = "${hydra_override_dirname:}"
+
+    assert OmegaConf.select(cfg, "hydra.sweep.subdir") == "+a=1,+b=2"
+
+
+def test_hydra_override_dirname_resolver_options(
+    hydra_restore_singletons: Any,
+) -> None:
+    setup_globals()
+    config_loader = ConfigLoaderImpl(
+        config_search_path=create_config_search_path("hydra/test_utils/configs")
+    )
+
+    cfg = config_loader.load_configuration(
+        config_name="config.yaml",
+        overrides=["+b=2", "+a=1", "+seed=123"],
+        run_mode=RunMode.RUN,
+    )
+    with open_dict(cfg.hydra.sweep):
+        cfg.hydra.sweep.subdir = (
+            "${hydra_override_dirname:{kv_sep: '-', item_sep: '/', "
+            "exclude_keys: [seed]}}"
+        )
+
+    assert OmegaConf.select(cfg, "hydra.sweep.subdir") == "+a-1/+b-2"
+
+
+@mark.parametrize(
+    ("options", "expected_error"),
+    [
+        param("{kv_sep: 1}", "hydra_override_dirname kv_sep must be a string"),
+        param("{item_sep: 1}", "hydra_override_dirname item_sep must be a string"),
+        param(
+            "{exclude_keys: seed}",
+            "hydra_override_dirname exclude_keys must be a list",
+        ),
+        param(
+            "{exclude_keys: [seed, 1]}",
+            "hydra_override_dirname exclude_keys must contain strings",
+        ),
+        param(
+            "{element_resolver: 1}",
+            "hydra_override_dirname element_resolver must be a string",
+        ),
+    ],
+)
+def test_hydra_override_dirname_resolver_validates_options(
+    hydra_restore_singletons: Any, options: str, expected_error: str
+) -> None:
+    setup_globals()
+    config_loader = ConfigLoaderImpl(
+        config_search_path=create_config_search_path("hydra/test_utils/configs")
+    )
+
+    cfg = config_loader.load_configuration(
+        config_name="config.yaml",
+        overrides=["+a=1"],
+        run_mode=RunMode.RUN,
+    )
+    with open_dict(cfg.hydra.sweep):
+        cfg.hydra.sweep.subdir = f"${{hydra_override_dirname:{options}}}"
+
+    with raises(InterpolationResolutionError, match=re.escape(expected_error)):
+        OmegaConf.select(cfg, "hydra.sweep.subdir")
+
+
+def test_hydra_override_dirname_resolver_options_from_config_node(
+    hydra_restore_singletons: Any,
+) -> None:
+    setup_globals()
+    config_loader = ConfigLoaderImpl(
+        config_search_path=create_config_search_path("hydra/test_utils/configs")
+    )
+
+    cfg = config_loader.load_configuration(
+        config_name="config.yaml",
+        overrides=["+b=2", "+a=1", "+seed=123"],
+        run_mode=RunMode.RUN,
+    )
+    with open_dict(cfg.hydra.sweep):
+        cfg.hydra.sweep.override_dirname_options = {
+            "kv_sep": "-",
+            "item_sep": "/",
+            "exclude_keys": ["seed"],
+        }
+        cfg.hydra.sweep.subdir = (
+            "${hydra_override_dirname:${hydra.sweep.override_dirname_options}}"
+        )
+
+    assert OmegaConf.select(cfg, "hydra.sweep.subdir") == "+a-1/+b-2"
+
+
+def test_hydra_override_dirname_resolver_element_resolver(
+    hydra_restore_singletons: Any,
+) -> None:
+    setup_globals()
+    try:
+        OmegaConf.register_new_resolver(
+            "pathsafe",
+            lambda value: str(value).replace("/", "_").replace("\\", "_"),
+            replace=True,
+        )
+        config_loader = ConfigLoaderImpl(
+            config_search_path=create_config_search_path("hydra/test_utils/configs")
+        )
+
+        cfg = config_loader.load_configuration(
+            config_name="config.yaml",
+            overrides=["+models/temporal_nets=net2", "+seed=123"],
+            run_mode=RunMode.RUN,
+        )
+        with open_dict(cfg.hydra.sweep):
+            cfg.hydra.sweep.subdir = (
+                "${hydra_override_dirname:{item_sep: '/', "
+                "element_resolver: pathsafe}}"
+            )
+
+        assert (
+            OmegaConf.select(cfg, "hydra.sweep.subdir")
+            == "+models_temporal_nets=net2/+seed=123"
+        )
+    finally:
+        OmegaConf.clear_resolver("pathsafe")
+
+
+def test_hydra_job_override_dirname_uses_resolver(
+    hydra_restore_singletons: Any,
+) -> None:
+    setup_globals()
+    config_loader = ConfigLoaderImpl(
+        config_search_path=create_config_search_path("hydra/test_utils/configs")
+    )
+
+    cfg = config_loader.load_configuration(
+        config_name="config.yaml",
+        overrides=["+x=1"],
+        run_mode=RunMode.RUN,
+    )
+
+    assert "_override_dirname" not in cfg.hydra.job
+    assert cfg.hydra.job.override_dirname == "+x=1"
+
+
+def test_hydra_job_override_dirname_uses_legacy_options(
+    hydra_restore_singletons: Any,
+) -> None:
+    setup_globals()
+    config_loader = ConfigLoaderImpl(
+        config_search_path=create_config_search_path("hydra/test_utils/configs")
+    )
+
+    cfg = config_loader.load_configuration(
+        config_name="config.yaml",
+        overrides=[
+            "+a-1=2",
+            "+a=1",
+            "+seed=123",
+            "hydra.job.config.override_dirname.kv_sep=-",
+            "hydra.job.config.override_dirname.item_sep=/",
+            "hydra.job.config.override_dirname.exclude_keys=[seed]",
+        ],
+        run_mode=RunMode.RUN,
+    )
+
+    assert cfg.hydra.job.override_dirname == "+a-1-2/+a-1"

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -939,7 +939,7 @@ def test_sys_exit(tmpdir: Path) -> None:
         ),
         (
             {
-                "hydra": {"run": {"dir": "foo-${hydra.job.override_dirname}"}},
+                "hydra": {"run": {"dir": "foo-${hydra_override_dirname:}"}},
                 "app": {"a": 1, "b": 2},
             },
             ["app.a=20", "hydra.job.chdir=True"],
@@ -947,7 +947,7 @@ def test_sys_exit(tmpdir: Path) -> None:
         ),
         (
             {
-                "hydra": {"run": {"dir": "foo-${hydra.job.override_dirname}"}},
+                "hydra": {"run": {"dir": "foo-${hydra_override_dirname:}"}},
                 "app": {"a": 1, "b": 2},
             },
             ["app.b=10", "app.a=20", "hydra.job.chdir=True"],
@@ -968,6 +968,43 @@ def test_local_run_workdir(
         prints="os.getcwd()",
         expected_outputs=str(expected_dir1),
     )
+
+
+def test_hydra_job_override_dirname_in_run_dir(tmpdir: Path) -> None:
+    tmp_path = Path(str(tmpdir))
+    cfg = OmegaConf.create(
+        {
+            "hydra": {
+                "run": {
+                    "dir": f"{tmp_path}/foo-${{hydra.job.override_dirname}}",
+                }
+            },
+            "app": {"a": 1},
+        }
+    )
+    OmegaConf.save(cfg, tmp_path / "config.yaml")
+    task_file = tmp_path / "task.py"
+    task_file.write_text(
+        dedent("""
+            import os
+
+            import hydra
+
+
+            @hydra.main(version_base=None, config_path=".", config_name="config")
+            def experiment(_cfg):
+                print(os.getcwd())
+
+
+            if __name__ == "__main__":
+                experiment()
+            """),
+        encoding="utf-8",
+    )
+
+    out, _err = run_python_script([str(task_file), "app.a=20", "hydra.job.chdir=True"])
+
+    assert out == str(tmp_path / "foo-app.a=20")
 
 
 @mark.parametrize(

--- a/website/docs/configure_hydra/Intro.md
+++ b/website/docs/configure_hydra/Intro.md
@@ -97,7 +97,7 @@ You can find more details in the [Job Configuration](job.md) page.
 
 Fields under **hydra.job**:
 - **name** : Job name, defaults to the Python file name without the suffix. can be overridden.
-- **override_dirname** : Pathname derived from the overrides for this job
+- **override_dirname** : Deprecated. Use the `hydra_override_dirname` resolver instead.
 - **chdir**: If `True`, Hydra calls `os.chdir(output_dir)` before calling back to the user's main function.
   See the [Output/Working directory tutorial](tutorials/basic/running_your_app/3_working_directory.md#automatically-change-current-working-dir-to-jobs-output-dir).
 - **id** : Job ID in the underlying jobs system (SLURM etc)
@@ -139,6 +139,9 @@ Fields under **hydra.overrides** are populated automatically and should not be o
 Hydra provides the following [OmegaConf resolvers](https://omegaconf.readthedocs.io/en/latest/usage.html#resolvers) by default.
 
 **hydra**: Interpolates into the `hydra` config node. e.g. Use `${hydra:job.name}` to get the Hydra job name.
+
+**hydra_override_dirname**: Creates a string from the command line overrides for the job. It is commonly used in output directory patterns.
+See [Customizing working directory pattern](workdir.md#using-hydra_override_dirname).
 
 **now**: Creates a string representing the current time using
 [strftime](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior).

--- a/website/docs/configure_hydra/job.md
+++ b/website/docs/configure_hydra/job.md
@@ -20,10 +20,8 @@ The Structured Config is below, the latest definition is <GithubLink to="hydra/c
       # Change current working dir to the output dir.
       chdir: bool = True
 
-      # Concatenation of job overrides that can be used as a part
-      # of the directory name.
-      # This can be configured in hydra.job.config.override_dirname
-      override_dirname: str = MISSING
+      # Deprecated. Use the hydra_override_dirname resolver instead.
+      override_dirname: str = "${hydra_override_dirname:}"
 
       # Job ID in underlying scheduling system
       id: str = MISSING
@@ -43,7 +41,7 @@ The Structured Config is below, the latest definition is <GithubLink to="hydra/c
       @dataclass
       class JobConfig:
           @dataclass
-          # configuration for the ${hydra.job.override_dirname} runtime variable
+          # Default configuration for the ${hydra_override_dirname:} resolver.
           class OverrideDirname:
               kv_sep: str = "="
               item_sep: str = ","
@@ -69,7 +67,7 @@ Learn more at the [Output/Working directory](/tutorials/basic/running_your_app/3
 
 
 ### hydra.job.override_dirname
-Enables the creation of an output directory which is based on command line overrides.
+This field is deprecated. Use the `hydra_override_dirname` resolver to create an output directory based on command line overrides.
 Learn more at the [Customizing Working Directory](/configure_hydra/workdir.md) page.
 
 ### hydra.job.id

--- a/website/docs/configure_hydra/workdir.md
+++ b/website/docs/configure_hydra/workdir.md
@@ -98,13 +98,11 @@ my_app
 </div>
 
 
-### Using `hydra.job.override_dirname`
+### Using `hydra_override_dirname`
 
 <ExampleGithubLink text="Example application" to="examples/configure_hydra/job_override_dirname"/>
 
-This field is populated automatically using your command line arguments and is typically being used as a part of your 
-output directory pattern. It is meant to be used along with the configuration for working dir, especially
-in `hydra.sweep.subdir`.
+The `hydra_override_dirname` resolver derives a directory name from your command line arguments. It is typically used as a part of your output directory pattern, especially in `hydra.sweep.subdir`.
 
 If we run the example application with the following commandline overrides and configs:
 
@@ -120,7 +118,7 @@ python my_app.py --multirun batch_size=32 learning_rate=0.1,0.01
 hydra:
   sweep:
     dir: multirun
-    subdir: ${hydra.job.override_dirname}
+    subdir: ${hydra_override_dirname:}
 ```
 </div>
 <div className="col  col--6">
@@ -134,23 +132,16 @@ multirun
 </div>
 </div>
 
-You can further customized the output dir creation by configuring`hydra.job.override_dirname`.
-
-In particular, the separator char `=` and the item separator char `,` can be modified by overriding 
-`hydra.job.config.override_dirname.kv_sep` and `hydra.job.config.override_dirname.item_sep`.
-Command line override keys can also be automatically excluded from the generated `override_dirname`.
+You can further customize the output dir creation by passing options to the resolver.
+In particular, the separator char `=`, the item separator char `,`, and excluded command line override keys can be configured directly at the use site.
 
 An example of a case where the exclude is useful is a random seed.
 
 ```yaml
 hydra:
-  run:
-    dir: output/${hydra.job.override_dirname}/seed=${seed}
-  job:
-    config:
-      override_dirname:
-        exclude_keys:
-          - seed
+  sweep:
+    dir: multirun
+    subdir: '${hydra_override_dirname:{exclude_keys: [seed]}}/seed=${seed}'
 ```
 With this configuration, running
 ```bash
@@ -169,3 +160,29 @@ multirun
     └── seed=2
 ```
 
+Custom separators can be specified the same way:
+
+```yaml
+hydra:
+  sweep:
+    subdir: '${hydra_override_dirname:{kv_sep: "-", item_sep: "_", exclude_keys: [seed]}}'
+```
+
+For more control, `element_resolver` can apply a custom OmegaConf resolver to each directory name element before the elements are joined.
+The resolver must be registered separately before Hydra starts.
+For example, this replaces path separators, including Windows path separators, with `_`:
+
+```python
+from omegaconf import OmegaConf
+
+OmegaConf.register_new_resolver(
+    "pathsafe",
+    lambda value: str(value).replace("/", "_").replace("\\", "_"),
+)
+```
+
+```yaml
+hydra:
+  sweep:
+    subdir: '${hydra_override_dirname:{item_sep: "/", element_resolver: pathsafe}}'
+```

--- a/website/docs/upgrades/1.3_to_1.4/hydra_job_override_dirname.md
+++ b/website/docs/upgrades/1.3_to_1.4/hydra_job_override_dirname.md
@@ -1,0 +1,60 @@
+---
+id: hydra_job_override_dirname
+title: hydra.job.override_dirname
+---
+
+Hydra 1.4 deprecates `hydra.job.override_dirname` in favor of the `hydra_override_dirname` resolver.
+The resolver keeps the same default behavior while making override dirname generation lazy and configurable at the use site.
+Users can also replace it with their own resolver or interpolation when they need fundamentally different behavior.
+
+```yaml title="Hydra 1.3"
+hydra:
+  sweep:
+    subdir: ${hydra.job.override_dirname}
+```
+
+```yaml title="Hydra 1.4"
+hydra:
+  sweep:
+    subdir: ${hydra_override_dirname:}
+```
+
+`hydra.job.config.override_dirname` is still used as the default configuration for `${hydra_override_dirname:}`:
+
+```yaml
+hydra:
+  sweep:
+    subdir: ${hydra_override_dirname:}/seed=${seed}
+  job:
+    config:
+      override_dirname:
+        exclude_keys:
+          - seed
+```
+
+You can also pass options directly:
+
+```yaml
+hydra:
+  sweep:
+    subdir: '${hydra_override_dirname:{kv_sep: "-", item_sep: "_", exclude_keys: [seed]}}'
+```
+
+For more control, `element_resolver` can apply a custom OmegaConf resolver to each directory name element before the elements are joined.
+The resolver must be registered separately before Hydra starts.
+For example, this replaces path separators, including Windows path separators, with `_`:
+
+```python
+from omegaconf import OmegaConf
+
+OmegaConf.register_new_resolver(
+    "pathsafe",
+    lambda value: str(value).replace("/", "_").replace("\\", "_"),
+)
+```
+
+```yaml
+hydra:
+  sweep:
+    subdir: '${hydra_override_dirname:{item_sep: "/", element_resolver: pathsafe}}'
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -161,6 +161,13 @@ module.exports = AddFBInternalOnly({
             'upgrades/version_base',
             {
                 type: 'category',
+                label: '1.3 to 1.4',
+                items: [
+                    'upgrades/1.3_to_1.4/hydra_job_override_dirname',
+                ],
+            },
+            {
+                type: 'category',
                 label: '1.1 to 1.2',
                 items: [
                     'upgrades/1.1_to_1.2/changes_to_hydra_main_config_path',


### PR DESCRIPTION

Introduce a lazy hydra_override_dirname resolver for deriving output directory names from task overrides, including call-site options and optional per-element resolver transforms.

Deprecate hydra.job.override_dirname as a compatibility interpolation that warns while preserving legacy behavior. Stop eagerly populating override_dirname during config loading.

Update examples, docs, and migration guidance to teach the resolver API, and add focused tests for resolver options, legacy compatibility, and deprecated usage in output directories.

Fixes #3018.
