### PR TITLE
Clarify multi-select config group docs

### DIFF
--- a/examples/patterns/multi-select/conf/config.yaml
+++ b/examples/patterns/multi-select/conf/config.yaml
@@ -1,2 +1,2 @@
 defaults:
-  - server: apache
+  - server/apache

--- a/examples/patterns/multi-select/conf/server/apache_https.yaml
+++ b/examples/patterns/multi-select/conf/server/apache_https.yaml
@@ -1,7 +1,0 @@
-defaults:
-  - site@https:
-      - fb
-      - google
-
-host: localhost
-port: 443

--- a/news/2695.docs
+++ b/news/2695.docs
@@ -1,0 +1,1 @@
+Clarify multi-select config group documentation and example.

--- a/tests/test_examples/test_patterns.py
+++ b/tests/test_examples/test_patterns.py
@@ -148,31 +148,6 @@ def test_configuring_experiments(
             },
             id="default:override",
         ),
-        param(
-            ["server=apache_https"],
-            {
-                "server": {
-                    "https": {
-                        "fb": {"domain": "facebook.com"},
-                        "google": {"domain": "google.com"},
-                    },
-                    "host": "localhost",
-                    "port": 443,
-                }
-            },
-            id="pkg_override",
-        ),
-        param(
-            ["server=apache_https", "server/site@server.https=amazon"],
-            {
-                "server": {
-                    "https": {"amazon": {"domain": "amazon.com"}},
-                    "host": "localhost",
-                    "port": 443,
-                }
-            },
-            id="pkg_override:override",
-        ),
     ],
 )
 def test_multi_select(

--- a/website/docs/patterns/select_multiple_configs_from_config_group.md
+++ b/website/docs/patterns/select_multiple_configs_from_config_group.md
@@ -104,49 +104,9 @@ server:
 ```
 
 
-### Overriding packages
-You can relocate the package of all the configs in the list. e.g:
-
-<div className="row">
-<div className="col col--6">
-
-```yaml title="server/apache.yaml" {2}
-defaults:
-  - site@https:
-    - fb
-    - google
-
-
-```
-</div>
-
-<div className="col col--6">
-
-```yaml title="$ python my_app.py" {2}
-server:
-  https:
-    fb:
-      domain: facebook.com
-    google:
-      domain: google.com
-```
-</div>
-</div>
-
-When overriding the selected configs of config groups with overridden packages you need to use the package. e.g:
-```yaml title="$ python my_app.py server/site@server.https=amazon"
-server:
-  https:
-    amazon:
-      domain: amazon.com
-  host: localhost
-  port: 443
-```
-
-
 ### Implementation considerations
 
-A nested list in the Defaults List is interpreted as a list of non-overridable configs:
+The following two forms compose the same output:
 
 <div className="row">
 <div className="col col--6">
@@ -160,7 +120,7 @@ defaults:
 </div>
 <div className="col col--6">
 
-```yaml title="Equivalent to" {2,3}
+```yaml title="Composes like" {2,3}
 defaults:
   - site/fb
   - site/google
@@ -169,8 +129,11 @@ defaults:
 </div>
 </div>
 
+Use the nested list form when you want to override the group later with
+`'server/site=[...]'`.
+
 To delete one of these non-overridable entries from the command line, use the
-exact config path, for example `~site/fb`.
+exact config path, for example `~server/site/fb`.
 
 All default package for all the configs in `server/site` is `server.site`.
 This example uses an explicit nesting level inside each of the website configs to prevent them stepping over one another:


### PR DESCRIPTION

Reduce the multi-select example to focus on selecting multiple configs from one config group. Remove the extra apache_https server option and use a direct server/apache include in the example config.

Clarify that the nested list form composes like expanded config entries while preserving group override syntax, and fix the delete example path.

Closes #2695.
