### PR TITLE
Harden instantiate target blocklist

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -23,9 +23,10 @@ jobs:
     - uses: actions/setup-node@v6
       with:
         node-version: "24"
-    - name: Deploy website
+    - name: Build or deploy website
       env:
-        WEBSITE_GITHUB_TOKEN: ${{ secrets.WEBSITE_GITHUB_TOKEN }}
+        WEBSITE_GITHUB_TOKEN: ${{ github.event_name != 'pull_request' && secrets.WEBSITE_GITHUB_TOKEN || '' }}
+        IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
       run: |
         SUBDIR=website
         git fetch
@@ -38,10 +39,14 @@ jobs:
           cd $SUBDIR
           corepack enable
           corepack pnpm install --frozen-lockfile
-          git config --global user.email omry@users.noreply.github.com
-          git config --global user.name omry
-          echo "machine github.com login docusaurus-bot password $WEBSITE_GITHUB_TOKEN" > ~/.netrc
-          GIT_USER=docusaurus-bot corepack pnpm run deploy
+          if [[ "$IS_PULL_REQUEST" == "true" ]]; then
+            corepack pnpm run build
+          else
+            git config --global user.email omry@users.noreply.github.com
+            git config --global user.name omry
+            echo "machine github.com login docusaurus-bot password $WEBSITE_GITHUB_TOKEN" > ~/.netrc
+            GIT_USER=docusaurus-bot corepack pnpm run deploy
+          fi
         else
           echo "No changes detected in directory $SUBDIR between origin/main and this diff"
         fi

--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -18,11 +18,21 @@ DEFAULT_BLOCKLISTED_MODULES = {
     "builtins.exec",
     "builtins.eval",
     "builtins.__import__",
+    "builtins.compile",
     "builtins.exit",
     "builtins.quit",
-    "os.environ.OMP_NUM_THREADS",
+    "ctypes.CDLL",
+    "ctypes.OleDLL",
+    "ctypes.PyDLL",
+    "ctypes.WinDLL",
+    "ctypes.cdll.LoadLibrary",
+    "ctypes.oledll.LoadLibrary",
+    "ctypes.pydll.LoadLibrary",
+    "ctypes.windll.LoadLibrary",
+    "importlib.import_module",
     "os.kill",
     "os.system",
+    "os.popen",
     "os.putenv",
     "os.remove",
     "os.removedirs",
@@ -34,6 +44,9 @@ DEFAULT_BLOCKLISTED_MODULES = {
     "os.killpg",
     "os.rename",
     "os.renames",
+    "os.startfile",
+    "os.posix_spawn",
+    "os.posix_spawnp",
     "os.truncate",
     "os.replace",
     "os.unlink",
@@ -48,10 +61,19 @@ DEFAULT_BLOCKLISTED_MODULES = {
     "os.lchown",
     "os.getcwd",
     "os.chdir",
+    "pty.spawn",
+    "runpy.run_module",
+    "runpy.run_path",
     "shutil.rmtree",
     "shutil.move",
     "shutil.chown",
     "subprocess.Popen",
+    "subprocess.run",
+    "subprocess.call",
+    "subprocess.check_call",
+    "subprocess.check_output",
+    "subprocess.getoutput",
+    "subprocess.getstatusoutput",
     "builtins.help",
     "sys.modules.ipdb",
     "sys.modules.joblib",
@@ -59,6 +81,19 @@ DEFAULT_BLOCKLISTED_MODULES = {
     "sys.modules.psutil",
     "sys.modules.tkinter",
 }
+
+DEFAULT_BLOCKLISTED_MODULE_PREFIXES = (
+    "os.exec",
+    "os.spawn",
+)
+
+
+def _get_os_alias_target(target: str) -> str:
+    for module in ("posix", "nt"):
+        module_prefix = f"{module}."
+        if target.startswith(module_prefix):
+            return f"os.{target[len(module_prefix):]}"
+    return target
 
 
 class _Keys(str, Enum):
@@ -77,6 +112,14 @@ def _is_target(x: Any) -> bool:
     if OmegaConf.is_dict(x):
         return "_target_" in x
     return False
+
+
+def _is_blocklisted_target(target: str) -> bool:
+    canonical_target = _get_os_alias_target(target)
+    return (
+        canonical_target in DEFAULT_BLOCKLISTED_MODULES
+        or canonical_target.startswith(DEFAULT_BLOCKLISTED_MODULE_PREFIXES)
+    )
 
 
 def _extract_pos_args(input_args: Any, kwargs: Any) -> Tuple[Any, Any]:
@@ -177,9 +220,14 @@ def _resolve_target(
 ) -> Union[type, Callable[..., Any]]:
     """Resolve target string, type or callable into type or callable."""
     if isinstance(target, str):
-        if target in DEFAULT_BLOCKLISTED_MODULES:
+        if _is_blocklisted_target(target):
             allowlist = os.environ.get("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "")
-            if target not in allowlist.split(":"):
+            allowlist_entries = allowlist.split(":")
+            canonical_target = _get_os_alias_target(target)
+            if (
+                target not in allowlist_entries
+                and canonical_target not in allowlist_entries
+            ):
                 msg = dedent(
                     f"""\
                     Target '{target}' is blocklisted and cannot be instantiated from config

--- a/news/3259.bugfix
+++ b/news/3259.bugfix
@@ -1,0 +1,1 @@
+Harden instantiate target blocklist coverage for security-sensitive callables.

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import copy
+import os
 import pickle
 import re
 from dataclasses import dataclass
@@ -19,6 +20,7 @@ from pytest import fixture, mark, param, raises, warns
 
 import hydra
 from hydra import version
+from hydra._internal.instantiate._instantiate2 import _resolve_target
 from hydra.errors import InstantiationException
 from hydra.test_utils.test_utils import assert_multiline_regex_search
 from hydra.types import ConvertMode, TargetConf
@@ -1603,14 +1605,38 @@ def test_cannot_locate_target(instantiate_func: Any) -> None:
     )
 
 
-def test_blocklisted_target_fails(instantiate_func: Any) -> None:
-    cfg = OmegaConf.create({"foo": {"_target_": "os.getcwd"}})
+@mark.parametrize(
+    "target",
+    [
+        "builtins.compile",
+        "ctypes.CDLL",
+        "ctypes.WinDLL",
+        "ctypes.windll.LoadLibrary",
+        "importlib.import_module",
+        "os.execl",
+        "os.getcwd",
+        "os.popen",
+        "os.posix_spawn",
+        "posix.kill",
+        "posix.remove",
+        "posix.system",
+        "nt.startfile",
+        "nt.system",
+        "pty.spawn",
+        "runpy.run_path",
+        "subprocess.Popen",
+        "subprocess.check_output",
+        "subprocess.run",
+    ],
+)
+def test_blocklisted_target_fails(instantiate_func: Any, target: str) -> None:
+    cfg = OmegaConf.create({"foo": {"_target_": target}})
     with raises(
         InstantiationException,
-        match=re.escape(dedent("""\
-                Target 'os.getcwd' is blocklisted and cannot be instantiated from config
+        match=re.escape(dedent(f"""\
+                Target '{target}' is blocklisted and cannot be instantiated from config
                 to prevent security vulnerabilities, set env var
-                HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE=os.getcwd:<other allowlisted targets> to bypass
+                HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE={target}:<other allowlisted targets> to bypass
                 full_key: foo""")),
     ) as exc_info:
         instantiate_func(cfg)
@@ -1633,6 +1659,17 @@ def test_allowlist_works(instantiate_func: Any, monkeypatch: Any) -> None:
     res = instantiate_func(cfg)
     assert res.foo is None
     assert res.bar == 3
+
+
+def test_allowlist_works_for_prefix_blocked_target(monkeypatch: Any) -> None:
+    monkeypatch.setenv("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "os.execl")
+    assert _resolve_target("os.execl", "") is os.execl
+
+
+def test_allowlist_works_for_canonical_os_alias(monkeypatch: Any) -> None:
+    alias_target = "nt.system" if os.name == "nt" else "posix.system"
+    monkeypatch.setenv("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "os.system")
+    assert _resolve_target(alias_target, "") is os.system
 
 
 @mark.parametrize(


### PR DESCRIPTION

Expand the instantiate target blocklist to cover additional command execution, code loading, process-control, and destructive filesystem callables. Canonicalize posix.* and nt.* targets to their os.* equivalents before checking the blocklist so platform module aliases are covered consistently.

Add regression coverage for exact targets, platform aliases, prefix-blocked targets, and the allowlist override path.

Fixes #3259

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookresearch/hydra/pull/3263).
* #3269
* #3264
* __->__ #3263
* #3267