### PR TITLE
Fix broken Binder link in Jupyter notebooks doc

### DIFF
--- a/news/2149.docs
+++ b/news/2149.docs
@@ -1,0 +1,1 @@
+Fix broken Binder link in the Jupyter notebooks documentation page.

--- a/website/docs/advanced/jupyter_notebooks.md
+++ b/website/docs/advanced/jupyter_notebooks.md
@@ -7,5 +7,5 @@ Hydra supports config composition inside Jupyter notebooks via the [Compose API]
 
 Run the Notebook in a the Binder to see a live demo, or open the Notebook source on GitHub.
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/facebookresearch/hydra/main?filepath=examples%2jupyter_notebooks)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/facebookresearch/hydra/main?filepath=examples%2Fjupyter_notebooks)
 [![Notebook source](https://img.shields.io/badge/-Notebooks%20source-informational)](https://github.com/facebookresearch/hydra//tree/main/examples/jupyter_notebooks/)


### PR DESCRIPTION
The Binder badge link on the Jupyter notebooks doc page points to a broken URL. The `filepath` query parameter has `%2` where it should have `%2F` (the URL-encoded `/`), so it resolves to a nonexistent path instead of `examples/jupyter_notebooks`.

This fixes the encoding so the link points to the correct directory.

Fixes #2149