### PR TITLE
Prevent Bash completion from executing non-Hydra scripts

### DIFF
--- a/hydra/_internal/core_plugins/bash_completion.py
+++ b/hydra/_internal/core_plugins/bash_completion.py
@@ -22,11 +22,16 @@ class BashCompletion(CompletionPlugin):
         if (( ${#words[@]} < 2 )); then
             return
         fi
+        if [[ "${words[1]}" == -* ]]; then
+            return
+        fi
         file_path=$(pwd)/${words[1]}
         if [ ! -f "$file_path" ]; then
             return
         fi
-        grep "@hydra.main" $file_path -q
+        if ! grep -Fq -- "@hydra.main" "$file_path"; then
+            return
+        fi
         helper="${words[0]} ${words[1]}"
     else
         helper="${words[0]}"

--- a/news/3275.bugfix
+++ b/news/3275.bugfix
@@ -1,0 +1,1 @@
+Prevent Bash completion from executing non-Hydra Python scripts.

--- a/tests/scripts/test_bash_completion_non_hydra.bash
+++ b/tests/scripts/test_bash_completion_non_hydra.bash
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+prog=("$@")
+
+eval "$("${prog[@]}" -sc install=bash)"
+
+COMP_LINE=${COMP_LINE:-"python non_hydra.py "}
+COMP_POINT=${#COMP_LINE}
+COMP_CWORD=2
+hydra_bash_completion

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -94,6 +94,59 @@ def test_bash_completion_with_dot_in_path() -> None:
     return
 
 
+@mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def test_bash_completion_does_not_execute_non_hydra_script(tmp_path: Path) -> None:
+    completion_app = Path("hydra/test_utils/completion.py").resolve()
+    completion_test = Path(
+        "tests/scripts/test_bash_completion_non_hydra.bash"
+    ).resolve()
+    script = tmp_path / "non_hydra.py"
+    script.write_text('from pathlib import Path\nPath("executed").touch()\n')
+
+    subprocess.check_call(
+        [
+            "bash",
+            str(completion_test),
+            "python",
+            str(completion_app),
+        ],
+        cwd=tmp_path,
+        env={"PATH": f"{Path(sys.executable).parent}{os.pathsep}{os.environ['PATH']}"},
+    )
+
+    assert not (tmp_path / "executed").exists()
+
+
+@mark.skipif(sys.platform == "win32", reason="does not run on windows")
+def test_bash_completion_does_not_execute_python_option_as_script(
+    tmp_path: Path,
+) -> None:
+    completion_app = Path("hydra/test_utils/completion.py").resolve()
+    completion_test = Path(
+        "tests/scripts/test_bash_completion_non_hydra.bash"
+    ).resolve()
+    (tmp_path / "--").write_text("# @hydra.main\n")
+    (tmp_path / "-sc").write_text(
+        'from pathlib import Path\nPath("executed").touch()\n'
+    )
+
+    subprocess.check_call(
+        [
+            "bash",
+            str(completion_test),
+            "python",
+            str(completion_app),
+        ],
+        cwd=tmp_path,
+        env={
+            "COMP_LINE": "python -- ",
+            "PATH": f"{Path(sys.executable).parent}{os.pathsep}{os.environ['PATH']}",
+        },
+    )
+
+    assert not (tmp_path / "executed").exists()
+
+
 base_completion_list: List[str] = [
     "dict.",
     "dict_prefix=",

--- a/website/docs/tutorials/basic/running_your_app/6_tab_completion.md
+++ b/website/docs/tutorials/basic/running_your_app/6_tab_completion.md
@@ -19,6 +19,15 @@ Get the exact command to install the completion from `--hydra-help`.
 Currently, Bash, zsh and Fish are supported.
 We are relying on the community to implement tab completion plugins for additional shells.
 
+Hydra tab completion supports applications invoked as a Python script, such as
+`python my_app.py`, or through an installed console entry point, such as
+`my_app`. The `python -m my_app` invocation form is not supported because Hydra
+cannot determine passively whether a module launches a Hydra application. A
+module does not necessarily correspond to a regular source file and may, for
+example, be loaded from a zip archive. For a packaged application, follow the
+[Application packaging](/advanced/packaging.md) guidance to define and use a
+console entry point instead.
+
 #### Fish instructions
 Fish support requires version >= 3.1.2.
 Previous versions will work but add an extra space after `.`.


### PR DESCRIPTION
## Summary

- Stop Bash completion before it queries a non-Hydra Python script, using a
  literal `@hydra.main` check.
- Reject Python options before treating the second word as a script path.
- Add shell regression tests proving neither path executes unintended code.
- Document that completion supports `python my_app.py` and installed console
  entry points, but not `python -m my_app`.
- Add a bugfix news fragment.

## Root cause

The generated Bash completion function checked Python source for `@hydra.main`, but the following variable assignment replaced the `grep` exit status. Completion therefore executed any existing Python file with `-sc query=bash`.

It also treated Python options as script paths. For example, completion for `python --` could execute a local file named `-sc`.

## Test plan

- `.venv/bin/pytest -q tests/test_completion.py -k does_not_execute`
- `PATH=/home/omry/dev/hydra/.venv/bin:$PATH .venv/bin/pytest -q tests/test_completion.py`
- `.venv/bin/isort hydra/_internal/core_plugins/bash_completion.py tests/test_completion.py --check --diff`
- `.venv/bin/flake8 --jobs=1 --config .flake8 hydra/_internal/core_plugins/bash_completion.py tests/test_completion.py`
- `bash -n tests/scripts/test_bash_completion_non_hydra.bash`
- `corepack pnpm build` from `website/`

Fixes https://github.com/facebookresearch/hydra/issues/3275
