### PR TITLE
Call on_job_end and on_run_end callbacks on KeyboardInterrupt

### DIFF
--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -170,11 +170,17 @@ class Hydra:
                 job_subdir_key=None,
                 configure_logging=with_log_configuration,
             )
-        except KeyboardInterrupt:
-            interrupted_ret = JobReturn()
-            interrupted_ret.status = JobStatus.FAILED
+        except KeyboardInterrupt as e:
+            # run_job attaches its populated JobReturn to the interrupt before
+            # re-raising; fall back to a minimal one if the interrupt happened
+            # before the job ran (e.g. during on_job_start)
+            job_return = getattr(e, "job_return", None)
+            if not isinstance(job_return, JobReturn):
+                job_return = JobReturn()
+                job_return.status = JobStatus.FAILED
+                job_return.return_value = e
             callbacks.on_run_end(
-                config=cfg, config_name=config_name, job_return=interrupted_ret
+                config=cfg, config_name=config_name, job_return=job_return
             )
             raise
         callbacks.on_run_end(config=cfg, config_name=config_name, job_return=ret)

--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -25,6 +25,7 @@ from hydra.core.plugins import Plugins
 from hydra.core.utils import (
     JobReturn,
     JobRuntime,
+    JobStatus,
     configure_log,
     run_job,
     setup_globals,
@@ -158,16 +159,24 @@ class Hydra:
         callbacks = Callbacks(cfg)
         callbacks.on_run_start(config=cfg, config_name=config_name)
 
-        ret = run_job(
-            hydra_context=HydraContext(
-                config_loader=self.config_loader, callbacks=callbacks
-            ),
-            task_function=task_function,
-            config=cfg,
-            job_dir_key="hydra.run.dir",
-            job_subdir_key=None,
-            configure_logging=with_log_configuration,
-        )
+        try:
+            ret = run_job(
+                hydra_context=HydraContext(
+                    config_loader=self.config_loader, callbacks=callbacks
+                ),
+                task_function=task_function,
+                config=cfg,
+                job_dir_key="hydra.run.dir",
+                job_subdir_key=None,
+                configure_logging=with_log_configuration,
+            )
+        except KeyboardInterrupt:
+            interrupted_ret = JobReturn()
+            interrupted_ret.status = JobStatus.FAILED
+            callbacks.on_run_end(
+                config=cfg, config_name=config_name, job_return=interrupted_ret
+            )
+            raise
         callbacks.on_run_end(config=cfg, config_name=config_name, job_return=ret)
 
         # access the result to trigger an exception in case the job failed.

--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -191,6 +191,12 @@ def run_job(
             except Exception as e:
                 ret.return_value = e
                 ret.status = JobStatus.FAILED
+            except KeyboardInterrupt:
+                ret.status = JobStatus.FAILED
+                ret.task_name = JobRuntime.instance().get("name")
+                _flush_loggers()
+                callbacks.on_job_end(config=config, job_return=ret)
+                raise
 
         ret.task_name = JobRuntime.instance().get("name")
 

--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -183,6 +183,7 @@ def run_job(
             _save_config(hydra_cfg, "hydra.yaml", hydra_output)
             _save_config(config.hydra.overrides.task, "overrides.yaml", hydra_output)
 
+        interrupt: Optional[KeyboardInterrupt] = None
         with env_override(hydra_cfg.hydra.job.env_set):
             callbacks.on_job_start(config=config, task_function=task_function)
             try:
@@ -191,18 +192,25 @@ def run_job(
             except Exception as e:
                 ret.return_value = e
                 ret.status = JobStatus.FAILED
-            except KeyboardInterrupt:
+            except KeyboardInterrupt as e:
+                # record the interrupt like any other failure so callbacks see
+                # it, but re-raise after finalization so it still propagates
+                # (multirun relies on it to stop the remaining jobs)
+                ret.return_value = e
                 ret.status = JobStatus.FAILED
-                ret.task_name = JobRuntime.instance().get("name")
-                _flush_loggers()
-                callbacks.on_job_end(config=config, job_return=ret)
-                raise
+                interrupt = e
 
         ret.task_name = JobRuntime.instance().get("name")
 
         _flush_loggers()
 
         callbacks.on_job_end(config=config, job_return=ret)
+
+        if interrupt is not None:
+            # expose the populated JobReturn to callers (Hydra.run) so
+            # on_run_end can receive the real job metadata after the re-raise
+            setattr(interrupt, "job_return", ret)
+            raise interrupt
 
         return ret
     finally:

--- a/news/3078.bugfix
+++ b/news/3078.bugfix
@@ -1,0 +1,1 @@
+Fix on_job_end and on_run_end callbacks not being called when a job is stopped with a KeyboardInterrupt.

--- a/tests/test_apps/app_with_callbacks/keyboard_interrupt/__init__.py
+++ b/tests/test_apps/app_with_callbacks/keyboard_interrupt/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/tests/test_apps/app_with_callbacks/keyboard_interrupt/config.yaml
+++ b/tests/test_apps/app_with_callbacks/keyboard_interrupt/config.yaml
@@ -1,0 +1,5 @@
+hydra:
+  callbacks:
+    custom_callback:
+      _target_: my_app.CustomCallback
+      callback_name: custom_callback

--- a/tests/test_apps/app_with_callbacks/keyboard_interrupt/my_app.py
+++ b/tests/test_apps/app_with_callbacks/keyboard_interrupt/my_app.py
@@ -23,13 +23,25 @@ class CustomCallback(Callback):
     def on_job_end(
         self, config: DictConfig, job_return: JobReturn, **kwargs: Any
     ) -> None:
-        log.info(f"{self.name} on_job_end")
+        log.info(f"{self.name} on_job_end {describe(job_return)}")
 
     def on_run_start(self, config: DictConfig, **kwargs: Any) -> None:
         log.info(f"{self.name} on_run_start")
 
     def on_run_end(self, config: DictConfig, **kwargs: Any) -> None:
-        log.info(f"{self.name} on_run_end")
+        job_return = kwargs.get("job_return")
+        assert isinstance(job_return, JobReturn)
+        log.info(f"{self.name} on_run_end {describe(job_return)}")
+
+
+def describe(job_return: JobReturn) -> str:
+    return (
+        f"status={job_return.status.name} "
+        f"exc={type(job_return._return_value).__name__} "
+        f"task_name={job_return.task_name} "
+        f"has_cfg={job_return.cfg is not None} "
+        f"has_working_dir={job_return.working_dir is not None}"
+    )
 
 
 @hydra.main(version_base=None, config_path=".", config_name="config")

--- a/tests/test_apps/app_with_callbacks/keyboard_interrupt/my_app.py
+++ b/tests/test_apps/app_with_callbacks/keyboard_interrupt/my_app.py
@@ -1,0 +1,41 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import logging
+from typing import Any
+
+from omegaconf import DictConfig
+
+import hydra
+from hydra.core.utils import JobReturn
+from hydra.experimental.callback import Callback
+
+log = logging.getLogger(__name__)
+
+
+class CustomCallback(Callback):
+    def __init__(self, callback_name: str) -> None:
+        self.name = callback_name
+        log.info(f"Init {self.name}")
+
+    def on_job_start(self, config: DictConfig, **kwargs: Any) -> None:
+        log.info(f"{self.name} on_job_start")
+
+    def on_job_end(
+        self, config: DictConfig, job_return: JobReturn, **kwargs: Any
+    ) -> None:
+        log.info(f"{self.name} on_job_end")
+
+    def on_run_start(self, config: DictConfig, **kwargs: Any) -> None:
+        log.info(f"{self.name} on_run_start")
+
+    def on_run_end(self, config: DictConfig, **kwargs: Any) -> None:
+        log.info(f"{self.name} on_run_end")
+
+
+@hydra.main(version_base=None, config_path=".", config_name="config")
+def my_app(cfg: DictConfig) -> None:
+    raise KeyboardInterrupt
+
+
+if __name__ == "__main__":
+    my_app()

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -2,6 +2,7 @@
 import copy
 import os
 import pickle
+import subprocess
 import sys
 from pathlib import Path
 from textwrap import dedent
@@ -130,18 +131,29 @@ def test_app_with_callbacks(
 def test_callbacks_on_keyboard_interrupt(tmpdir: Path) -> None:
     app_path = "tests/test_apps/app_with_callbacks/keyboard_interrupt/my_app.py"
     cmd = [
+        sys.executable,
         app_path,
         f'hydra.run.dir="{str(tmpdir)}"',
         "hydra.job.chdir=True",
         "hydra.hydra_logging.formatters.simple.format='[HYDRA] %(message)s'",
         "hydra.job_logging.formatters.simple.format='[JOB] %(message)s'",
     ]
-    result, _err = run_python_script(
-        cmd, print_error=False, raise_exception=False, allow_warnings=True
-    )
+    process = subprocess.run(cmd, capture_output=True, text=True)
+    result = process.stdout
 
-    assert "[JOB] custom_callback on_job_end" in result
-    assert "[JOB] custom_callback on_run_end" in result
+    expected_job_return = (
+        "status=FAILED exc=KeyboardInterrupt task_name=my_app "
+        "has_cfg=True has_working_dir=True"
+    )
+    # both callbacks fire exactly once, with a fully populated JobReturn
+    # carrying the interrupt
+    assert result.count("custom_callback on_job_end") == 1
+    assert result.count("custom_callback on_run_end") == 1
+    assert f"[JOB] custom_callback on_job_end {expected_job_return}" in result
+    assert f"[JOB] custom_callback on_run_end {expected_job_return}" in result
+    # the interrupt must still propagate out of the application
+    assert process.returncode != 0
+    assert "KeyboardInterrupt" in process.stderr
 
 
 @mark.parametrize("multirun", [True, False])

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -127,6 +127,23 @@ def test_app_with_callbacks(
     )
 
 
+def test_callbacks_on_keyboard_interrupt(tmpdir: Path) -> None:
+    app_path = "tests/test_apps/app_with_callbacks/keyboard_interrupt/my_app.py"
+    cmd = [
+        app_path,
+        f'hydra.run.dir="{str(tmpdir)}"',
+        "hydra.job.chdir=True",
+        "hydra.hydra_logging.formatters.simple.format='[HYDRA] %(message)s'",
+        "hydra.job_logging.formatters.simple.format='[JOB] %(message)s'",
+    ]
+    result, _err = run_python_script(
+        cmd, print_error=False, raise_exception=False, allow_warnings=True
+    )
+
+    assert "[JOB] custom_callback on_job_end" in result
+    assert "[JOB] custom_callback on_run_end" in result
+
+
 @mark.parametrize("multirun", [True, False])
 def test_experimental_save_job_info_callback(tmpdir: Path, multirun: bool) -> None:
     app_path = "tests/test_apps/app_with_pickle_job_info_callback/my_app.py"


### PR DESCRIPTION
## Summary

run_job() in hydra/core/utils.py only catches Exception around the task function call. KeyboardInterrupt is a BaseException, not an Exception, so it skips right past that except block and callbacks.on_job_end never runs. Hydra.run() then never reaches callbacks.on_run_end either, because run_job propagates the interrupt before returning.

## Root cause

In hydra/core/utils.py, run_job has:

```python
try:
    ret.return_value = task_function(task_cfg)
    ret.status = JobStatus.COMPLETED
except Exception as e:
    ret.return_value = e
    ret.status = JobStatus.FAILED
```

A KeyboardInterrupt during task_function isn't caught here, so it jumps straight out of run_job, past the on_job_end call at the bottom of the function. Same thing happens one level up in Hydra.run(), where run_job's return is needed before callbacks.on_run_end can fire.

## Fix

Added a separate except KeyboardInterrupt branch in run_job that sets status, flushes loggers, calls on_job_end, and then re-raises. I re-raise instead of swallowing it because BasicLauncher's multirun loop relies on the interrupt propagating immediately to stop remaining jobs in the batch. If run_job just recorded it and returned normally like it does for Exception, a Ctrl+C during job 2 of 5 would let jobs 3-5 keep running.

Hydra.run() got the same treatment: wraps the run_job call in try/except KeyboardInterrupt, fires on_run_end with a JobReturn marked FAILED, then re-raises.

## Testing

Added a test app under tests/test_apps/app_with_callbacks/keyboard_interrupt/ whose task function just raises KeyboardInterrupt, plus a test in test_callbacks.py that runs it and checks the on_job_end/on_run_end log lines show up. Confirmed the test fails without the fix (reverted the two source files locally, test fails with the callback lines missing) and passes with it.

Ran the full test suite locally: 2533 passed, 219 skipped, 1 xfailed. Also ran flake8 and black on the changed files, both clean.

Fixes #3078