### PR TITLE
Build website without deploying on PRs

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -23,9 +23,10 @@ jobs:
     - uses: actions/setup-node@v6
       with:
         node-version: "24"
-    - name: Deploy website
+    - name: Build or deploy website
       env:
-        WEBSITE_GITHUB_TOKEN: ${{ secrets.WEBSITE_GITHUB_TOKEN }}
+        WEBSITE_GITHUB_TOKEN: ${{ github.event_name != 'pull_request' && secrets.WEBSITE_GITHUB_TOKEN || '' }}
+        IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
       run: |
         SUBDIR=website
         git fetch
@@ -38,10 +39,14 @@ jobs:
           cd $SUBDIR
           corepack enable
           corepack pnpm install --frozen-lockfile
-          git config --global user.email omry@users.noreply.github.com
-          git config --global user.name omry
-          echo "machine github.com login docusaurus-bot password $WEBSITE_GITHUB_TOKEN" > ~/.netrc
-          GIT_USER=docusaurus-bot corepack pnpm run deploy
+          if [[ "$IS_PULL_REQUEST" == "true" ]]; then
+            corepack pnpm run build
+          else
+            git config --global user.email omry@users.noreply.github.com
+            git config --global user.name omry
+            echo "machine github.com login docusaurus-bot password $WEBSITE_GITHUB_TOKEN" > ~/.netrc
+            GIT_USER=docusaurus-bot corepack pnpm run deploy
+          fi
         else
           echo "No changes detected in directory $SUBDIR between origin/main and this diff"
         fi


### PR DESCRIPTION

Run the Docusaurus build instead of deploy for pull_request events in the website workflow. Keep the existing gh-pages deployment path for push events.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookresearch/hydra/pull/3267).
* #3269
* #3264
* #3263
* __->__ #3267