### PR TITLE
Instantiate plugin configs non-recursively

### DIFF
--- a/hydra/core/plugins.py
+++ b/hydra/core/plugins.py
@@ -110,7 +110,10 @@ class Plugins(metaclass=Singleton):
                 raise RuntimeError(f"Unknown plugin class : '{classname}'")
             clazz = self.class_name_to_class[classname]
             plugin = instantiate(
-                config=config, _target_=clazz, _target_whitelist_=classname
+                config=config,
+                _target_=clazz,
+                _target_whitelist_=classname,
+                _recursive_=False,
             )
             assert isinstance(plugin, Plugin)
 

--- a/news/3268.api_change
+++ b/news/3268.api_change
@@ -1,0 +1,1 @@
+Instantiate launcher and sweeper plugin configs non-recursively.

--- a/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/optuna_sweeper.py
+++ b/plugins/hydra_optuna_sweeper/hydra_plugins/hydra_optuna_sweeper/optuna_sweeper.py
@@ -3,9 +3,8 @@ from typing import Any, List, Optional
 
 from hydra.plugins.sweeper import Sweeper
 from hydra.types import HydraContext, TaskFunction
+from hydra.utils import instantiate
 from omegaconf import DictConfig
-
-from .config import SamplerConfig
 
 
 class OptunaSweeper(Sweeper):
@@ -13,7 +12,7 @@ class OptunaSweeper(Sweeper):
 
     def __init__(
         self,
-        sampler: SamplerConfig,
+        sampler: Any,
         direction: Any,
         storage: Optional[Any],
         study_name: Optional[str],
@@ -25,6 +24,15 @@ class OptunaSweeper(Sweeper):
         params: Optional[DictConfig],
     ) -> None:
         from ._impl import OptunaSweeperImpl
+
+        sampler = instantiate(
+            sampler,
+            _skip_instantiate_full_deepcopy_=True,
+            _target_whitelist_=(
+                "hydra_plugins.hydra_optuna_sweeper.*",
+                "optuna.samplers.*",
+            ),
+        )
 
         self.sweeper = OptunaSweeperImpl(
             sampler,

--- a/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
+++ b/plugins/hydra_optuna_sweeper/tests/test_optuna_sweeper_plugin.py
@@ -387,7 +387,10 @@ def test_motpe_sampler_removed() -> None:
         InstantiationException,
         match="The 'motpe' sampler was removed in Optuna 4.0",
     ):
-        instantiate(OmegaConf.structured(MOTPESamplerConfig))
+        instantiate(
+            OmegaConf.structured(MOTPESamplerConfig),
+            _target_whitelist_="hydra_plugins.hydra_optuna_sweeper.config.raise_motpe_removed",
+        )
 
 
 def test_example_with_removed_motpe(
@@ -406,4 +409,5 @@ def test_example_with_removed_motpe(
     ]
 
     out, err = run_process(cmd, print_error=False, raise_exception=False)
-    assert "The 'motpe' sampler was removed in Optuna 4.0" in err
+    assert "motpe" in err
+    assert "sampler was removed in Optuna 4.0" in err

--- a/tests/test_plugin_interface.py
+++ b/tests/test_plugin_interface.py
@@ -1,14 +1,19 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from typing import List, Type
+import sys
+import types
+from typing import List, Sequence, Type
 
-from pytest import mark, raises
+from omegaconf import DictConfig, OmegaConf
+from pytest import MonkeyPatch, mark, raises
 
 from hydra.core.config_search_path import ConfigSearchPath
 from hydra.core.plugins import Plugins
+from hydra.core.utils import JobReturn
 from hydra.plugins.launcher import Launcher
 from hydra.plugins.plugin import Plugin
 from hydra.plugins.search_path_plugin import SearchPathPlugin
 from hydra.plugins.sweeper import Sweeper
+from hydra.types import HydraContext, TaskFunction
 from hydra.utils import get_class
 
 # This only test core plugins.
@@ -16,6 +21,27 @@ from hydra.utils import get_class
 launchers = ["hydra._internal.core_plugins.basic_launcher.BasicLauncher"]
 sweepers = ["hydra._internal.core_plugins.basic_sweeper.BasicSweeper"]
 search_path_plugins: List[str] = []
+
+
+class PluginWithNestedTarget(Launcher):
+    def __init__(self, nested: DictConfig) -> None:
+        self.nested = nested
+
+    def setup(
+        self,
+        *,
+        hydra_context: HydraContext,
+        task_function: TaskFunction,
+        config: DictConfig,
+    ) -> None: ...
+
+    def launch(
+        self, job_overrides: Sequence[Sequence[str]], initial_job_idx: int
+    ) -> Sequence[JobReturn]:
+        raise NotImplementedError()
+
+
+PluginWithNestedTarget.__module__ = "hydra._internal.core_plugins.test_plugin"
 
 
 @mark.parametrize(
@@ -50,3 +76,31 @@ def test_register_bad_plugin() -> None:
 
     with raises(ValueError, match="Not a valid Hydra Plugin"):
         Plugins.instance().register(NotAPlugin)  # type: ignore
+
+
+def test_plugin_instantiation_is_not_recursive(monkeypatch: MonkeyPatch) -> None:
+    classname = "hydra._internal.core_plugins.test_plugin.PluginWithNestedTarget"
+    module = types.ModuleType("hydra._internal.core_plugins.test_plugin")
+    setattr(module, "PluginWithNestedTarget", PluginWithNestedTarget)
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setitem(
+        Plugins.instance().class_name_to_class, classname, PluginWithNestedTarget
+    )
+
+    plugin = Plugins.instance()._instantiate(
+        OmegaConf.create(
+            {
+                "_target_": classname,
+                "nested": {
+                    "_target_": "tests.instantiate.AClass",
+                    "a": 1,
+                    "b": 2,
+                    "c": 3,
+                },
+            }
+        )
+    )
+
+    assert isinstance(plugin, PluginWithNestedTarget)
+    assert isinstance(plugin.nested, DictConfig)
+    assert plugin.nested._target_ == "tests.instantiate.AClass"

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -282,12 +282,12 @@ with target_whitelist("my_app.*"):
 You can disable recursive instantiation by setting `_recursive_` to `False` in the config node or in the call-site
 In that case the Trainer object will receive an OmegaConf DictConfig for nested dataset and optimizer instead of the instantiated objects.
 ```python
-optimizer = instantiate(
+trainer = instantiate(
     cfg.trainer,
     _recursive_=False,
     _target_whitelist_="my_app.Trainer",
 )
-print(optimizer)
+print(trainer)
 ```
 
 Output:

--- a/website/docs/upgrades/1.3_to_1.4/instantiate_target_whitelist.md
+++ b/website/docs/upgrades/1.3_to_1.4/instantiate_target_whitelist.md
@@ -70,6 +70,14 @@ The inner framework whitelist adds `my_framework.*`; the outer application
 whitelist adds `my_app.*`. The framework does not need to know which
 application model targets are trusted.
 
+## Plugin authors
+
+Hydra 1.4 instantiates launcher and sweeper plugin configs non-recursively.
+Hydra core instantiates only the registered plugin class. If your plugin config
+contains nested `_target_` values, accept the nested config in the plugin
+constructor and call `instantiate()` from plugin code with a plugin-owned
+whitelist.
+
 ## Choose target patterns
 
 Whitelist entries may be exact targets or package prefixes ending in `.*`.


### PR DESCRIPTION

Change Hydra plugin construction to instantiate only the registered plugin class in core. Plugins that need nested targets now instantiate them from plugin code with an explicit target whitelist.

Update the Optuna sweeper to instantiate its sampler config directly and document the plugin-author migration.

Closes #3268
