### PR TITLE
Preserve nested dataclass targets during instantiation

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -21,6 +21,7 @@ skip=
     .sl
     .nox
     .build
+    .venv
     build
     contrib
     hydra/grammar/gen

--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -7,7 +7,7 @@ from enum import Enum
 from textwrap import dedent
 from typing import Any, Callable, Dict, List, Sequence, Tuple, Union
 
-from omegaconf import OmegaConf, SCMode
+from omegaconf import AnyNode, OmegaConf, SCMode
 from omegaconf._utils import is_structured_config
 
 from hydra._internal.utils import _locate
@@ -377,6 +377,12 @@ def _convert_node(node: Any, convert: Union[ConvertMode, str]) -> Any:
     return node
 
 
+def _wrap_structured_config_as_object(value: Any) -> Any:
+    if is_structured_config(value):
+        return AnyNode(value, flags={"allow_objects": True})
+    return value
+
+
 def instantiate_node(
     node: Any,
     *args: Any,
@@ -425,7 +431,9 @@ def instantiate_node(
             return items
         else:
             # Otherwise, use ListConfig as container
-            lst = OmegaConf.create(items, flags={"allow_objects": True})
+            lst = OmegaConf.create([], flags={"allow_objects": True})
+            for item in items:
+                lst.append(_wrap_structured_config_as_object(item))
             lst._set_parent(node)
             return lst
 
@@ -465,8 +473,8 @@ def instantiate_node(
                 # Otherwise use DictConfig and resolve interpolations lazily.
                 cfg = OmegaConf.create({}, flags={"allow_objects": True})
                 for key, value in node.items():
-                    cfg[key] = instantiate_node(
-                        value, convert=convert, recursive=recursive
+                    cfg[key] = _wrap_structured_config_as_object(
+                        instantiate_node(value, convert=convert, recursive=recursive)
                     )
                 cfg._set_parent(node)
                 cfg._metadata.object_type = node._metadata.object_type

--- a/news/2507.bugfix
+++ b/news/2507.bugfix
@@ -1,0 +1,1 @@
+Preserve nested dataclass targets during instantiation.

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -7,7 +7,14 @@ from functools import partial
 from textwrap import dedent
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
-from omegaconf import MISSING, DictConfig, ListConfig, MissingMandatoryValue, OmegaConf
+from omegaconf import (
+    MISSING,
+    AnyNode,
+    DictConfig,
+    ListConfig,
+    MissingMandatoryValue,
+    OmegaConf,
+)
 from pytest import fixture, mark, param, raises, warns
 
 import hydra
@@ -84,6 +91,10 @@ def config(request: Any, src: Any) -> Any:
     cfg_copy = copy.deepcopy(config)
     yield config
     assert config == cfg_copy
+
+
+def structured_config_object_node(value: Any) -> Any:
+    return AnyNode(value, flags={"allow_objects": True})
 
 
 @mark.parametrize(
@@ -1848,14 +1859,17 @@ def test_convert_and_recursive_node(
                 },
             },
             (
-                # a is a DictConfig because of top level DictConfig
                 OmegaConf.create(
                     {
-                        "a": SimpleDataClass(
-                            a=OmegaConf.create({"foo": 99}), b=OmegaConf.create([1, 99])
+                        "a": structured_config_object_node(
+                            SimpleDataClass(
+                                a=OmegaConf.create({"foo": 99}),
+                                b=OmegaConf.create([1, 99]),
+                            )
                         ),
                         "b": None,
-                    }
+                    },
+                    flags={"allow_objects": True},
                 ),
                 {"a": SimpleDataClass(a={"foo": 99}, b=[1, 99]), "b": None},
                 {"a": SimpleDataClass(a={"foo": 99}, b=[1, 99]), "b": None},
@@ -2012,6 +2026,35 @@ def test_instantiated_regular_class_container_types_object2(
     assert isinstance(ret.a, list)
     assert isinstance(ret.a[0], dict)
     assert isinstance(ret.a[1], User)
+
+
+def test_nested_dataclass_targets_remain_objects_with_convert_none(
+    instantiate_func: Any,
+) -> None:
+    dataclass_target = {
+        "_target_": "tests.instantiate.SimpleDataClass",
+        "a": "foo",
+        "b": 123,
+    }
+
+    top = instantiate_func(dataclass_target, _convert_=ConvertMode.NONE)
+    assert isinstance(top, SimpleDataClass)
+
+    ret_list = instantiate_func([dataclass_target], _convert_=ConvertMode.NONE)
+    assert isinstance(ret_list, ListConfig)
+    assert isinstance(ret_list[0], SimpleDataClass)
+    assert ret_list[0] == top
+
+    ret = instantiate_func(
+        {"nested": dataclass_target, "items": [dataclass_target]},
+        _convert_=ConvertMode.NONE,
+    )
+    assert isinstance(ret, DictConfig)
+    assert isinstance(ret.nested, SimpleDataClass)
+    assert ret.nested == top
+    assert isinstance(ret["items"], ListConfig)
+    assert isinstance(ret["items"][0], SimpleDataClass)
+    assert ret["items"][0] == top
 
 
 @mark.parametrize(


### PR DESCRIPTION

Preserve dataclass instances returned by nested _target_ entries when _convert_=none inserts them into DictConfig or ListConfig containers. Add regression coverage for nested dict and list containers, including top-level list roots.

Fixes #2507
