### PR TITLE
Reject swept multirun controller config changes

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -318,7 +318,7 @@ class ConfigLoaderImpl(ConfigLoader):
             overrides=overrides,
             run_mode=RunMode.RUN,
         )
-        ConfigLoaderImpl._ensure_no_sweep_config_controller_override(
+        ConfigLoaderImpl._ensure_sweep_config_controller_unchanged(
             master_config=master_config,
             sweep_config=sweep_config,
         )
@@ -331,13 +331,16 @@ class ConfigLoaderImpl(ConfigLoader):
         return sweep_config
 
     @staticmethod
-    def _ensure_no_sweep_config_controller_override(
+    def _ensure_sweep_config_controller_unchanged(
         master_config: DictConfig, sweep_config: DictConfig
     ) -> None:
-        controller_groups = ("hydra/launcher", "hydra/sweeper")
+        controller_groups = (
+            ("hydra/launcher", "launcher"),
+            ("hydra/sweeper", "sweeper"),
+        )
         master_choices = master_config.hydra.runtime.choices
         sweep_choices = sweep_config.hydra.runtime.choices
-        for group in controller_groups:
+        for group, node in controller_groups:
             master_choice = master_choices.get(group)
             sweep_choice = sweep_choices.get(group)
             if master_choice != sweep_choice:
@@ -347,6 +350,14 @@ class ConfigLoaderImpl(ConfigLoader):
                     f"but a swept job config changed it from "
                     f"'{master_choice}' to '{sweep_choice}'. Select it in "
                     "the primary config or from the command line."
+                )
+            if not OmegaConf.structural_equality(
+                master_config.hydra[node], sweep_config.hydra[node]
+            ):
+                raise ConfigCompositionException(
+                    f"'hydra.{node}' must be configured before the sweep starts, "
+                    "but a swept job config changed it. Configure it in the "
+                    "primary config or from the command line."
                 )
 
     def get_search_path(self) -> ConfigSearchPath:

--- a/news/3231.bugfix
+++ b/news/3231.bugfix
@@ -1,1 +1,1 @@
-Reject swept configs that override the multirun launcher or sweeper.
+Reject swept configs that change multirun launcher or sweeper configuration.

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_config.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_config.py
@@ -6,9 +6,8 @@ from importlib import import_module
 from importlib.metadata import version
 from typing import Any, Dict, List, Optional
 
-from omegaconf import OmegaConf
-
 from hydra.core.config_store import ConfigStore
+from omegaconf import OmegaConf
 
 
 @dataclass

--- a/tests/test_apps/sweep_hydra_launcher_override/conf/experiment/launcher_config.yaml
+++ b/tests/test_apps/sweep_hydra_launcher_override/conf/experiment/launcher_config.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+hydra:
+  launcher:
+    _target_: hydra._internal.core_plugins.basic_launcher.NotALauncher
+
+experiment: launcher_config

--- a/tests/test_apps/sweep_hydra_launcher_override/conf/experiment/sweeper_params.yaml
+++ b/tests/test_apps/sweep_hydra_launcher_override/conf/experiment/sweeper_params.yaml
@@ -1,0 +1,7 @@
+# @package _global_
+hydra:
+  sweeper:
+    params:
+      x: 1,2
+
+experiment: sweeper_params

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -671,6 +671,36 @@ def test_multirun_rejects_swept_config_hydra_controller_override(
 
 
 @mark.parametrize(
+    "controller,experiment",
+    [
+        param("hydra.launcher", "launcher_config", id="launcher"),
+        param("hydra.sweeper", "sweeper_params", id="sweeper"),
+    ],
+)
+def test_multirun_rejects_swept_config_hydra_controller_config_override(
+    hydra_restore_singletons: Any,
+    hydra_sweep_runner: TSweepRunner,
+    tmpdir: Path,
+    controller: str,
+    experiment: str,
+) -> None:
+    with raises(
+        ConfigCompositionException,
+        match=rf"{re.escape(controller)}.*must be configured before the sweep starts",
+    ):
+        with hydra_sweep_runner(
+            calling_file="tests/test_apps/sweep_hydra_launcher_override/my_app.py",
+            calling_module=None,
+            config_path="conf",
+            config_name="config.yaml",
+            task_function=None,
+            overrides=[f"experiment=base,{experiment}"],
+            temp_dir=tmpdir,
+        ):
+            pass
+
+
+@mark.parametrize(
     "script, flags, overrides,expected",
     [
         param(


### PR DESCRIPTION

Detect when a swept job config changes hydra.launcher or hydra.sweeper after the multirun has already started.

Keep the existing selected-controller guard and add structural comparison of the launcher and sweeper config nodes so advanced sweep configs fail loudly when they cross that boundary. Add launcher and sweeper regression fixtures and update the news fragment.

Refs #2807.
