### PR TITLE
Fix missing _self_ warnings in examples

### DIFF
--- a/examples/advanced/nested_defaults_list/conf/config.yaml
+++ b/examples/advanced/nested_defaults_list/conf/config.yaml
@@ -1,4 +1,5 @@
 defaults:
   - server/apache
+  - _self_
 
 debug: false

--- a/examples/advanced/ray_example/conf/config.yaml
+++ b/examples/advanced/ray_example/conf/config.yaml
@@ -1,6 +1,7 @@
 defaults:
   - dataset: imagenet
   - model: alexnet
+  - _self_
 
 ray:
   init:

--- a/news/1781.maintenance
+++ b/news/1781.maintenance
@@ -1,0 +1,1 @@
+Remove missing `_self_` warnings from example configurations.

--- a/tests/test_examples/test_advanced_defaults_lists.py
+++ b/tests/test_examples/test_advanced_defaults_lists.py
@@ -1,0 +1,42 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from pathlib import Path
+from typing import Any
+
+from omegaconf import OmegaConf
+from pytest import MonkeyPatch
+
+from hydra import compose, initialize_config_dir
+from hydra.test_utils.test_utils import chdir_hydra_root, run_python_script
+
+chdir_hydra_root()
+
+
+def test_nested_defaults_list(tmpdir: Path) -> None:
+    result, stderr = run_python_script(
+        [
+            "examples/advanced/nested_defaults_list/my_app.py",
+            f'hydra.run.dir="{tmpdir}"',
+            "hydra.job.chdir=True",
+        ]
+    )
+
+    assert stderr == ""
+    assert OmegaConf.create(result) == {
+        "server": {"db": {"name": "mysql"}, "name": "apache"},
+        "debug": False,
+    }
+
+
+def test_ray_example_config(
+    hydra_restore_singletons: Any, monkeypatch: MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SELF_WARNING_AS_ERROR", "1")
+    config_dir = Path("examples/advanced/ray_example/conf").absolute()
+    with initialize_config_dir(version_base=None, config_dir=str(config_dir)):
+        cfg = compose(config_name="config")
+
+    assert cfg == {
+        "dataset": {"name": "imagenet", "path": "/datasets/imagenet"},
+        "model": {"type": "alexnet", "num_layers": 7},
+        "ray": {"init": {"num_cpus": 4}},
+    }


### PR DESCRIPTION

Add explicit _self_ entries to the nested Defaults List and Ray example primary configs while preserving their composition order.

Add regression coverage for both example configurations and a maintenance news fragment.

Closes #1781
