### PR TITLE
Harden instantiate target blocklist

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -2,6 +2,7 @@
 
 import copy
 import functools
+import os
 from enum import Enum
 from textwrap import dedent
 from typing import Any, Callable, Dict, List, Sequence, Tuple, Union
@@ -12,6 +13,87 @@ from omegaconf._utils import is_structured_config
 from hydra._internal.utils import _locate
 from hydra.errors import InstantiationException
 from hydra.types import ConvertMode, TargetConf
+
+DEFAULT_BLOCKLISTED_MODULES = {
+    "builtins.exec",
+    "builtins.eval",
+    "builtins.__import__",
+    "builtins.compile",
+    "builtins.exit",
+    "builtins.quit",
+    "ctypes.CDLL",
+    "ctypes.OleDLL",
+    "ctypes.PyDLL",
+    "ctypes.WinDLL",
+    "ctypes.cdll.LoadLibrary",
+    "ctypes.oledll.LoadLibrary",
+    "ctypes.pydll.LoadLibrary",
+    "ctypes.windll.LoadLibrary",
+    "importlib.import_module",
+    "os.kill",
+    "os.system",
+    "os.popen",
+    "os.putenv",
+    "os.remove",
+    "os.removedirs",
+    "os.rmdir",
+    "os.fchdir",
+    "os.setuid",
+    "os.fork",
+    "os.forkpty",
+    "os.killpg",
+    "os.rename",
+    "os.renames",
+    "os.startfile",
+    "os.posix_spawn",
+    "os.posix_spawnp",
+    "os.truncate",
+    "os.replace",
+    "os.unlink",
+    "os.fchmod",
+    "os.fchown",
+    "os.chmod",
+    "os.chown",
+    "os.chroot",
+    "os.fchdir",
+    "os.lchflags",
+    "os.lchmod",
+    "os.lchown",
+    "os.getcwd",
+    "os.chdir",
+    "pty.spawn",
+    "runpy.run_module",
+    "runpy.run_path",
+    "shutil.rmtree",
+    "shutil.move",
+    "shutil.chown",
+    "subprocess.Popen",
+    "subprocess.run",
+    "subprocess.call",
+    "subprocess.check_call",
+    "subprocess.check_output",
+    "subprocess.getoutput",
+    "subprocess.getstatusoutput",
+    "builtins.help",
+    "sys.modules.ipdb",
+    "sys.modules.joblib",
+    "sys.modules.resource",
+    "sys.modules.psutil",
+    "sys.modules.tkinter",
+}
+
+DEFAULT_BLOCKLISTED_MODULE_PREFIXES = (
+    "os.exec",
+    "os.spawn",
+)
+
+
+def _get_os_alias_target(target: str) -> str:
+    for module in ("posix", "nt"):
+        module_prefix = f"{module}."
+        if target.startswith(module_prefix):
+            return f"os.{target[len(module_prefix):]}"
+    return target
 
 
 class _Keys(str, Enum):
@@ -30,6 +112,14 @@ def _is_target(x: Any) -> bool:
     if OmegaConf.is_dict(x):
         return "_target_" in x
     return False
+
+
+def _is_blocklisted_target(target: str) -> bool:
+    canonical_target = _get_os_alias_target(target)
+    return (
+        canonical_target in DEFAULT_BLOCKLISTED_MODULES
+        or canonical_target.startswith(DEFAULT_BLOCKLISTED_MODULE_PREFIXES)
+    )
 
 
 def _extract_pos_args(input_args: Any, kwargs: Any) -> Tuple[Any, Any]:
@@ -130,6 +220,21 @@ def _resolve_target(
 ) -> Union[type, Callable[..., Any]]:
     """Resolve target string, type or callable into type or callable."""
     if isinstance(target, str):
+        if _is_blocklisted_target(target):
+            allowlist = os.environ.get("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "")
+            allowlist_entries = allowlist.split(":")
+            canonical_target = _get_os_alias_target(target)
+            if target not in allowlist_entries and canonical_target not in allowlist_entries:
+                msg = dedent(
+                    f"""\
+                    Target '{target}' is blocklisted and cannot be instantiated from config
+                    to prevent security vulnerabilities, set env var
+                    HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE={target}:<other allowlisted targets> to bypass"""
+                )
+                if full_key:
+                    msg += f"\nfull_key: {full_key}"
+                raise InstantiationException(msg)
+
         try:
             target = _locate(target)
         except Exception as e:

--- a/news/3259.bugfix
+++ b/news/3259.bugfix
@@ -1,0 +1,1 @@
+Harden instantiate target blocklist coverage for security-sensitive callables.

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import copy
+import os
 import pickle
 import re
 from dataclasses import dataclass
@@ -12,6 +13,7 @@ from pytest import fixture, mark, param, raises, warns
 
 import hydra
 from hydra import version
+from hydra._internal.instantiate._instantiate2 import _resolve_target
 from hydra.errors import InstantiationException
 from hydra.test_utils.test_utils import assert_multiline_regex_search
 from hydra.types import ConvertMode, TargetConf
@@ -1496,6 +1498,72 @@ def test_cannot_locate_target(instantiate_func: Any) -> None:
         ),
         chained.args[0],
     )
+
+
+@mark.parametrize(
+    "target",
+    [
+        "builtins.compile",
+        "ctypes.CDLL",
+        "ctypes.WinDLL",
+        "ctypes.windll.LoadLibrary",
+        "importlib.import_module",
+        "os.execl",
+        "os.getcwd",
+        "os.popen",
+        "os.posix_spawn",
+        "posix.kill",
+        "posix.remove",
+        "posix.system",
+        "nt.startfile",
+        "nt.system",
+        "pty.spawn",
+        "runpy.run_path",
+        "subprocess.Popen",
+        "subprocess.check_output",
+        "subprocess.run",
+    ],
+)
+def test_blocklisted_target_fails(instantiate_func: Any, target: str) -> None:
+    cfg = OmegaConf.create({"foo": {"_target_": target}})
+    with raises(
+        InstantiationException,
+        match=re.escape(dedent(f"""\
+                Target '{target}' is blocklisted and cannot be instantiated from config
+                to prevent security vulnerabilities, set env var
+                HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE={target}:<other allowlisted targets> to bypass
+                full_key: foo""")),
+    ) as exc_info:
+        instantiate_func(cfg)
+    err = exc_info.value
+    assert hasattr(err, "__cause__")
+    chained = err.__cause__
+    assert chained is None
+
+
+def test_allowlist_works(instantiate_func: Any, monkeypatch: Any) -> None:
+    cfg = OmegaConf.create(
+        {
+            "foo": {"_target_": "builtins.exec", "_args_": ["5+8"]},
+            "bar": {"_target_": "builtins.eval", "_args_": ["1+2"]},
+        }
+    )
+    monkeypatch.setenv(
+        "HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "builtins.exec:builtins.eval"
+    )
+    res = instantiate_func(cfg)
+    assert res.foo is None
+    assert res.bar == 3
+
+
+def test_allowlist_works_for_prefix_blocked_target(monkeypatch: Any) -> None:
+    monkeypatch.setenv("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "os.execl")
+    assert _resolve_target("os.execl", "") is os.execl
+
+
+def test_allowlist_works_for_canonical_os_alias(monkeypatch: Any) -> None:
+    monkeypatch.setenv("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "os.kill")
+    assert _resolve_target("posix.kill", "") is os.kill
 
 
 @mark.parametrize(


### PR DESCRIPTION
Backport of #3259 to the 1.3 branch.

This hardens the instantiate target blocklist and adds regression coverage.