### PR TITLE
Fix glob sweeps with primary config search paths

### DIFF
--- a/hydra/_internal/config_loader_impl.py
+++ b/hydra/_internal/config_loader_impl.py
@@ -53,6 +53,7 @@ class ConfigLoaderImpl(ConfigLoader):
     ) -> None:
         self.config_search_path = config_search_path
         self.repository = ConfigRepository(config_search_path=config_search_path)
+        self._active_repository: Optional[IConfigRepository] = None
 
     @staticmethod
     def validate_sweep_overrides_legal(
@@ -143,6 +144,41 @@ class ConfigLoaderImpl(ConfigLoader):
         from_shell: bool = True,
         validate_sweep_overrides: bool = True,
     ) -> DictConfig:
+        return self._load_configuration(
+            config_name=config_name,
+            overrides=overrides,
+            run_mode=run_mode,
+            from_shell=from_shell,
+            validate_sweep_overrides=validate_sweep_overrides,
+            activate_config_repository=False,
+        )
+
+    def _load_configuration_with_active_repository(
+        self,
+        config_name: Optional[str],
+        overrides: List[str],
+        run_mode: RunMode,
+        from_shell: bool = True,
+        validate_sweep_overrides: bool = True,
+    ) -> DictConfig:
+        return self._load_configuration(
+            config_name=config_name,
+            overrides=overrides,
+            run_mode=run_mode,
+            from_shell=from_shell,
+            validate_sweep_overrides=validate_sweep_overrides,
+            activate_config_repository=True,
+        )
+
+    def _load_configuration(
+        self,
+        config_name: Optional[str],
+        overrides: List[str],
+        run_mode: RunMode,
+        from_shell: bool,
+        validate_sweep_overrides: bool,
+        activate_config_repository: bool,
+    ) -> DictConfig:
         try:
             return self._load_configuration_impl(
                 config_name=config_name,
@@ -150,6 +186,7 @@ class ConfigLoaderImpl(ConfigLoader):
                 run_mode=run_mode,
                 from_shell=from_shell,
                 validate_sweep_overrides=validate_sweep_overrides,
+                activate_config_repository=activate_config_repository,
             )
         except OmegaConfBaseException as e:
             raise ConfigCompositionException().with_traceback(sys.exc_info()[2]) from e
@@ -242,6 +279,7 @@ class ConfigLoaderImpl(ConfigLoader):
         run_mode: RunMode,
         from_shell: bool = True,
         validate_sweep_overrides: bool = True,
+        activate_config_repository: bool = False,
     ) -> DictConfig:
         from hydra import __version__, version
 
@@ -303,6 +341,9 @@ class ConfigLoaderImpl(ConfigLoader):
             cfg.hydra.job.name = JobRuntime().get("name")
 
         cfg.hydra.job.config_name = config_name
+
+        if activate_config_repository:
+            self._active_repository = caching_repo
 
         return cfg
 
@@ -588,6 +629,12 @@ class ConfigLoaderImpl(ConfigLoader):
         config_name: Optional[str] = None,
         overrides: Optional[List[str]] = None,
     ) -> List[str]:
+        if (
+            config_name is None
+            and overrides is None
+            and self._active_repository is not None
+        ):
+            return self._active_repository.get_group_options(group_name, results_filter)
         if overrides is None:
             overrides = []
         _, caching_repo = self._parse_overrides_and_create_caching_repo(
@@ -630,6 +677,8 @@ class ConfigLoaderImpl(ConfigLoader):
         return cfg
 
     def get_sources(self) -> List[ConfigSource]:
+        if self._active_repository is not None:
+            return self._active_repository.get_sources()
         return self.repository.get_sources()
 
     def compute_defaults_list(

--- a/hydra/_internal/hydra.py
+++ b/hydra/_internal/hydra.py
@@ -150,6 +150,7 @@ class Hydra:
             overrides=overrides,
             with_log_configuration=with_log_configuration,
             run_mode=RunMode.RUN,
+            activate_config_repository=True,
         )
         if cfg.hydra.mode is None:
             cfg.hydra.mode = RunMode.RUN
@@ -202,6 +203,7 @@ class Hydra:
             overrides=overrides,
             with_log_configuration=with_log_configuration,
             run_mode=RunMode.MULTIRUN,
+            activate_config_repository=True,
         )
 
         callbacks = Callbacks(cfg)
@@ -644,6 +646,7 @@ class Hydra:
         from_shell: bool = True,
         validate_sweep_overrides: bool = True,
         run_callback: bool = True,
+        activate_config_repository: bool = False,
     ) -> DictConfig:
         """
         :param config_name:
@@ -654,16 +657,28 @@ class Hydra:
         :param validate_sweep_overrides: True if sweep overrides should be validated
         :param run_callback: True if the on_compose_config callback should be called, generally should always
                              be True except for internal use cases
+        :param activate_config_repository: True to retain the effective repository on the invocation loader
         :return:
         """
 
-        cfg = self.config_loader.load_configuration(
-            config_name=config_name,
-            overrides=overrides,
-            run_mode=run_mode,
-            from_shell=from_shell,
-            validate_sweep_overrides=validate_sweep_overrides,
-        )
+        if activate_config_repository and isinstance(
+            self.config_loader, ConfigLoaderImpl
+        ):
+            cfg = self.config_loader._load_configuration_with_active_repository(
+                config_name=config_name,
+                overrides=overrides,
+                run_mode=run_mode,
+                from_shell=from_shell,
+                validate_sweep_overrides=validate_sweep_overrides,
+            )
+        else:
+            cfg = self.config_loader.load_configuration(
+                config_name=config_name,
+                overrides=overrides,
+                run_mode=run_mode,
+                from_shell=from_shell,
+                validate_sweep_overrides=validate_sweep_overrides,
+            )
         if with_log_configuration:
             configure_log(cfg.hydra.hydra_logging, cfg.hydra.verbose)
             global log

--- a/news/1942.bugfix
+++ b/news/1942.bugfix
@@ -1,0 +1,1 @@
+Make glob sweeps respect the primary config search path.

--- a/tests/test_apps/glob_searchpath/__init__.py
+++ b/tests/test_apps/glob_searchpath/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/tests/test_apps/glob_searchpath/conf/__init__.py
+++ b/tests/test_apps/glob_searchpath/conf/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved

--- a/tests/test_apps/glob_searchpath/conf/config.yaml
+++ b/tests/test_apps/glob_searchpath/conf/config.yaml
@@ -1,0 +1,3 @@
+hydra:
+  searchpath:
+    - pkg://hydra.test_utils.configs

--- a/tests/test_apps/glob_searchpath/my_app.py
+++ b/tests/test_apps/glob_searchpath/my_app.py
@@ -1,0 +1,13 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from omegaconf import DictConfig
+
+import hydra
+
+
+@hydra.main(version_base=None, config_path="conf", config_name="config")
+def my_app(cfg: DictConfig) -> None:
+    print(f"foo={cfg.foo}")
+
+
+if __name__ == "__main__":
+    my_app()

--- a/tests/test_basic_sweeper.py
+++ b/tests/test_basic_sweeper.py
@@ -98,3 +98,20 @@ def test_partial_failure(
         """).strip()
 
     assert_multiline_regex_search(expected_err_regex, err)
+
+
+def test_glob_uses_primary_config_searchpath(tmpdir: Any) -> None:
+    cmd = [
+        sys.executable,
+        "tests/test_apps/glob_searchpath/my_app.py",
+        "+group1@=glob(file*)",
+        f"hydra.sweep.dir={tmpdir}",
+        "hydra.job.chdir=False",
+        "--multirun",
+    ]
+    out, err = run_process(cmd=cmd, print_error=False, raise_exception=False)
+
+    assert err == ""
+    assert "Launching 2 jobs locally" in out
+    assert "foo=10" in out
+    assert "foo=20" in out

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -29,6 +29,7 @@ from hydra.errors import (
     OverrideParseException,
 )
 from hydra.test_utils.test_utils import chdir_hydra_root
+from hydra.types import RunMode
 
 chdir_hydra_root()
 
@@ -726,6 +727,37 @@ class TestConfigSearchPathOverride:
             ),
         ):
             compose(config_name=config_name, overrides=[override])
+
+    def test_compose_searchpath_does_not_change_active_repository(
+        self, init_configs: Any
+    ) -> None:
+        gh = GlobalHydra.instance()
+        assert gh.hydra is not None
+        cfg = gh.hydra.compose_config(
+            config_name="with_sp",
+            overrides=["+group1=file1"],
+            run_mode=RunMode.RUN,
+            from_shell=False,
+            activate_config_repository=True,
+        )
+        assert cfg.foo == 10
+
+        config_loader = gh.hydra.config_loader
+        options = config_loader.get_group_options("group1")
+        sources = [
+            (source.provider, source.path) for source in config_loader.get_sources()
+        ]
+        assert options == ["abc.cde", "file1", "file2"]
+        assert (
+            "hydra.searchpath in main",
+            "hydra.test_utils.configs",
+        ) in sources
+
+        assert compose(config_name="without_sp") == {}
+        assert config_loader.get_group_options("group1") == options
+        assert [
+            (source.provider, source.path) for source in config_loader.get_sources()
+        ] == sources
 
 
 def test_deprecated_compose(hydra_restore_singletons: Any) -> None:


### PR DESCRIPTION

Retain the effective config repository for application run and multirun composition so glob sweeps enumerate options from the primary config search path. Keep ad hoc Compose API calls isolated from the active application repository.

Add end-to-end glob coverage, Compose isolation coverage, and a news fragment.

Fixes #1942
