### PR TITLE
Fix hydra.job.env_set interpolation resolution

### DIFF
--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -136,7 +136,12 @@ def run_job(
                 del task_cfg["hydra"]
 
         ret.cfg = task_cfg
-        hydra_cfg = copy.deepcopy(HydraConfig.instance().cfg)
+        hydra_cfg = HydraConfig.instance().cfg
+        assert isinstance(hydra_cfg, DictConfig)
+        env_set = hydra_cfg.hydra.job.env_set
+        with read_write(env_set):
+            OmegaConf.resolve(env_set)
+        hydra_cfg = copy.deepcopy(hydra_cfg)
         assert isinstance(hydra_cfg, DictConfig)
         ret.hydra_cfg = hydra_cfg
         overrides = OmegaConf.to_container(config.hydra.overrides.task)

--- a/news/2800.bugfix
+++ b/news/2800.bugfix
@@ -1,0 +1,1 @@
+Resolve hydra.job.env_set interpolations before setting environment variables.

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -1066,6 +1066,19 @@ def test_hydra_env_set_with_config(tmpdir: Path) -> None:
     )
 
 
+def test_hydra_env_set_with_config_interpolation(tmpdir: Path) -> None:
+    cfg = OmegaConf.create(
+        {"foo": "bar", "hydra": {"job": {"env_set": {"foo": "${foo}"}}}}
+    )
+    integration_test(
+        tmpdir=tmpdir,
+        task_config=cfg,
+        overrides=[],
+        prints="os.environ['foo']",
+        expected_outputs="bar",
+    )
+
+
 def test_hydra_env_set_with_override(tmpdir: Path) -> None:
     integration_test(
         tmpdir=tmpdir,


### PR DESCRIPTION

Resolve hydra.job.env_set while the masked Hydra config still has its full-config parent link, before deepcopying the Hydra config for job return and output serialization.

Add regression coverage for hydra.job.env_set interpolating from the task config.

Fixes #2800.
