### PR TITLE
Fix Defaults List interpolation for relocated groups

### DIFF
--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -337,7 +337,7 @@ def _check_not_missing(
     return False
 
 
-def _create_interpolation_map(
+def _create_legacy_interpolation_map(
     overrides: Overrides,
     defaults_list: List[InputDefault],
     self_added: bool,
@@ -585,7 +585,13 @@ def _create_defaults_tree_impl(
                 add_child(children, new_root)
 
     # processed deferred interpolations
-    known_choices = _create_interpolation_map(overrides, defaults_list, self_added)
+    known_choices = OmegaConf.create(overrides.known_choices)
+    # TODO: Remove Hydra 1.1 compatibility in
+    # https://github.com/facebookresearch/hydra/issues/3221.
+    if not version.base_at_least("1.2"):
+        known_choices = _create_legacy_interpolation_map(
+            overrides, defaults_list, self_added
+        )
 
     for idx, dd in enumerate(children):
         if isinstance(dd, InputDefault) and dd.is_interpolation():

--- a/hydra/core/default_element.py
+++ b/hydra/core/default_element.py
@@ -11,6 +11,9 @@ from hydra import version
 from hydra._internal.deprecation_warning import deprecation_warning
 from hydra.errors import ConfigCompositionException
 
+_defaults_list_interpolation_pattern: Pattern[str] = re.compile(r"\${\s*([^{}]*?)\s*}")
+_legacy_interpolation_pattern: Pattern[str] = re.compile(r"\${defaults\.\d+\.")
+
 
 @dataclass
 class ResultDefault:
@@ -230,13 +233,30 @@ class InputDefault:
     def _resolve_interpolation_impl(
         self, known_choices: DictConfig, val: Optional[str]
     ) -> str:
-        node = OmegaConf.create({"_dummy_": val})
-        node._set_parent(known_choices)
-        try:
-            ret = node["_dummy_"]
-            assert isinstance(ret, str)
-            return ret
-        except InterpolationResolutionError:
+        assert val is not None
+
+        if not version.base_at_least("1.2") and re.search(
+            _legacy_interpolation_pattern, val
+        ):
+            node = OmegaConf.create({"_dummy_": val})
+            node._set_parent(known_choices)
+            try:
+                resolved = node["_dummy_"]
+                assert isinstance(resolved, str)
+                return resolved
+            except InterpolationResolutionError:
+                pass
+
+        def replace(match: re.Match[str]) -> str:
+            key = match.group(1).strip()
+            if key in known_choices:
+                choice = known_choices[key]
+                if isinstance(choice, str):
+                    return choice
+            return match.group(0)
+
+        ret = _defaults_list_interpolation_pattern.sub(replace, val)
+        if "${" in ret:
             options = [
                 x
                 for x in known_choices.keys()
@@ -248,6 +268,8 @@ class InputDefault:
             else:
                 msg = f"Error resolving interpolation '{val}'"
             raise ConfigCompositionException(msg)
+
+        return ret
 
     def get_override_key(self) -> str:
         default_pkg = self.get_default_package()
@@ -437,9 +459,6 @@ class ConfigDefault(InputDefault):
         return False
 
 
-_legacy_interpolation_pattern: Pattern[str] = re.compile(r"\${defaults\.\d\.")
-
-
 @dataclass(repr=False)
 class GroupDefault(InputDefault):
     # config group name if present
@@ -543,16 +562,14 @@ class GroupDefault(InputDefault):
     def resolve_interpolation(self, known_choices: DictConfig) -> None:
         name = self.get_name()
         if name is not None:
-            if re.match(_legacy_interpolation_pattern, name) is not None:
+            if re.search(_legacy_interpolation_pattern, name) is not None:
                 msg = dedent(
                     f"""
 Defaults list element '{self.get_override_key()}={name}' is using a deprecated interpolation form.
 See http://hydra.cc/docs/1.1/upgrades/1.0_to_1.1/defaults_list_interpolation for migration information."""
                 )
                 if not version.base_at_least("1.2"):
-                    deprecation_warning(
-                        message=msg,
-                    )
+                    deprecation_warning(message=msg)
                 else:
                     raise ConfigCompositionException(msg)
 

--- a/news/1855.api_change
+++ b/news/1855.api_change
@@ -1,0 +1,1 @@
+Remove resolver interpolation from Defaults Lists.

--- a/news/1855.bugfix
+++ b/news/1855.bugfix
@@ -1,0 +1,1 @@
+Allow Defaults List interpolation to reference relocated config groups.

--- a/tests/defaults_list/data/interpolation_with_nested_package_override.yaml
+++ b/tests/defaults_list/data/interpolation_with_nested_package_override.yaml
@@ -1,0 +1,3 @@
+defaults:
+  - group1: group_item1_pkg2
+  - group2: ${ group1/group2@group1.pkg2 }

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -3,6 +3,7 @@ import re
 from textwrap import dedent
 from typing import Any, Dict, List, Optional
 
+from omegaconf import OmegaConf
 from pytest import mark, param, raises, warns
 
 from hydra import version
@@ -1914,6 +1915,44 @@ def test_placeholder(
             id="interpolation_with_package_override:override",
         ),
         param(
+            "interpolation_with_nested_package_override",
+            [],
+            DefaultsTreeNode(
+                node=ConfigDefault(path="interpolation_with_nested_package_override"),
+                children=[
+                    DefaultsTreeNode(
+                        node=GroupDefault(group="group1", value="group_item1_pkg2"),
+                        children=[
+                            GroupDefault(group="group2", value="file1", package="pkg2"),
+                            ConfigDefault(path="_self_"),
+                        ],
+                    ),
+                    GroupDefault(group="group2", value="file1"),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="interpolation_with_nested_package_override",
+        ),
+        param(
+            "interpolation_with_nested_package_override",
+            ["group1/group2@group1.pkg2=file2"],
+            DefaultsTreeNode(
+                node=ConfigDefault(path="interpolation_with_nested_package_override"),
+                children=[
+                    DefaultsTreeNode(
+                        node=GroupDefault(group="group1", value="group_item1_pkg2"),
+                        children=[
+                            GroupDefault(group="group2", value="file2", package="pkg2"),
+                            ConfigDefault(path="_self_"),
+                        ],
+                    ),
+                    GroupDefault(group="group2", value="file2"),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="interpolation_with_nested_package_override:override",
+        ),
+        param(
             "interpolation_with_nested_defaults_list",
             [],
             DefaultsTreeNode(
@@ -1994,18 +2033,12 @@ def test_placeholder(
         param(
             "interpolation_resolver_in_nested",
             [],
-            DefaultsTreeNode(
-                node=ConfigDefault(path="interpolation_resolver_in_nested"),
-                children=[
-                    DefaultsTreeNode(
-                        node=GroupDefault(group="group1", value="resolver"),
-                        children=[
-                            GroupDefault(group="group2", value="file1"),
-                            ConfigDefault(path="_self_"),
-                        ],
-                    ),
-                    ConfigDefault(path="_self_"),
-                ],
+            raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Error resolving interpolation '${oc.decode:file1}', "
+                    "possible interpolation keys: group1"
+                ),
             ),
             id="interpolation_resolver_in_nested",
         ),
@@ -2151,6 +2184,32 @@ def test_legacy_interpolation(
             input_overrides=overrides,
             expected=expected,
         )
+
+
+def test_legacy_interpolation_multi_digit_index(
+    hydra_restore_singletons: Any,
+) -> None:
+    msg = dedent(
+        """
+    Defaults list element 'target=.*' is using a deprecated interpolation form.
+    See http://hydra.cc/docs/1.1/upgrades/1.0_to_1.1/defaults_list_interpolation for migration information."""
+    )
+    known_choices = OmegaConf.create(
+        {"defaults": [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {"group": "file1"}]}
+    )
+
+    version.setbase("1.1")
+    default = GroupDefault(group="target", value="${defaults.10.group}")
+    default.update_parent("", "")
+    with warns(expected_warning=UserWarning, match=msg):
+        default.resolve_interpolation(known_choices)
+    assert default.value == "file1"
+
+    version.setbase("1.2")
+    default = GroupDefault(group="target", value="${defaults.10.group}")
+    default.update_parent("", "")
+    with raises(ConfigCompositionException, match=msg):
+        default.resolve_interpolation(known_choices)
 
 
 @mark.parametrize(

--- a/website/docs/advanced/defaults_list.md
+++ b/website/docs/advanced/defaults_list.md
@@ -223,6 +223,7 @@ e.g., If *db* is overridden to *sqlite*, *combination_specific_config* will beco
 
  - Interpolation keys in the Defaults List cannot reference values in the Final Config Object (it does not yet exist).
  - Defaults List interpolation keys are absolute (even in nested configs).
+ - OmegaConf resolvers are not supported in Defaults List interpolation.
  - The subtree expanded by an Interpolated Config may not contain Default List overrides.
 
 See [Patterns/Specializing Configs](/patterns/specializing_config.md) for more information.


### PR DESCRIPTION
Resolve Defaults List interpolation keys with direct known-choice lookup so nested group paths and package overrides work. Reject resolver interpolation while retaining the Hydra 1.1 positional form behind an explicit compatibility gate. Document the supported surface and add regression coverage and news fragments.

The broader removal of legacy compatibility paths is tracked in https://github.com/facebookresearch/hydra/issues/3221.

Closes https://github.com/facebookresearch/hydra/issues/1855
