### PR TITLE
Reject unsupported Defaults List keywords

### DIFF
--- a/hydra/_internal/config_repository.py
+++ b/hydra/_internal/config_repository.py
@@ -51,6 +51,8 @@ class IConfigRepository(ABC):
 
 
 class ConfigRepository(IConfigRepository):
+    _KNOWN_DEFAULTS_LIST_KEYWORDS = ("optional", "override")
+
     config_search_path: ConfigSearchPath
     sources: List[ConfigSource]
 
@@ -199,7 +201,9 @@ class ConfigRepository(IConfigRepository):
                 assert isinstance(key, str)
                 config_group, package, _package2 = self._split_group(key)
                 keywords = ConfigRepository.Keywords()
-                self._extract_keywords_from_config_group(config_group, keywords)
+                self._extract_keywords_from_config_group(
+                    config_path, config_group, keywords
+                )
 
                 if not version.base_at_least("1.2"):
                     if not keywords.optional and old_optional is not None:
@@ -301,18 +305,22 @@ class ConfigRepository(IConfigRepository):
 
     @staticmethod
     def _extract_keywords_from_config_group(
-        group: str, keywords: "ConfigRepository.Keywords"
+        config_path: str, group: str, keywords: "ConfigRepository.Keywords"
     ) -> None:
-        elements = group.split(" ")
+        elements = group.split()
+        if not elements:
+            raise ValueError(f"In {config_path}: Missing group name in defaults list")
         group = elements[-1]
         elements = elements[0:-1]
-        for idx, e in enumerate(elements):
-            if e == "optional":
+        for keyword in elements:
+            if keyword not in ConfigRepository._KNOWN_DEFAULTS_LIST_KEYWORDS:
+                raise ValueError(
+                    f"In {config_path}: Unsupported keyword '{keyword}' in defaults list"
+                )
+            if keyword == "optional":
                 keywords.optional = True
-            elif e == "override":
+            elif keyword == "override":
                 keywords.override = True
-            else:
-                break
         keywords.group = group
 
 

--- a/news/1951.bugfix
+++ b/news/1951.bugfix
@@ -1,0 +1,1 @@
+Reject unsupported keywords in Defaults List entries.

--- a/tests/defaults_list/data/empty_group.yaml
+++ b/tests/defaults_list/data/empty_group.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - "": file1

--- a/tests/defaults_list/data/keyword_whitespace.yaml
+++ b/tests/defaults_list/data/keyword_whitespace.yaml
@@ -1,0 +1,3 @@
+defaults:
+  - "optional  group1": file1
+  - "override\tgroup2": file2

--- a/tests/defaults_list/data/unknown_keyword.yaml
+++ b/tests/defaults_list/data/unknown_keyword.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - optioal group1: file1

--- a/tests/defaults_list/data/whitespace_group.yaml
+++ b/tests/defaults_list/data/whitespace_group.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - "   ": file1

--- a/tests/defaults_list/test_defaults_list.py
+++ b/tests/defaults_list/test_defaults_list.py
@@ -56,6 +56,14 @@ Plugins.instance()
             id="optional",
         ),
         param(
+            "keyword_whitespace",
+            [
+                GroupDefault(group="group1", value="file1", optional=True),
+                GroupDefault(group="group2", value="file2", override=True),
+            ],
+            id="keyword_whitespace",
+        ),
+        param(
             "config_default",
             [ConfigDefault(path="empty")],
             id="non_config_group_default",
@@ -69,6 +77,27 @@ def test_loaded_defaults_list(
     result = repo.load_config(config_path=config_path)
     assert result is not None
     assert result.defaults_list == expected_list
+
+
+def test_unknown_keyword_in_defaults_list() -> None:
+    repo = create_repo()
+    with raises(
+        ValueError,
+        match=re.escape(
+            "In unknown_keyword: Unsupported keyword 'optioal' in defaults list"
+        ),
+    ):
+        repo.load_config(config_path="unknown_keyword")
+
+
+@mark.parametrize("config_name", ["empty_group", "whitespace_group"])
+def test_missing_group_name_in_defaults_list(config_name: str) -> None:
+    repo = create_repo()
+    with raises(
+        ValueError,
+        match=re.escape(f"In {config_name}: Missing group name in defaults list"),
+    ):
+        repo.load_config(config_path=config_name)
 
 
 @mark.parametrize(


### PR DESCRIPTION
## Summary

- Validate Defaults List prefix tokens against the known `optional` and
  `override` keywords.
- Reject unsupported keywords with the containing config path and offending
  token in the error.
- Preserve config groups literally named `optional` or `override`.
- Add regression coverage and a bugfix news fragment.

## Root cause

The Defaults List parser split group-default keys on spaces and always treated
the final token as the config group. It recognized known leading keywords but
silently discarded any unknown leading token, so a misspelling such as
`optioal dataset_model` composed `dataset_model` without reporting the typo.

## Test plan

- `.venv/bin/pytest -q tests/defaults_list`
- `.venv/bin/isort hydra/_internal/config_repository.py tests/defaults_list/test_defaults_list.py --check --diff`
- `.venv/bin/flake8 --jobs=1 --config .flake8 hydra/_internal/config_repository.py tests/defaults_list/test_defaults_list.py`
- `.venv/bin/pyrefly check --config pyproject.toml hydra/_internal/config_repository.py tests/defaults_list/test_defaults_list.py`

Fixes https://github.com/facebookresearch/hydra/issues/1951
