### PR TITLE
Add instantiate target whitelist policy

### DIFF
--- a/examples/experimental/rerun/my_app.py
+++ b/examples/experimental/rerun/my_app.py
@@ -6,6 +6,7 @@ from omegaconf import DictConfig
 
 import hydra
 from hydra.core.hydra_config import HydraConfig
+from hydra.utils import target_whitelist
 
 log = logging.getLogger(__name__)
 
@@ -17,4 +18,5 @@ def my_app(cfg: DictConfig) -> None:
 
 
 if __name__ == "__main__":
-    my_app()
+    with target_whitelist("hydra.experimental.callbacks.*"):
+        my_app()

--- a/examples/instantiate/docs_example/my_app.py
+++ b/examples/instantiate/docs_example/my_app.py
@@ -3,7 +3,7 @@
 from omegaconf import DictConfig
 
 import hydra
-from hydra.utils import instantiate
+from hydra.utils import instantiate, target_whitelist
 
 
 class Optimizer:
@@ -41,42 +41,43 @@ class Trainer:
 
 @hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
-    optimizer = instantiate(cfg.trainer.optimizer)
-    print(optimizer)
-    # Optimizer(algo=SGD,lr=0.01)
+    with target_whitelist("my_app.*"):
+        optimizer = instantiate(cfg.trainer.optimizer)
+        print(optimizer)
+        # Optimizer(algo=SGD,lr=0.01)
 
-    # override parameters on the call-site
-    optimizer = instantiate(cfg.trainer.optimizer, lr=0.2)
-    print(optimizer)
-    # Optimizer(algo=SGD,lr=0.2)
+        # override parameters on the call-site
+        optimizer = instantiate(cfg.trainer.optimizer, lr=0.2)
+        print(optimizer)
+        # Optimizer(algo=SGD,lr=0.2)
 
-    # recursive instantiation
-    trainer = instantiate(cfg.trainer)
-    print(trainer)
-    # Trainer(
-    #   optimizer=Optimizer(algo=SGD,lr=0.01),
-    #   dataset=Dataset(name=Imagenet, path=/datasets/imagenet)
-    # )
+        # recursive instantiation
+        trainer = instantiate(cfg.trainer)
+        print(trainer)
+        # Trainer(
+        #   optimizer=Optimizer(algo=SGD,lr=0.01),
+        #   dataset=Dataset(name=Imagenet, path=/datasets/imagenet)
+        # )
 
-    # override nested parameters from the call-site
-    trainer = instantiate(
-        cfg.trainer,
-        optimizer={"lr": 0.3},
-        dataset={"name": "cifar10", "path": "/datasets/cifar10"},
-    )
-    print(trainer)
-    # Trainer(
-    #   optimizer=Optimizer(algo=SGD,lr=0.3),
-    #   dataset=Dataset(name=cifar10, path=/datasets/cifar10)
-    # )
+        # override nested parameters from the call-site
+        trainer = instantiate(
+            cfg.trainer,
+            optimizer={"lr": 0.3},
+            dataset={"name": "cifar10", "path": "/datasets/cifar10"},
+        )
+        print(trainer)
+        # Trainer(
+        #   optimizer=Optimizer(algo=SGD,lr=0.3),
+        #   dataset=Dataset(name=cifar10, path=/datasets/cifar10)
+        # )
 
-    # non recursive instantiation
-    trainer = instantiate(cfg.trainer, _recursive_=False)
-    print(trainer)
-    # Trainer(
-    #     optimizer={'_target_': 'my_app.Optimizer', 'algo': 'SGD', 'lr': 0.01},
-    #     dataset={'_target_': 'my_app.Dataset', 'name': 'Imagenet', 'path': '/datasets/imagenet'}
-    # )
+        # non recursive instantiation
+        trainer = instantiate(cfg.trainer, _recursive_=False)
+        print(trainer)
+        # Trainer(
+        #     optimizer={'_target_': 'my_app.Optimizer', 'algo': 'SGD', 'lr': 0.01},
+        #     dataset={'_target_': 'my_app.Dataset', 'name': 'Imagenet', 'path': '/datasets/imagenet'}
+        # )
 
 
 if __name__ == "__main__":

--- a/examples/instantiate/object/my_app.py
+++ b/examples/instantiate/object/my_app.py
@@ -2,7 +2,7 @@
 from omegaconf import DictConfig
 
 import hydra
-from hydra.utils import instantiate
+from hydra.utils import instantiate, target_whitelist
 
 
 class DBConnection:
@@ -32,7 +32,8 @@ class PostgreSQLConnection(DBConnection):
 
 @hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
-    connection = instantiate(cfg.db)
+    with target_whitelist("my_app.*"):
+        connection = instantiate(cfg.db)
     connection.connect()
 
 

--- a/examples/instantiate/object_recursive/my_app.py
+++ b/examples/instantiate/object_recursive/my_app.py
@@ -4,7 +4,7 @@ from typing import List
 from omegaconf import DictConfig
 
 import hydra
-from hydra.utils import instantiate
+from hydra.utils import instantiate, target_whitelist
 
 
 class Driver:
@@ -30,7 +30,8 @@ class Car:
 
 @hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
-    car: Car = instantiate(cfg.car)
+    with target_whitelist("my_app.*"):
+        car: Car = instantiate(cfg.car)
     car.drive()
 
 

--- a/examples/instantiate/partial/my_app.py
+++ b/examples/instantiate/partial/my_app.py
@@ -4,7 +4,7 @@ from typing import Any
 from omegaconf import DictConfig
 
 import hydra
-from hydra.utils import instantiate
+from hydra.utils import instantiate, target_whitelist
 
 
 class Optimizer:
@@ -30,7 +30,8 @@ class Model:
 
 @hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
-    model = instantiate(cfg.model)
+    with target_whitelist("my_app.*"):
+        model = instantiate(cfg.model)
     print(model)
 
 

--- a/examples/instantiate/schema/my_app.py
+++ b/examples/instantiate/schema/my_app.py
@@ -6,7 +6,7 @@ from omegaconf import MISSING
 
 import hydra
 from hydra.core.config_store import ConfigStore
-from hydra.utils import instantiate
+from hydra.utils import instantiate, target_whitelist
 
 
 class DBConnection:
@@ -71,7 +71,8 @@ cs.store(group="db", name="postgresql", node=PostGreSQLConfig)
 
 @hydra.main(version_base=None, config_name="config")
 def my_app(cfg: Config) -> None:
-    connection = instantiate(cfg.db)
+    with target_whitelist("my_app.*"):
+        connection = instantiate(cfg.db)
     connection.connect()
 
 

--- a/examples/instantiate/schema_recursive/my_app.py
+++ b/examples/instantiate/schema_recursive/my_app.py
@@ -6,7 +6,7 @@ from omegaconf import MISSING
 
 import hydra
 from hydra.core.config_store import ConfigStore
-from hydra.utils import instantiate
+from hydra.utils import instantiate, target_whitelist
 
 
 class Tree:
@@ -48,7 +48,8 @@ def pretty_print(tree: Tree, name: str = "root", depth: int = 0) -> None:
 
 @hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: Config) -> None:
-    tree: Tree = instantiate(cfg.tree)
+    with target_whitelist("my_app.*"):
+        tree: Tree = instantiate(cfg.tree)
     pretty_print(tree)
 
 

--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -2,14 +2,17 @@
 
 import copy
 import functools
+import inspect
 import os
+from contextvars import ContextVar
 from enum import Enum
 from textwrap import dedent
-from typing import Any, Callable, Dict, List, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Sequence, Tuple, Union, cast
 
 from omegaconf import AnyNode, OmegaConf, SCMode
 from omegaconf._utils import is_structured_config
 
+from hydra._internal.deprecation_warning import deprecation_warning
 from hydra._internal.utils import _locate
 from hydra.errors import InstantiationException
 from hydra.types import ConvertMode, TargetConf
@@ -88,6 +91,18 @@ DEFAULT_BLOCKLISTED_MODULE_PREFIXES = (
 )
 
 
+class _UnsafeAllowAllTargets:
+    def __repr__(self) -> str:
+        return "UNSAFE_ALLOW_ALL_TARGETS"
+
+
+UNSAFE_ALLOW_ALL_TARGETS = _UnsafeAllowAllTargets()
+NormalizedTargetWhitelist = Union[Tuple[str, ...], _UnsafeAllowAllTargets, None]
+_TARGET_WHITELIST_CONTEXT: ContextVar[NormalizedTargetWhitelist] = ContextVar(
+    "hydra_instantiate_target_whitelist", default=None
+)
+
+
 def _get_os_alias_target(target: str) -> str:
     for module in ("posix", "nt"):
         module_prefix = f"{module}."
@@ -104,6 +119,7 @@ class _Keys(str, Enum):
     RECURSIVE = "_recursive_"
     ARGS = "_args_"
     PARTIAL = "_partial_"
+    TARGET_WHITELIST = "_target_whitelist_"
 
 
 def _is_target(x: Any) -> bool:
@@ -119,6 +135,159 @@ def _is_blocklisted_target(target: str) -> bool:
     return (
         canonical_target in DEFAULT_BLOCKLISTED_MODULES
         or canonical_target.startswith(DEFAULT_BLOCKLISTED_MODULE_PREFIXES)
+    )
+
+
+def _validate_target_whitelist_pattern(pattern: Any) -> str:
+    if not isinstance(pattern, str):
+        raise InstantiationException(
+            f"Invalid _target_whitelist_ entry '{pattern}': expected a string"
+        )
+    if pattern == "":
+        raise InstantiationException("Invalid _target_whitelist_ entry: empty string")
+    if "*" not in pattern:
+        return pattern
+    if pattern == "*" or not pattern.endswith(".*") or pattern.count("*") > 1:
+        raise InstantiationException(dedent(f"""\
+                Invalid _target_whitelist_ entry '{pattern}'. Only trailing '.*'
+                package wildcards are supported. The wildcard '*' is not allowed
+                as a target whitelist pattern. To preserve legacy all-target
+                behavior, pass UNSAFE_ALLOW_ALL_TARGETS explicitly."""))
+    prefix = pattern[:-2]
+    if prefix == "" or prefix.endswith("."):
+        raise InstantiationException(
+            f"Invalid _target_whitelist_ entry '{pattern}': missing package prefix"
+        )
+    return pattern
+
+
+def _normalize_target_whitelist(
+    target_whitelist: Any,
+) -> NormalizedTargetWhitelist:
+    if target_whitelist is None:
+        return None
+    if target_whitelist is UNSAFE_ALLOW_ALL_TARGETS:
+        return UNSAFE_ALLOW_ALL_TARGETS
+    if isinstance(target_whitelist, _TargetWhitelistPolicy):
+        return target_whitelist.whitelist
+    if isinstance(target_whitelist, str):
+        return (_validate_target_whitelist_pattern(target_whitelist),)
+    try:
+        return tuple(
+            _validate_target_whitelist_pattern(pattern) for pattern in target_whitelist
+        )
+    except TypeError as e:
+        raise InstantiationException(
+            "Invalid _target_whitelist_: expected a string, a sequence of strings, "
+            "or UNSAFE_ALLOW_ALL_TARGETS"
+        ) from e
+
+
+def _combine_target_whitelists(
+    base: NormalizedTargetWhitelist, extra: NormalizedTargetWhitelist
+) -> NormalizedTargetWhitelist:
+    if base is UNSAFE_ALLOW_ALL_TARGETS or extra is UNSAFE_ALLOW_ALL_TARGETS:
+        return UNSAFE_ALLOW_ALL_TARGETS
+    if base is None:
+        return extra
+    if extra is None:
+        return base
+    return tuple(
+        dict.fromkeys(cast(Tuple[str, ...], base) + cast(Tuple[str, ...], extra))
+    )
+
+
+class _TargetWhitelistPolicy:
+    def __init__(
+        self, whitelist: NormalizedTargetWhitelist, reset: bool = False
+    ) -> None:
+        self.whitelist = whitelist
+        self.reset = reset
+        self._tokens: List[Any] = []
+
+    def resolve(
+        self, inherited: NormalizedTargetWhitelist
+    ) -> NormalizedTargetWhitelist:
+        if self.reset:
+            return self.whitelist
+        return _combine_target_whitelists(inherited, self.whitelist)
+
+    def __enter__(self) -> "_TargetWhitelistPolicy":
+        self._tokens.append(
+            _TARGET_WHITELIST_CONTEXT.set(self.resolve(_TARGET_WHITELIST_CONTEXT.get()))
+        )
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        _TARGET_WHITELIST_CONTEXT.reset(self._tokens.pop())
+
+
+TargetWhitelist = Union[
+    str, Sequence[str], _UnsafeAllowAllTargets, _TargetWhitelistPolicy, None
+]
+
+
+def target_whitelist(target_whitelist: TargetWhitelist, reset: bool = False) -> Any:
+    """
+    Create a target whitelist object for hydra.utils.instantiate().
+
+    The returned object can be used as a context manager to apply a whitelist to
+    instantiate() calls in the current context, or passed to instantiate() as
+    _target_whitelist_.
+
+    :param target_whitelist: A target string, list of target strings, or
+        UNSAFE_ALLOW_ALL_TARGETS. A trailing .* allows targets under a package
+        prefix.
+    :param reset: If True, ignore any outer target_whitelist() context.
+        If False, add these targets to the current context.
+    """
+    return _TargetWhitelistPolicy(
+        whitelist=_normalize_target_whitelist(target_whitelist),
+        reset=reset,
+    )
+
+
+def _resolve_target_whitelist(
+    target_whitelist: TargetWhitelist,
+) -> NormalizedTargetWhitelist:
+    inherited = _TARGET_WHITELIST_CONTEXT.get()
+    if isinstance(target_whitelist, _TargetWhitelistPolicy):
+        return target_whitelist.resolve(inherited)
+    return _combine_target_whitelists(
+        inherited, _normalize_target_whitelist(target_whitelist)
+    )
+
+
+def _is_target_whitelisted(target: str, target_whitelist: Tuple[str, ...]) -> bool:
+    for pattern in target_whitelist:
+        if pattern.endswith(".*"):
+            prefix = pattern[:-2]
+            if target.startswith(f"{prefix}."):
+                return True
+        elif target == pattern:
+            return True
+    return False
+
+
+def _warn_legacy_target_whitelist(target: str) -> None:
+    stacklevel = 1
+    frame = inspect.currentframe()
+    while frame is not None:
+        if frame.f_code.co_filename != __file__:
+            break
+        stacklevel += 1
+        frame = frame.f_back
+    deprecation_warning(
+        dedent(
+            f"""\
+            hydra.utils.instantiate() resolved _target_='{target}' with no
+            _target_whitelist_. This preserves legacy behavior but is deprecated
+            because config-controlled targets can execute arbitrary code. Pass a
+            callsite target whitelist, or pass UNSAFE_ALLOW_ALL_TARGETS to
+            explicitly keep legacy behavior.
+            See https://hydra.cc/docs/upgrades/1.3_to_1.4/instantiate_target_whitelist/"""
+        ),
+        stacklevel=stacklevel,
     )
 
 
@@ -188,10 +357,19 @@ def _call_target(
 
 
 def _convert_target_to_string(t: Any) -> Any:
-    if callable(t):
+    if callable(t) and hasattr(t, "__qualname__"):
         return f"{t.__module__}.{t.__qualname__}"
     else:
         return t
+
+
+def _get_target_name_for_check(target: Union[str, type, Callable[..., Any]]) -> str:
+    if isinstance(target, str):
+        return target
+    if hasattr(target, "__qualname__"):
+        return f"{target.__module__}.{target.__qualname__}"
+    target_type = type(target)
+    return f"{target_type.__module__}.{target_type.__qualname__}"
 
 
 def _prepare_input_dict_or_list(d: Union[Dict[Any, Any], List[Any]]) -> Any:
@@ -216,35 +394,52 @@ def _prepare_input_dict_or_list(d: Union[Dict[Any, Any], List[Any]]) -> Any:
 
 
 def _resolve_target(
-    target: Union[str, type, Callable[..., Any]], full_key: str
+    target: Union[str, type, Callable[..., Any]],
+    full_key: str,
+    target_whitelist: NormalizedTargetWhitelist = None,
 ) -> Union[type, Callable[..., Any]]:
     """Resolve target string, type or callable into type or callable."""
-    if isinstance(target, str):
-        if _is_blocklisted_target(target):
-            allowlist = os.environ.get("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "")
-            allowlist_entries = allowlist.split(":")
-            canonical_target = _get_os_alias_target(target)
-            if (
-                target not in allowlist_entries
-                and canonical_target not in allowlist_entries
-            ):
-                msg = dedent(
-                    f"""\
-                    Target '{target}' is blocklisted and cannot be instantiated from config
-                    to prevent security vulnerabilities, set env var
-                    HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE={target}:<other allowlisted targets> to bypass"""
-                )
-                if full_key:
-                    msg += f"\nfull_key: {full_key}"
-                raise InstantiationException(msg)
-
-        try:
-            target = _locate(target)
-        except Exception as e:
-            msg = f"Error locating target '{target}', set env var HYDRA_FULL_ERROR=1 to see chained exception."
+    if isinstance(target, str) or callable(target):
+        target_name = _get_target_name_for_check(target)
+        if target_whitelist is UNSAFE_ALLOW_ALL_TARGETS:
+            pass
+        elif target_whitelist is None:
+            if _is_blocklisted_target(target_name):
+                allowlist = os.environ.get("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "")
+                allowlist_entries = allowlist.split(":")
+                canonical_target = _get_os_alias_target(target_name)
+                if (
+                    target_name not in allowlist_entries
+                    and canonical_target not in allowlist_entries
+                ):
+                    msg = dedent(
+                        f"""\
+                        Target '{target_name}' is blocklisted and cannot be instantiated from config
+                        to prevent security vulnerabilities, set env var
+                        HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE={target_name}:<other allowlisted targets> to bypass"""
+                    )
+                    if full_key:
+                        msg += f"\nfull_key: {full_key}"
+                    raise InstantiationException(msg)
+            _warn_legacy_target_whitelist(target_name)
+        elif not _is_target_whitelisted(
+            target_name, cast(Tuple[str, ...], target_whitelist)
+        ):
+            msg = dedent(f"""\
+                Target '{target_name}' is not in the instantiate target whitelist.
+                Pass _target_whitelist_ from trusted code to allow expected targets.""")
             if full_key:
                 msg += f"\nfull_key: {full_key}"
-            raise InstantiationException(msg) from e
+            raise InstantiationException(msg)
+
+        if isinstance(target, str):
+            try:
+                target = _locate(target)
+            except Exception as e:
+                msg = f"Error locating target '{target}', set env var HYDRA_FULL_ERROR=1 to see chained exception."
+                if full_key:
+                    msg += f"\nfull_key: {full_key}"
+                raise InstantiationException(msg) from e
     if not callable(target):
         msg = f"Expected a callable target, got '{target}' of type '{type(target).__name__}'"
         if full_key:
@@ -283,6 +478,7 @@ def instantiate(
     config: Any,
     *args: Any,
     _skip_instantiate_full_deepcopy_: bool = False,
+    _target_whitelist_: TargetWhitelist = None,
     **kwargs: Any,
 ) -> Any:
     """
@@ -291,7 +487,7 @@ def instantiate(
                    _target_ : target class or callable name (str)
                               IMPORTANT: This may pose a security risk since the config
                               can be used to execute arbitrary code. Make sure to use this only
-                              with trusted configs or configure the allowlist/blocklist.
+                              with trusted configs or configure the target whitelist.
                    And may contain:
                    _args_: List-like of positional arguments to pass to the target
                    _recursive_: Construct nested objects as well (bool).
@@ -314,6 +510,10 @@ def instantiate(
                     of full config before resolving omegaconf interpolations, which may
                     potentially modify the config's parent/sibling configs in place.
                     False by default.
+    :param _target_whitelist_: A target string, list of target strings,
+                    target_whitelist() policy, or UNSAFE_ALLOW_ALL_TARGETS. A trailing
+                    .* allows targets under a package prefix. Passing None preserves
+                    legacy behavior unless a target_whitelist() context is active.
     :param args: Optional positional parameters pass-through
     :param kwargs: Optional named parameters to override
                    parameters in the config object. Parameters not present
@@ -327,6 +527,8 @@ def instantiate(
     # Return None if config is None
     if config is None:
         return None
+
+    target_whitelist = _resolve_target_whitelist(_target_whitelist_)
 
     # TargetConf edge case
     if isinstance(config, TargetConf) and config._target_ == "???":
@@ -374,7 +576,12 @@ def instantiate(
         _partial_ = config.pop(_Keys.PARTIAL, False)
 
         return instantiate_node(
-            config, *args, recursive=_recursive_, convert=_convert_, partial=_partial_
+            config,
+            *args,
+            recursive=_recursive_,
+            convert=_convert_,
+            partial=_partial_,
+            target_whitelist=target_whitelist,
         )
     elif OmegaConf.is_list(config):
         # Finalize config (convert targets to strings, merge with kwargs)
@@ -401,7 +608,12 @@ def instantiate(
             )
 
         return instantiate_node(
-            config, *args, recursive=_recursive_, convert=_convert_, partial=_partial_
+            config,
+            *args,
+            recursive=_recursive_,
+            convert=_convert_,
+            partial=_partial_,
+            target_whitelist=target_whitelist,
         )
     else:
         raise InstantiationException(dedent(f"""\
@@ -437,6 +649,7 @@ def instantiate_node(
     convert: Union[str, ConvertMode] = ConvertMode.NONE,
     recursive: bool = True,
     partial: bool = False,
+    target_whitelist: NormalizedTargetWhitelist = None,
 ) -> Any:
     # Return None if config is None
     if node is None or (OmegaConf.is_config(node) and node._is_none()):
@@ -470,7 +683,12 @@ def instantiate_node(
     # If OmegaConf list, create new list of instances if recursive
     if OmegaConf.is_list(node):
         items = [
-            instantiate_node(item, convert=convert, recursive=recursive)
+            instantiate_node(
+                item,
+                convert=convert,
+                recursive=recursive,
+                target_whitelist=target_whitelist,
+            )
             for item in node._iter_ex(resolve=True)
         ]
 
@@ -486,9 +704,20 @@ def instantiate_node(
             return lst
 
     elif OmegaConf.is_dict(node):
+        if _Keys.TARGET_WHITELIST in node:
+            msg = (
+                "_target_whitelist_ must be passed to instantiate() from trusted "
+                "code, not configured inside the config being instantiated."
+            )
+            if full_key:
+                msg += f"\nfull_key: {full_key}"
+            raise InstantiationException(msg)
+
         exclude_keys = set({"_target_", "_convert_", "_recursive_", "_partial_"})
         if _is_target(node):
-            _target_ = _resolve_target(node.get(_Keys.TARGET), full_key)
+            _target_ = _resolve_target(
+                node.get(_Keys.TARGET), full_key, target_whitelist
+            )
             kwargs = {}
             is_partial = node.get("_partial_", False) or partial
             for key in node.keys():
@@ -498,7 +727,10 @@ def instantiate_node(
                     value = node[key]
                     if recursive:
                         value = instantiate_node(
-                            value, convert=convert, recursive=recursive
+                            value,
+                            convert=convert,
+                            recursive=recursive,
+                            target_whitelist=target_whitelist,
                         )
                     kwargs[key] = _convert_node(value, convert)
 
@@ -514,7 +746,10 @@ def instantiate_node(
                 for key, value in node.items():
                     # list items inherits recursive flag from the containing dict.
                     dict_items[key] = instantiate_node(
-                        value, convert=convert, recursive=recursive
+                        value,
+                        convert=convert,
+                        recursive=recursive,
+                        target_whitelist=target_whitelist,
                     )
                 return dict_items
             else:
@@ -522,7 +757,12 @@ def instantiate_node(
                 cfg = OmegaConf.create({}, flags={"allow_objects": True})
                 for key, value in node.items():
                     cfg[key] = _wrap_structured_config_as_object(
-                        instantiate_node(value, convert=convert, recursive=recursive)
+                        instantiate_node(
+                            value,
+                            convert=convert,
+                            recursive=recursive,
+                            target_whitelist=target_whitelist,
+                        )
                     )
                 cfg._set_parent(node)
                 cfg._metadata.object_type = node._metadata.object_type

--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -109,7 +109,9 @@ class Plugins(metaclass=Singleton):
             if classname not in self.class_name_to_class.keys():
                 raise RuntimeError(f"Unknown plugin class : '{classname}'")
             clazz = self.class_name_to_class[classname]
-            plugin = instantiate(config=config, _target_=clazz)
+            plugin = instantiate(
+                config=config, _target_=clazz, _target_whitelist_=classname
+            )
             assert isinstance(plugin, Plugin)
 
         except ImportError as e:

--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -16,6 +16,10 @@ log = logging.getLogger(__name__)
 # Instantiation related symbols
 instantiate = hydra._internal.instantiate._instantiate2.instantiate
 call = instantiate
+UNSAFE_ALLOW_ALL_TARGETS = (
+    hydra._internal.instantiate._instantiate2.UNSAFE_ALLOW_ALL_TARGETS
+)
+target_whitelist = hydra._internal.instantiate._instantiate2.target_whitelist
 ConvertMode = hydra.types.ConvertMode
 
 

--- a/news/3259.api_change
+++ b/news/3259.api_change
@@ -1,0 +1,1 @@
+Deprecate instantiate target resolution without a callsite target whitelist.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,8 @@
 [pytest]
+testpaths =
+  build_helpers
+  tests
+
 norecursedirs = 
   .nox                  # generated virtualenvs
   build                 # generated build directory

--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, NoReturn, Optional, Tuple
 from omegaconf import MISSING, DictConfig, ListConfig
 
 from hydra.types import TargetConf
-from hydra.utils import instantiate
+from hydra.utils import UNSAFE_ALLOW_ALL_TARGETS, instantiate
 from tests.instantiate.module_shadowed_by_function import a_function
 
 module_shadowed_by_function = a_function
@@ -95,6 +95,11 @@ def module_function(x: int) -> int:
 
 def module_function2() -> str:
     return "fn return"
+
+
+class CallableClass:
+    def __call__(self) -> str:
+        return "callable class"
 
 
 class ExceptionTakingNoArgument(Exception):
@@ -426,7 +431,9 @@ class TargetWithInstantiateInInit:
         if user:
             self.user = user
         else:
-            self.user = instantiate(user_config)
+            self.user = instantiate(
+                user_config, _target_whitelist_=UNSAFE_ALLOW_ALL_TARGETS
+            )
 
     def __eq__(self, other: Any) -> bool:
         return self.user.__eq__(other.user)

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import copy
+import inspect
 import os
 import pickle
 import re
@@ -18,12 +19,13 @@ from omegaconf import (
 )
 from pytest import fixture, mark, param, raises, warns
 
-import hydra
 from hydra import version
+from hydra._internal.instantiate import _instantiate2
 from hydra._internal.instantiate._instantiate2 import _resolve_target
 from hydra.errors import InstantiationException
 from hydra.test_utils.test_utils import assert_multiline_regex_search
 from hydra.types import ConvertMode, TargetConf
+from hydra.utils import UNSAFE_ALLOW_ALL_TARGETS, target_whitelist
 from tests.instantiate import (
     AClass,
     Adam,
@@ -33,6 +35,7 @@ from tests.instantiate import (
     ASubclass,
     BadAdamConf,
     BClass,
+    CallableClass,
     CenterCrop,
     CenterCropConf,
     Compose,
@@ -68,14 +71,18 @@ from tests.instantiate import (
 
 @fixture(
     params=[
-        hydra._internal.instantiate._instantiate2.instantiate,
+        _instantiate2.instantiate,
     ],
     ids=[
         "instantiate2",
     ],
 )
 def instantiate_func(request: Any) -> Any:
-    return request.param
+    def wrapper(config: Any, *args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("_target_whitelist_", UNSAFE_ALLOW_ALL_TARGETS)
+        return request.param(config, *args, **kwargs)
+
+    return wrapper
 
 
 @fixture(
@@ -1629,7 +1636,7 @@ def test_cannot_locate_target(instantiate_func: Any) -> None:
         "subprocess.run",
     ],
 )
-def test_blocklisted_target_fails(instantiate_func: Any, target: str) -> None:
+def test_blocklisted_target_fails(target: str) -> None:
     cfg = OmegaConf.create({"foo": {"_target_": target}})
     with raises(
         InstantiationException,
@@ -1639,14 +1646,14 @@ def test_blocklisted_target_fails(instantiate_func: Any, target: str) -> None:
                 HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE={target}:<other allowlisted targets> to bypass
                 full_key: foo""")),
     ) as exc_info:
-        instantiate_func(cfg)
+        _instantiate2.instantiate(cfg)
     err = exc_info.value
     assert hasattr(err, "__cause__")
     chained = err.__cause__
     assert chained is None
 
 
-def test_allowlist_works(instantiate_func: Any, monkeypatch: Any) -> None:
+def test_allowlist_works(monkeypatch: Any) -> None:
     cfg = OmegaConf.create(
         {
             "foo": {"_target_": "builtins.exec", "_args_": ["5+8"]},
@@ -1656,20 +1663,251 @@ def test_allowlist_works(instantiate_func: Any, monkeypatch: Any) -> None:
     monkeypatch.setenv(
         "HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "builtins.exec:builtins.eval"
     )
-    res = instantiate_func(cfg)
+    with warns(UserWarning, match="_target_whitelist_"):
+        res = _instantiate2.instantiate(cfg)
     assert res.foo is None
     assert res.bar == 3
 
 
 def test_allowlist_works_for_prefix_blocked_target(monkeypatch: Any) -> None:
     monkeypatch.setenv("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "os.execl")
-    assert _resolve_target("os.execl", "") is os.execl
+    with warns(UserWarning, match="_target_whitelist_"):
+        assert _resolve_target("os.execl", "") is os.execl
+
+
+def test_target_whitelist_warns_in_legacy_mode() -> None:
+    cfg = {"_target_": "tests.instantiate.AClass", "a": 10, "b": 20, "c": 30}
+    with warns(UserWarning, match="_target_whitelist_"):
+        assert _instantiate2.instantiate(cfg) == AClass(a=10, b=20, c=30)
+
+
+def test_target_whitelist_warning_points_to_user_callsite() -> None:
+    def call_legacy_instantiate(config: Any) -> Any:
+        nonlocal expected_lineno
+        frame = inspect.currentframe()
+        assert frame is not None
+        expected_lineno = frame.f_lineno + 1
+        return _instantiate2.instantiate(config)
+
+    expected_lineno = -1
+    cfg = {
+        "nested": {
+            "_target_": "tests.instantiate.AClass",
+            "a": 10,
+            "b": 20,
+            "c": 30,
+        }
+    }
+    with warns(UserWarning, match="_target_whitelist_") as records:
+        assert call_legacy_instantiate(cfg) == {"nested": AClass(a=10, b=20, c=30)}
+
+    assert os.path.samefile(records[0].filename, __file__)
+    assert records[0].lineno == expected_lineno
+
+
+def test_target_whitelist_applies_to_callable_targets() -> None:
+    cfg = {"_target_": AClass, "a": 10, "b": 20, "c": 30}
+    with warns(UserWarning, match="_target_whitelist_"):
+        assert _instantiate2.instantiate(cfg) == AClass(a=10, b=20, c=30)
+
+    assert _instantiate2.instantiate(
+        cfg, _target_whitelist_="tests.instantiate.AClass"
+    ) == AClass(a=10, b=20, c=30)
+
+    cfg = OmegaConf.create(
+        {"_target_": module_function, "x": 10},
+        flags={"allow_objects": True},
+    )
+    with warns(UserWarning, match="_target_whitelist_"):
+        assert _instantiate2.instantiate(cfg) == 10
+
+    with raises(
+        InstantiationException,
+        match=(
+            "Target 'tests.instantiate.module_function' is not in the "
+            "instantiate target whitelist"
+        ),
+    ):
+        _instantiate2.instantiate(cfg, _target_whitelist_=[])
+
+    assert (
+        _instantiate2.instantiate(
+            cfg, _target_whitelist_="tests.instantiate.module_function"
+        )
+        == 10
+    )
+
+    cfg = OmegaConf.create(
+        {"_target_": eval, "_args_": ["1+2"]},
+        flags={"allow_objects": True},
+    )
+    with raises(
+        InstantiationException,
+        match="Target 'builtins.eval' is blocklisted",
+    ):
+        _instantiate2.instantiate(cfg)
+
+    target = CallableClass()
+    cfg = OmegaConf.create(
+        {"_target_": target},
+        flags={"allow_objects": True},
+    )
+    assert (
+        _instantiate2.instantiate(
+            cfg, _target_whitelist_="tests.instantiate.CallableClass"
+        )
+        == "callable class"
+    )
+
+    cfg = {"_target_": target}
+    assert (
+        _instantiate2.instantiate(
+            cfg, _target_whitelist_="tests.instantiate.CallableClass"
+        )
+        == "callable class"
+    )
+
+
+@mark.parametrize(
+    "target_whitelist",
+    [
+        "tests.instantiate.*",
+        ["tests.instantiate.AClass"],
+    ],
+)
+def test_target_whitelist_allows_expected_targets(
+    instantiate_func: Any, target_whitelist: Any
+) -> None:
+    cfg = {"_target_": "tests.instantiate.AClass", "a": 10, "b": 20, "c": 30}
+    assert instantiate_func(cfg, _target_whitelist_=target_whitelist) == AClass(
+        a=10, b=20, c=30
+    )
+
+
+def test_target_whitelist_context_allows_expected_targets() -> None:
+    cfg = {"_target_": "tests.instantiate.AClass", "a": 10, "b": 20, "c": 30}
+    with target_whitelist("tests.instantiate.*"):
+        assert _instantiate2.instantiate(cfg) == AClass(a=10, b=20, c=30)
+
+
+def test_target_whitelist_context_stacks_additively() -> None:
+    class_cfg = {
+        "_target_": "tests.instantiate.AClass",
+        "a": 10,
+        "b": 20,
+        "c": 30,
+    }
+    function_cfg = {"_target_": "tests.instantiate.module_function", "x": 10}
+
+    with target_whitelist("tests.instantiate.AClass"):
+        assert _instantiate2.instantiate(class_cfg) == AClass(a=10, b=20, c=30)
+        with target_whitelist("tests.instantiate.module_function"):
+            assert _instantiate2.instantiate(class_cfg) == AClass(a=10, b=20, c=30)
+            assert _instantiate2.instantiate(function_cfg) == 10
+
+        with raises(
+            InstantiationException,
+            match="Target 'tests.instantiate.module_function' is not in the instantiate target whitelist",
+        ):
+            _instantiate2.instantiate(function_cfg)
+
+
+def test_target_whitelist_context_reset_replaces_outer_context() -> None:
+    cfg = {"_target_": "tests.instantiate.AClass", "a": 10, "b": 20, "c": 30}
+
+    with target_whitelist("tests.instantiate.*"):
+        with target_whitelist([], reset=True):
+            with raises(
+                InstantiationException,
+                match="Target 'tests.instantiate.AClass' is not in the instantiate target whitelist",
+            ):
+                _instantiate2.instantiate(cfg)
+
+        assert _instantiate2.instantiate(cfg) == AClass(a=10, b=20, c=30)
+
+
+def test_target_whitelist_policy_can_be_passed_to_instantiate(
+    instantiate_func: Any,
+) -> None:
+    cfg = {"_target_": "tests.instantiate.AClass", "a": 10, "b": 20, "c": 30}
+    policy = target_whitelist("tests.instantiate.*", reset=True)
+    assert instantiate_func(cfg, _target_whitelist_=policy) == AClass(a=10, b=20, c=30)
+
+
+def test_target_whitelist_policy_reset_replaces_context_for_instantiate() -> None:
+    cfg = {"_target_": "tests.instantiate.AClass", "a": 10, "b": 20, "c": 30}
+
+    with target_whitelist("tests.instantiate.*"):
+        with raises(
+            InstantiationException,
+            match="Target 'tests.instantiate.AClass' is not in the instantiate target whitelist",
+        ):
+            _instantiate2.instantiate(
+                cfg, _target_whitelist_=target_whitelist([], reset=True)
+            )
+
+
+@mark.parametrize(
+    "target_whitelist",
+    [
+        [],
+        "tests.other.*",
+        ["tests.instantiate.BClass"],
+    ],
+)
+def test_target_whitelist_blocks_unlisted_targets(
+    instantiate_func: Any, target_whitelist: Any
+) -> None:
+    cfg = {"_target_": "tests.instantiate.AClass", "a": 10}
+    with raises(
+        InstantiationException,
+        match="Target 'tests.instantiate.AClass' is not in the instantiate target whitelist",
+    ):
+        instantiate_func(cfg, _target_whitelist_=target_whitelist)
+
+
+@mark.parametrize("target_whitelist", ["*", "*.*", "tests.*.AClass"])
+def test_target_whitelist_rejects_broad_wildcards(
+    instantiate_func: Any, target_whitelist: str
+) -> None:
+    cfg = {"_target_": "tests.instantiate.AClass", "a": 10}
+    with raises(
+        InstantiationException,
+        match="Invalid _target_whitelist_ entry",
+    ):
+        instantiate_func(cfg, _target_whitelist_=target_whitelist)
+
+
+def test_target_whitelist_in_config_is_rejected(instantiate_func: Any) -> None:
+    cfg = {
+        "_target_": "tests.instantiate.AClass",
+        "_target_whitelist_": "tests.instantiate.*",
+        "a": 10,
+    }
+    with raises(
+        InstantiationException,
+        match="_target_whitelist_ must be passed to instantiate\\(\\)",
+    ):
+        instantiate_func(cfg)
+
+
+def test_target_whitelist_can_explicitly_allow_blocklisted_targets(
+    instantiate_func: Any,
+) -> None:
+    cfg = {"_target_": "builtins.eval", "_args_": ["1+2"]}
+    assert instantiate_func(cfg, _target_whitelist_="builtins.eval") == 3
+
+
+def test_target_whitelist_unsafe_allows_all_targets(instantiate_func: Any) -> None:
+    cfg = {"_target_": "builtins.eval", "_args_": ["1+2"]}
+    assert instantiate_func(cfg, _target_whitelist_=UNSAFE_ALLOW_ALL_TARGETS) == 3
 
 
 def test_allowlist_works_for_canonical_os_alias(monkeypatch: Any) -> None:
     alias_target = "nt.system" if os.name == "nt" else "posix.system"
     monkeypatch.setenv("HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE", "os.system")
-    assert _resolve_target(alias_target, "") is os.system
+    with warns(UserWarning, match="no\n_target_whitelist_"):
+        assert _resolve_target(alias_target, "") is os.system
 
 
 @mark.parametrize(

--- a/tests/instantiate/test_positional.py
+++ b/tests/instantiate/test_positional.py
@@ -5,8 +5,14 @@ from typing import Any
 from pytest import mark, param, raises
 
 from hydra.errors import InstantiationException
-from hydra.utils import instantiate
+from hydra.utils import UNSAFE_ALLOW_ALL_TARGETS, instantiate
 from tests.instantiate import ArgsClass
+
+
+def unsafe_instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
+    kwargs.setdefault("_target_whitelist_", UNSAFE_ALLOW_ALL_TARGETS)
+    return instantiate(config, *args, **kwargs)
+
 
 #######################
 # non-recursive tests #
@@ -46,7 +52,7 @@ from tests.instantiate import ArgsClass
     ],
 )
 def test_instantiate_args_kwargs(cfg: Any, expected: Any) -> None:
-    assert instantiate(cfg) == expected
+    assert unsafe_instantiate(cfg) == expected
 
 
 @mark.parametrize(
@@ -81,7 +87,7 @@ def test_instantiate_unsupported_args_type(cfg: Any, msg: str) -> None:
         InstantiationException,
         match=msg,
     ):
-        instantiate(cfg)
+        unsafe_instantiate(cfg)
 
 
 @mark.parametrize(
@@ -112,7 +118,7 @@ def test_instantiate_unsupported_args_type(cfg: Any, msg: str) -> None:
     ],
 )
 def test_instantiate_args_kwargs_with_interpolation(cfg: Any, expected: Any) -> None:
-    assert instantiate(cfg) == expected
+    assert unsafe_instantiate(cfg) == expected
 
 
 @mark.parametrize(
@@ -151,7 +157,7 @@ def test_instantiate_args_kwargs_with_interpolation(cfg: Any, expected: Any) -> 
 def test_instantiate_args_kwargs_with_override(
     cfg: Any, args_override: Any, expected: Any, kwargs_override: Any
 ) -> None:
-    assert instantiate(cfg, *args_override, **kwargs_override) == expected
+    assert unsafe_instantiate(cfg, *args_override, **kwargs_override) == expected
 
 
 ###################
@@ -208,7 +214,7 @@ def test_instantiate_args_kwargs_with_override(
     ],
 )
 def test_recursive_instantiate_args_kwargs(cfg: Any, expected: Any) -> None:
-    assert instantiate(cfg) == expected
+    assert unsafe_instantiate(cfg) == expected
 
 
 @mark.parametrize(
@@ -271,4 +277,4 @@ def test_recursive_instantiate_args_kwargs(cfg: Any, expected: Any) -> None:
 def test_recursive_instantiate_args_kwargs_with_override(
     cfg: Any, args_override: Any, expected: Any, kwargs_override: Any
 ) -> None:
-    assert instantiate(cfg, *args_override, **kwargs_override) == expected
+    assert unsafe_instantiate(cfg, *args_override, **kwargs_override) == expected

--- a/tests/instantiate/test_positional_only_arguments.py
+++ b/tests/instantiate/test_positional_only_arguments.py
@@ -3,9 +3,13 @@ from typing import Any
 
 from pytest import mark, param
 
-from hydra.utils import instantiate
+from hydra.utils import UNSAFE_ALLOW_ALL_TARGETS, instantiate
 
 from .positional_only import PosOnlyArgsClass
+
+
+def unsafe_instantiate(config: Any, *args: Any) -> Any:
+    return instantiate(config, *args, _target_whitelist_=UNSAFE_ALLOW_ALL_TARGETS)
 
 
 @mark.parametrize(
@@ -40,4 +44,4 @@ from .positional_only import PosOnlyArgsClass
     ],
 )
 def test_positional_only_arguments(cfg: Any, args: Any, expected: Any) -> None:
-    assert instantiate(cfg, *args) == expected
+    assert unsafe_instantiate(cfg, *args) == expected

--- a/tests/test_apps/app_with_callbacks/app_with_log_compose_callback/my_app.py
+++ b/tests/test_apps/app_with_callbacks/app_with_log_compose_callback/my_app.py
@@ -7,6 +7,7 @@ from omegaconf import MISSING
 import hydra
 from hydra.core.config_store import ConfigStore
 from hydra.core.hydra_config import HydraConfig
+from hydra.utils import target_whitelist
 
 
 @dataclass
@@ -29,4 +30,5 @@ def my_app(cfg: Config) -> None:
 
 
 if __name__ == "__main__":
-    my_app()
+    with target_whitelist("hydra.experimental.callbacks.*"):
+        my_app()

--- a/tests/test_apps/app_with_callbacks/custom_callback/my_app.py
+++ b/tests/test_apps/app_with_callbacks/custom_callback/my_app.py
@@ -8,6 +8,7 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 from hydra.core.utils import JobReturn
 from hydra.experimental.callback import Callback
+from hydra.utils import target_whitelist
 
 log = logging.getLogger(__name__)
 
@@ -44,4 +45,5 @@ def my_app(cfg: DictConfig) -> None:
 
 
 if __name__ == "__main__":
-    my_app()
+    with target_whitelist("my_app.*"):
+        my_app()

--- a/tests/test_apps/app_with_callbacks/on_job_start_accepts_task_function/my_app.py
+++ b/tests/test_apps/app_with_callbacks/on_job_start_accepts_task_function/my_app.py
@@ -8,6 +8,7 @@ from omegaconf import DictConfig
 import hydra
 from hydra.experimental.callback import Callback
 from hydra.types import TaskFunction
+from hydra.utils import target_whitelist
 
 log = logging.getLogger(__name__)
 
@@ -26,4 +27,5 @@ def my_app(cfg: DictConfig) -> Any:
 
 
 if __name__ == "__main__":
-    my_app()
+    with target_whitelist("my_app.*"):
+        my_app()

--- a/tests/test_apps/app_with_pickle_job_info_callback/my_app.py
+++ b/tests/test_apps/app_with_pickle_job_info_callback/my_app.py
@@ -9,6 +9,7 @@ from omegaconf import DictConfig
 
 import hydra
 from hydra.core.hydra_config import HydraConfig
+from hydra.utils import target_whitelist
 
 log = logging.getLogger(__name__)
 
@@ -29,4 +30,5 @@ def my_app(cfg: DictConfig) -> str:
 
 
 if __name__ == "__main__":
-    my_app()
+    with target_whitelist("hydra.experimental.callbacks.*"):
+        my_app()

--- a/tools/configen/example/my_app.py
+++ b/tools/configen/example/my_app.py
@@ -20,8 +20,9 @@ ConfigStore.instance().store(
 
 @hydra.main(version_base=None, config_path=".", config_name="config")
 def my_app(cfg: DictConfig) -> None:
-    user: User = hydra.utils.instantiate(cfg.user)
-    admin: Admin = hydra.utils.instantiate(cfg.admin)
+    with hydra.utils.target_whitelist("configen.samples.my_module.*"):
+        user: User = hydra.utils.instantiate(cfg.user)
+        admin: Admin = hydra.utils.instantiate(cfg.admin)
     print(user)
     print(admin)
 

--- a/tools/configen/tests/test_generate.py
+++ b/tools/configen/tests/test_generate.py
@@ -11,7 +11,7 @@ from configen.config import ConfigenConf, Flags, ModuleConf
 from configen.configen import generate_module
 from hydra.test_utils.test_utils import chdir_hydra_root, run_python_script
 
-from hydra.utils import ConvertMode, get_class, instantiate
+from hydra.utils import ConvertMode, get_class, instantiate, target_whitelist
 from omegaconf import OmegaConf
 
 from pytest import mark, param
@@ -281,7 +281,8 @@ def test_instantiate_classes(
     schema = OmegaConf.structured(get_class(full_class))
     cfg = OmegaConf.merge(schema, params)
     kwargs["config"] = cfg
-    obj = instantiate(*args, **kwargs)
+    with target_whitelist("tests.test_modules.*"):
+        obj = instantiate(*args, **kwargs)
     assert obj == expected
 
 

--- a/website/README.md
+++ b/website/README.md
@@ -36,4 +36,4 @@ Done automatically once a website change is landed to main.
 
 ### Adding pages
 
-New pages, e.g., for a new plugin, should be added to `docs/`. They can be accessed on a local server via `http://localhost:3000/docs/page_name`.
+New pages, e.g., for a new plugin, should be added to `docs/`. They can be accessed on a local server via `http://localhost:9134/docs/page_name`.

--- a/website/docs/advanced/instantiate_objects/config_files.md
+++ b/website/docs/advanced/instantiate_objects/config_files.md
@@ -85,6 +85,6 @@ With this, you can instantiate the object from the configuration with a single l
 ```python
 @hydra.main(version_base=None, config_path="conf", config_name="config")
 def my_app(cfg):
-    connection = hydra.utils.instantiate(cfg.db)
+    connection = hydra.utils.instantiate(cfg.db, _target_whitelist_="my_app.*")
     connection.connect()
 ```

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -18,16 +18,6 @@ Call/instantiate supports:
 - Constructing an object by calling the `__init__` method
 - Calling functions, static functions, class methods and other callable global objects
 
-
-:::warning
-This may pose a security risk since the config can be used to execute arbitrary code. Make
-sure to use this only with trusted configs.
-
-There is a default list of blocklisted modules. To bypass it, set the env var
-HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE with a colon-separated list of modules to allowlist,
-eg. `HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE=os.rename:shutil.move`
-:::
-
 <details>
     <summary>Instantiate API (Expand for details)</summary>
 
@@ -55,6 +45,11 @@ eg. `HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE=os.rename:shutil.move`
                                       are converted to dicts / lists too.
                        _partial_: If True, return functools.partial wrapped method or object
                                   False by default. Configure per target.
+        :param _target_whitelist_: A target string, list of target strings,
+                                   object returned by target_whitelist(), or
+                                   UNSAFE_ALLOW_ALL_TARGETS. Passing None
+                                   preserves legacy behavior unless a
+                                   target_whitelist() context is active.
         :param args: Optional positional parameters pass-through
         :param kwargs: Optional named parameters to override
                        parameters in the config object. Parameters not present
@@ -71,8 +66,87 @@ eg. `HYDRA_INSTANTIATE_ALLOWLIST_OVERRIDE=os.rename:shutil.move`
 
 </details><br/>
 
+<details>
+    <summary>Target whitelist API (Expand for details)</summary>
+
+    ```python
+    def target_whitelist(
+        target_whitelist: str | Sequence[str] | UNSAFE_ALLOW_ALL_TARGETS | None,
+        reset: bool = False,
+    ):
+        """
+        Create a target whitelist object for hydra.utils.instantiate().
+
+        The returned object can be used as a context manager to apply a whitelist
+        to instantiate() calls in the current context, or passed to instantiate()
+        as _target_whitelist_.
+
+        :param target_whitelist: A target string, list of target strings, or
+                                 UNSAFE_ALLOW_ALL_TARGETS. A trailing .*
+                                 allows targets under a package prefix.
+        :param reset: If True, ignore any outer target_whitelist() context.
+                      If False, add these targets to the current context.
+        """
+    ```
+
+</details><br/>
+
 The config passed to these functions must have a key called `_target_`, with the value of a fully qualified class name, class method, static method or callable.
 For convenience, `None` config results in a `None` object.
+
+Create a whitelist object with `target_whitelist()`. Use it as a context manager
+to apply a whitelist to every `instantiate()` call in a block. This is useful
+when another function or framework calls `instantiate()` internally, or when
+calling `instantiate()` multiple times with the same whitelist:
+
+```python
+from hydra.utils import instantiate, target_whitelist
+
+with target_whitelist("my_app.*"):
+    framework_function(cfg)
+```
+
+Or pass it directly to one `instantiate()` call:
+
+```python
+model = instantiate(
+    cfg.model,
+    _target_whitelist_=target_whitelist("my_app.models.*"),
+)
+```
+
+Nested `target_whitelist()` scopes stack by default: an inner scope adds its
+targets to the outer scope.
+
+```python
+with target_whitelist("my_app.models.*"):
+    with target_whitelist("my_app.optimizers.*"):
+        train(cfg)
+```
+
+Use `reset=True` when the inner scope should replace the outer scope instead of
+adding to it:
+
+```python
+with target_whitelist("my_app.*"):
+    with target_whitelist("my_app.models.*", reset=True):
+        instantiate(cfg.model)
+```
+
+For simple direct calls, `_target_whitelist_` also accepts a string or list of
+strings.
+
+The wildcard `*` by itself is not allowed as a whitelist entry. To explicitly
+preserve legacy all-target behavior, use `UNSAFE_ALLOW_ALL_TARGETS`:
+
+```python
+from hydra.utils import UNSAFE_ALLOW_ALL_TARGETS, instantiate
+
+component = instantiate(
+    cfg.component,
+    _target_whitelist_=UNSAFE_ALLOW_ALL_TARGETS,
+)
+```
 
 **Named arguments** : Config fields (except reserved fields like `_target_`) are passed as named arguments to the target.
 Named arguments in the config can be overridden by passing named argument with the same name in the `instantiate()` call-site.
@@ -103,10 +177,6 @@ optimizer:
   _target_: my_app.Optimizer
   algo: SGD
   lr: 0.01
-
-
-
-
 ```
 
 
@@ -115,18 +185,26 @@ optimizer:
 <div className="col col--6">
 
 ```python title="Instantiation"
-opt = instantiate(cfg.optimizer)
+with target_whitelist("my_app.*"):
+    opt = instantiate(cfg.optimizer)
 print(opt)
 # Optimizer(algo=SGD,lr=0.01)
-
-# override parameters on the call-site
-opt = instantiate(cfg.optimizer, lr=0.2)
-print(opt)
-# Optimizer(algo=SGD,lr=0.2)
 ```
 
 </div>
 </div>
+
+You can override parameters at the call-site:
+
+```python
+with target_whitelist("my_app.*"):
+    opt = instantiate(
+        cfg.optimizer,
+        lr=0.2,
+    )
+print(opt)
+# Optimizer(algo=SGD,lr=0.2)
+```
 
 
 ### Recursive instantiation
@@ -163,20 +241,22 @@ trainer:
 
 Hydra will instantiate nested objects recursively by default.
 ```python
-trainer = instantiate(cfg.trainer)
-print(trainer)
-# Trainer(
-#  optimizer=Optimizer(algo=SGD,lr=0.01),
-#  dataset=Dataset(name=Imagenet, path=/datasets/imagenet)
-# )
+with target_whitelist("my_app.*"):
+    trainer = instantiate(cfg.trainer)
+    print(trainer)
+    # Trainer(
+    #  optimizer=Optimizer(algo=SGD,lr=0.01),
+    #  dataset=Dataset(name=Imagenet, path=/datasets/imagenet)
+    # )
 ```
 You can override parameters for nested objects:
 ```python
-trainer = instantiate(
-    cfg.trainer,
-    optimizer={"lr": 0.3},
-    dataset={"name": "cifar10", "path": "/datasets/cifar10"},
-)
+with target_whitelist("my_app.*"):
+    trainer = instantiate(
+        cfg.trainer,
+        optimizer={"lr": 0.3},
+        dataset={"name": "cifar10", "path": "/datasets/cifar10"},
+    )
 print(trainer)
 # Trainer(
 #   optimizer=Optimizer(algo=SGD,lr=0.3),
@@ -186,20 +266,27 @@ print(trainer)
 
 Similarly, positional arguments of nested objects can be overridden:
 ```python
-obj = instantiate(
-    cfg.object,
-    # pass 1 and 2 as positional arguments to the target object
-    1, 2,
-    # pass 3 and 4 as positional arguments to a nested child object
-    child={"_args_": [3, 4]},
-)
+with target_whitelist("my_app.*"):
+    obj = instantiate(
+        cfg.object,
+        # pass 1 and 2 as positional arguments
+        # to the target object
+        1, 2,
+        # pass 3 and 4 as positional arguments
+        # to a nested child object
+        child={"_args_": [3, 4]},
+    )
 ```
 
 ### Disable recursive instantiation
 You can disable recursive instantiation by setting `_recursive_` to `False` in the config node or in the call-site
 In that case the Trainer object will receive an OmegaConf DictConfig for nested dataset and optimizer instead of the instantiated objects.
 ```python
-optimizer = instantiate(cfg.trainer, _recursive_=False)
+optimizer = instantiate(
+    cfg.trainer,
+    _recursive_=False,
+    _target_whitelist_="my_app.Trainer",
+)
 print(optimizer)
 ```
 
@@ -265,22 +352,22 @@ cfg = OmegaConf.create(
     }
 )
 
-obj_none = instantiate(cfg, _convert_="none")
+obj_none = instantiate(cfg, _convert_="none", _target_whitelist_="__main__.*")
 assert isinstance(obj_none, MyTarget)
 assert isinstance(obj_none.foo, DictConfig)
 assert isinstance(obj_none.bar, DictConfig)
 
-obj_partial = instantiate(cfg, _convert_="partial")
+obj_partial = instantiate(cfg, _convert_="partial", _target_whitelist_="__main__.*")
 assert isinstance(obj_partial, MyTarget)
 assert isinstance(obj_partial.foo, DictConfig)
 assert isinstance(obj_partial.bar, dict)
 
-obj_object = instantiate(cfg, _convert_="object")
+obj_object = instantiate(cfg, _convert_="object", _target_whitelist_="__main__.*")
 assert isinstance(obj_object, MyTarget)
 assert isinstance(obj_object.foo, Foo)
 assert isinstance(obj_object.bar, dict)
 
-obj_all = instantiate(cfg, _convert_="all")
+obj_all = instantiate(cfg, _convert_="all", _target_whitelist_="__main__.*")
 assert isinstance(obj_all, MyTarget)
 assert isinstance(obj_all.foo, dict)
 assert isinstance(obj_all.bar, dict)
@@ -292,16 +379,16 @@ instances of `MyTarget` that are equivalent to the above:
 
 ```python
 cfg_none = OmegaConf.create({..., "_convert_": "none"})
-obj_none = instantiate(cfg_none)
+obj_none = instantiate(cfg_none, _target_whitelist_="__main__.*")
 
 cfg_partial = OmegaConf.create({..., "_convert_": "partial"})
-obj_partial = instantiate(cfg_partial)
+obj_partial = instantiate(cfg_partial, _target_whitelist_="__main__.*")
 
 cfg_object = OmegaConf.create({..., "_convert_": "object"})
-obj_object = instantiate(cfg_object)
+obj_object = instantiate(cfg_object, _target_whitelist_="__main__.*")
 
 cfg_all = OmegaConf.create({..., "_convert_": "all"})
-obj_all = instantiate(cfg_all)
+obj_all = instantiate(cfg_all, _target_whitelist_="__main__.*")
 ```
 
 ### Partial Instantiation
@@ -352,7 +439,8 @@ model:
 <div className="col col--7">
 
 ```python title="Instantiation"
-model = instantiate(cfg.model)
+with target_whitelist("my_app.*"):
+    model = instantiate(cfg.model)
 print(model)
 # "Model(Optimizer=Optimizer(algo=SGD,lr=0.01),lr=0.01)
 ```
@@ -363,7 +451,11 @@ print(model)
 If you are repeatedly instantiating the same config,
 using `_partial_=True` may provide a significant speedup as compared with regular (non-partial) instantiation.
 ```python
-factory = instantiate(config, _partial_=True)
+factory = instantiate(
+    config,
+    _partial_=True,
+    _target_whitelist_="my_app.*",
+)
 obj = factory()
 ```
 In the above example, repeatedly calling `factory` would be faster than repeatedly calling `instantiate(config)`.
@@ -381,7 +473,11 @@ bar_conf = {
     "foo": {"_target_": "__main__.Foo"},
 }
 
-bar_factory = instantiate(bar_conf, _partial_=True)
+bar_factory = instantiate(
+    bar_conf,
+    _partial_=True,
+    _target_whitelist_="__main__.*",
+)
 bar1 = bar_factory()
 bar2 = bar_factory()
 
@@ -401,7 +497,11 @@ you will need to provide a dotpath looking up that function in Python's [`builti
 ```python
 from hydra.utils import instantiate
 # instantiate({"_target_": "len"}, [1,2,3])  # this gives an InstantiationException
-instantiate({"_target_": "builtins.len"}, [1,2,3])  # this works, returns the number 3
+instantiate(
+    {"_target_": "builtins.len"},
+    [1,2,3],
+    _target_whitelist_="builtins.len",
+)  # this works, returns the number 3
 ```
 
 ### Dotpath lookup machinery

--- a/website/docs/advanced/instantiate_objects/structured_config.md
+++ b/website/docs/advanced/instantiate_objects/structured_config.md
@@ -63,7 +63,7 @@ cs.store(group="db", name="postgresql", node=PostGreSQLConfig)
 
 @hydra.main(version_base=None, config_name="config")
 def my_app(cfg: Config) -> None:
-    connection = instantiate(cfg.db)
+    connection = instantiate(cfg.db, _target_whitelist_="my_app.*")
     connection.connect()
 
 if __name__ == "__main__":

--- a/website/docs/upgrades/1.3_to_1.4/instantiate_target_whitelist.md
+++ b/website/docs/upgrades/1.3_to_1.4/instantiate_target_whitelist.md
@@ -1,0 +1,98 @@
+---
+id: instantiate_target_whitelist
+title: Instantiate target whitelist
+---
+
+Running `hydra.utils.instantiate()` on config nodes from untrusted sources can
+result in arbitrary code execution. This is a security risk because configs are
+sometimes bundled with packages, models, checkpoints, or other downloaded
+artifacts.
+
+To address this, Hydra 1.4 deprecates resolving `_target_` values unless
+trusted Python code at the callsite also provides `_target_whitelist_`.
+
+For the full API reference, see
+[Instantiating objects with Hydra](/docs/advanced/instantiate_objects/overview).
+
+## Update direct calls
+
+If your code calls `instantiate()` directly, pass the targets that call is
+expected to resolve:
+
+```python
+from hydra.utils import instantiate
+
+model = instantiate(cfg.model, _target_whitelist_="my_app.models.*")
+```
+
+## Update wrapped calls
+
+If another function calls `instantiate()` internally, put the whitelist around
+that call. This is also useful when calling `instantiate()` multiple times with
+the same whitelist.
+
+```python
+from hydra.utils import target_whitelist
+
+with target_whitelist("my_app.*"):
+    framework_function(cfg)
+```
+
+## Framework authors
+
+Framework authors should whitelist framework-owned targets around the internal
+`instantiate()` calls that resolve framework config. Trust decisions for
+application-owned targets should stay with the application. If framework code
+also instantiates application objects, the application can wrap the framework
+call with its own whitelist.
+
+For example, a framework can whitelist its own launcher target:
+
+```python
+from hydra.utils import instantiate, target_whitelist
+
+def train(cfg):
+    with target_whitelist("my_framework.*"):
+        launcher = instantiate(cfg.launcher)
+
+    model = instantiate(cfg.model)
+    launcher.run(model)
+```
+
+Application code can then add its own targets around the framework call:
+
+```python
+with target_whitelist("my_app.*"):
+    train(cfg)
+```
+
+The inner framework whitelist adds `my_framework.*`; the outer application
+whitelist adds `my_app.*`. The framework does not need to know which
+application model targets are trusted.
+
+## Choose target patterns
+
+Whitelist entries may be exact targets or package prefixes ending in `.*`.
+The wildcard `*` by itself is not allowed.
+
+Be careful with namespace packages and plugin namespaces. A whitelist entry such
+as `my_app.*` allows any importable target under that Python namespace, including
+modules contributed by other installed distributions. For shared namespaces,
+prefer exact target names or narrower prefixes.
+
+## Legacy behavior
+
+To preserve legacy all-target behavior, use `UNSAFE_ALLOW_ALL_TARGETS`
+explicitly:
+
+```python
+from hydra.utils import UNSAFE_ALLOW_ALL_TARGETS, instantiate
+
+obj = instantiate(cfg.component, _target_whitelist_=UNSAFE_ALLOW_ALL_TARGETS)
+```
+
+Use this only when you intentionally want the old behavior.
+
+Calling `instantiate()` without `_target_whitelist_` still works in Hydra 1.4,
+but it emits a deprecation warning when resolving `_target_`.
+Legacy mode continues to use Hydra's target blocklist as defense-in-depth.

--- a/website/package.json
+++ b/website/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "docusaurus start --port 9134",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy"

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -164,6 +164,7 @@ module.exports = AddFBInternalOnly({
                 label: '1.3 to 1.4',
                 items: [
                     'upgrades/1.3_to_1.4/hydra_job_override_dirname',
+                    'upgrades/1.3_to_1.4/instantiate_target_whitelist',
                 ],
             },
             {


### PR DESCRIPTION

Add callsite target whitelists for hydra.utils.instantiate(), including direct call and context-manager forms, legacy warnings, explicit unsafe opt-out, plugin internal usage, examples, tests, and migration documentation.

Update trusted examples and test applications to provide whitelists at Python callsites, and constrain default pytest discovery to the core test roots.

Closes #3259

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookresearch/hydra/pull/3264).
* #3269
* __->__ #3264