### PR TITLE
Fix RQ launcher result serialization

### DIFF
--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/_core.py
@@ -2,10 +2,12 @@
 import logging
 import time
 import uuid
+from base64 import b64decode
+from binascii import Error as BinasciiError
 from pathlib import Path
-from typing import Any, Dict, List, Sequence, cast
+from pickle import UnpicklingError
+from typing import Any, Dict, List, Optional, Sequence, cast
 
-import cloudpickle  # type: ignore
 from fakeredis import FakeStrictRedis  # type: ignore
 from hydra.core.hydra_config import HydraConfig
 from hydra.core.singleton import Singleton
@@ -16,14 +18,24 @@ from hydra.core.utils import (
     run_job,
     setup_globals,
 )
+from hydra.errors import CompactHydraException
 from hydra.types import HydraContext, TaskFunction
 from omegaconf import DictConfig, OmegaConf, open_dict
 from redis import Redis  # type: ignore[import-untyped]
 from rq import Queue
+from rq.results import UNSERIALIZABLE_RETURN_VALUE_PAYLOAD, Result
 
 from .rq_launcher import RQLauncher
+from .serializer import CloudpickleSerializer
 
 log = logging.getLogger(__name__)
+
+_UNSERIALIZABLE_RETURN_VALUE = UNSERIALIZABLE_RETURN_VALUE_PAYLOAD
+_SERIALIZER_ERROR = (
+    "RQ could not deserialize the job result. This usually means the worker "
+    "was not started with Hydra's cloudpickle serializer. Start RQ workers with "
+    "`-S hydra_plugins.hydra_rq_launcher.serializer.CloudpickleSerializer`."
+)
 
 
 def execute_job(
@@ -86,7 +98,7 @@ def launch(
         name=rq_cfg.queue,
         connection=connection,
         is_async=is_async,
-        serializer=cloudpickle,
+        serializer=CloudpickleSerializer,
     )
 
     # Enqueue jobs
@@ -136,7 +148,7 @@ def launch(
         )
         jobs.append(job)
 
-        log.info(f"Enqueued {job.get_id()}")
+        log.info(f"Enqueued {_get_job_id(job)}")
         log.info(f"\t#{idx + 1} : {description}")
 
     log.info("Finished enqueuing")
@@ -146,7 +158,9 @@ def launch(
     log.info(f"Polling job statuses every {rq_cfg.wait_polling} sec")
     while True:
         job_ids_done = [
-            job.get_id() for job in jobs if job.get_status() in ["finished", "failed"]
+            _get_job_id(job)
+            for job in jobs
+            if job.get_status() in ["finished", "failed"]
         ]
         if len(job_ids_done) == len(jobs):
             break
@@ -155,11 +169,80 @@ def launch(
 
     runs: List[JobReturn] = []
     for job in jobs:
-        result = job.result if job.result is not None else None
-        runs.append(cast(JobReturn, result))
+        runs.append(_get_job_result(job))
 
     return runs
 
 
 class StopAfterEnqueue(Exception):
     pass
+
+
+def _get_job_result(job: Any) -> JobReturn:
+    try:
+        result = job.return_value() if hasattr(job, "return_value") else job.result
+    except UnpicklingError as exc:
+        if _is_unserializable_return_value(job):
+            raise CompactHydraException(
+                f"{_SERIALIZER_ERROR} Job id: {_get_job_id(job)}"
+            ) from exc
+        raise
+
+    if result == _UNSERIALIZABLE_RETURN_VALUE:
+        raise CompactHydraException(f"{_SERIALIZER_ERROR} Job id: {_get_job_id(job)}")
+
+    return cast(JobReturn, result)
+
+
+def _is_unserializable_return_value(job: Any) -> bool:
+    legacy_result = job.connection.hget(job.key, "result")
+    if _matches_unserializable_return_value(legacy_result):
+        return True
+
+    latest_result = _get_latest_result_payload(job)
+    if latest_result is None:
+        return False
+
+    return_value = latest_result.get(b"return_value") or latest_result.get(
+        "return_value"
+    )
+    if return_value is None:
+        return False
+
+    try:
+        decoded_return_value = b64decode(return_value)
+    except (BinasciiError, TypeError):
+        return False
+
+    return _matches_unserializable_return_value(decoded_return_value)
+
+
+def _matches_unserializable_return_value(value: Any) -> bool:
+    if value in (
+        _UNSERIALIZABLE_RETURN_VALUE,
+        _UNSERIALIZABLE_RETURN_VALUE.encode("utf-8"),
+    ):
+        return True
+
+    if isinstance(value, bytes):
+        try:
+            return CloudpickleSerializer.loads(value) == _UNSERIALIZABLE_RETURN_VALUE
+        except Exception:
+            return False
+
+    return False
+
+
+def _get_latest_result_payload(job: Any) -> Optional[Dict[Any, Any]]:
+    response = job.connection.xrevrange(
+        Result.get_key(_get_job_id(job)), "+", "-", count=1
+    )
+    if not response:
+        return None
+    return cast(Dict[Any, Any], response[0][1])
+
+
+def _get_job_id(job: Any) -> str:
+    if hasattr(job, "get_id"):
+        return str(job.get_id())
+    return str(job.id)

--- a/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/serializer.py
+++ b/plugins/hydra_rq_launcher/hydra_plugins/hydra_rq_launcher/serializer.py
@@ -1,0 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import cloudpickle  # type: ignore
+
+
+class CloudpickleSerializer:
+    dumps = cloudpickle.dumps
+    loads = cloudpickle.loads

--- a/plugins/hydra_rq_launcher/news/2338.bugfix
+++ b/plugins/hydra_rq_launcher/news/2338.bugfix
@@ -1,0 +1,1 @@
+Upgrade RQ launcher dependencies and validate worker result serialization.

--- a/plugins/hydra_rq_launcher/setup.py
+++ b/plugins/hydra_rq_launcher/setup.py
@@ -28,9 +28,9 @@ setup(
     python_requires=">=3.10",
     install_requires=[
         "cloudpickle",
-        "fakeredis<1.7.4",  # https://github.com/dsoftwareinc/fakeredis-py/issues/3
+        "fakeredis>=2.36.2,<3",
         "hydra-core>=1.1.0.dev7",
-        "rq>=1.5.1,<1.12",
+        "rq>=2.10.0,<3",
     ],
     include_package_data=True,
 )

--- a/plugins/hydra_rq_launcher/tests/test_rq_launcher.py
+++ b/plugins/hydra_rq_launcher/tests/test_rq_launcher.py
@@ -1,7 +1,11 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from base64 import b64encode
+from pickle import UnpicklingError
 from typing import List
 
+import pytest
 from hydra.core.plugins import Plugins
+from hydra.errors import CompactHydraException
 from hydra.plugins.launcher import Launcher
 from hydra.test_utils.launcher_common_tests import (
     IntegrationTestSuite,
@@ -9,8 +13,11 @@ from hydra.test_utils.launcher_common_tests import (
 )
 from hydra.test_utils.test_utils import TSweepRunner, chdir_plugin_root
 from pytest import mark
+from rq.serializers import DefaultSerializer
 
+from hydra_plugins.hydra_rq_launcher._core import _get_job_result
 from hydra_plugins.hydra_rq_launcher.rq_launcher import RQLauncher
+from hydra_plugins.hydra_rq_launcher.serializer import CloudpickleSerializer
 
 chdir_plugin_root()
 
@@ -66,3 +73,67 @@ def test_example_app(
         assert sweep.returns is not None and len(sweep.returns[0]) == 4
         for ret in sweep.returns[0]:
             assert tuple(ret.overrides) in overrides
+
+
+def test_cloudpickle_serializer() -> None:
+    def value(x: int) -> int:
+        return x + 1
+
+    assert CloudpickleSerializer.loads(CloudpickleSerializer.dumps(value))(41) == 42
+
+
+def test_unserializable_rq_result_error() -> None:
+    class Connection:
+        def hget(self, key: str, field: str) -> bytes:
+            assert key == "rq:job:123"
+            assert field == "result"
+            return b"Unserializable return value"
+
+    class Job:
+        key = "rq:job:123"
+        connection = Connection()
+
+        def get_id(self) -> str:
+            return "123"
+
+        @property
+        def result(self) -> object:
+            raise UnpicklingError("pickle data was truncated")
+
+    with pytest.raises(CompactHydraException, match="cloudpickle serializer"):
+        _get_job_result(Job())
+
+
+def test_unserializable_rq_result_stream_error() -> None:
+    class Connection:
+        def hget(self, key: str, field: str) -> None:
+            assert key == "rq:job:123"
+            assert field == "result"
+            return None
+
+        def xrevrange(self, key: str, start: str, end: str, count: int) -> List[object]:
+            assert key == "rq:results:123"
+            assert start == "+"
+            assert end == "-"
+            assert count == 1
+            return [
+                (
+                    b"1-0",
+                    {
+                        b"return_value": b64encode(
+                            DefaultSerializer.dumps("Unserializable return value")
+                        ),
+                    },
+                )
+            ]
+
+    class Job:
+        id = "123"
+        key = "rq:job:123"
+        connection = Connection()
+
+        def return_value(self) -> object:
+            raise UnpicklingError("pickle data was truncated")
+
+    with pytest.raises(CompactHydraException, match="cloudpickle serializer"):
+        _get_job_result(Job())

--- a/website/docs/plugins/rq_launcher.md
+++ b/website/docs/plugins/rq_launcher.md
@@ -80,7 +80,8 @@ export REDIS_SSL_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 Assuming configured environment variables, workers connecting to the Redis server can be launched using:
 
 ```commandline
-rq worker --url redis://:$REDIS_PASSWORD@$REDIS_HOST:$REDIS_PORT/$REDIS_DB
+rq worker --url redis://:$REDIS_PASSWORD@$REDIS_HOST:$REDIS_PORT/$REDIS_DB \
+  -S hydra_plugins.hydra_rq_launcher.serializer.CloudpickleSerializer
 ```
 
 An <GithubLink to="plugins/hydra_rq_launcher/example">example application</GithubLink> using this launcher is provided in the plugin repository.
@@ -106,6 +107,6 @@ $ python my_app.py --multirun task=1,2,3,4,5
 [HYDRA] Polling job statuses every 1.0 sec
 ```
 
-Note that any dependencies need to be installed in the Python environment used to run the RQ worker. For serialization of jobs [`cloudpickle`](https://github.com/cloudpickle/cloudpickle) is used.
+Note that any dependencies need to be installed in the Python environment used to run the RQ worker. Workers must use Hydra's cloudpickle serializer so that job results are serialized compatibly with the RQ launcher.
 
 The [RQ documentation](https://python-rq.org/) holds further information on [job monitoring](http://python-rq.org/docs/monitoring/), which can be done via console or [web interfaces](https://github.com/nvie/rq-dashboard), and provides [patterns](https://python-rq.org/patterns/) for worker and exception handling.


### PR DESCRIPTION

Use a shared cloudpickle serializer class for the RQ launcher and document the matching worker startup command. Upgrade the RQ launcher dependency range to RQ 2.10/fakeredis 2.36 and use RQ 2 return-value APIs with a compatibility fallback.

Detect RQ unserializable-result sentinels in both legacy job-hash results and RQ 2 result streams, raising a compact Hydra error that points users at the worker serializer setting. Add regression coverage for the serializer and both sentinel storage paths.

Closes #2338.
