### PR TITLE
Support OmegaConf tuple configurations

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -374,22 +374,31 @@ def _get_target_name_for_check(target: Union[str, type, Callable[..., Any]]) -> 
     return f"{target_type.__module__}.{target_type.__qualname__}"
 
 
-def _prepare_input_dict_or_list(d: Union[Dict[Any, Any], List[Any]]) -> Any:
+def _prepare_input_container(
+    d: Union[Dict[Any, Any], List[Any], Tuple[Any, ...]],
+) -> Any:
     res: Any
     if isinstance(d, dict):
         res = {}
         for k, v in d.items():
             if k == "_target_":
                 v = _convert_target_to_string(d["_target_"])
-            elif isinstance(v, (dict, list)):
-                v = _prepare_input_dict_or_list(v)
+            elif isinstance(v, (dict, list)) or type(v) is tuple:
+                v = _prepare_input_container(v)
             res[k] = v
     elif isinstance(d, list):
         res = []
         for v in d:
-            if isinstance(v, (list, dict)):
-                v = _prepare_input_dict_or_list(v)
+            if isinstance(v, (list, dict)) or type(v) is tuple:
+                v = _prepare_input_container(v)
             res.append(v)
+    elif type(d) is tuple:
+        res = tuple(
+            _prepare_input_container(v)
+            if isinstance(v, (dict, list)) or type(v) is tuple
+            else v
+            for v in d
+        )
     else:
         assert False
     return res
@@ -460,9 +469,9 @@ def _deep_copy_full_config(subconfig: Any) -> Any:
         return copy.deepcopy(subconfig)
     full_key = str(full_key)
 
-    if OmegaConf.is_list(subconfig._get_parent()):
+    if OmegaConf.is_sequence(subconfig._get_parent()):
         # OmegaConf has a bug where _get_full_key doesn't add [] if the parent
-        # is a list, eg. instead of foo[0], it'll return foo0
+        # is a sequence, eg. instead of foo[0], it'll return foo0
         index = subconfig._key()
         full_key = full_key[: -len(str(index))] + f"[{index}]"
     root = subconfig._get_root()
@@ -497,15 +506,18 @@ def instantiate(
                                 may be overridden via a _recursive_ key in
                                 the kwargs
                    _convert_: Conversion strategy
-                        none    : Passed objects are DictConfig and ListConfig, default
-                        partial : Passed objects are converted to dict and list, with
-                                  the exception of Structured Configs (and their fields).
-                        object  : Passed objects are converted to dict and list.
+                        none    : Passed objects are DictConfig, ListConfig and
+                                  TupleConfig, default
+                        partial : Passed objects are converted to dict, list and
+                                  tuple, with the exception of Structured Configs
+                                  (and their fields).
+                        object  : Passed objects are converted to dict, list and tuple.
                                   Structured Configs are converted to instances of the
                                   backing dataclass / attr class.
-                        all     : Passed objects are dicts, lists and primitives without
-                                  a trace of OmegaConf containers. Structured configs
-                                  are converted to dicts / lists too.
+                        all     : Passed objects are dicts, lists, tuples and
+                                  primitives without a trace of OmegaConf containers.
+                                  Structured configs are converted to primitive
+                                  containers too.
                    _partial_: If True, return functools.partial wrapped method or object
                               False by default. Configure per target.
     :param _skip_instantiate_full_deepcopy_: If True, deep copy just the input config instead
@@ -546,13 +558,17 @@ def instantiate(
         )
         # TODO: print full key
 
-    if isinstance(config, (dict, list)):
-        config = _prepare_input_dict_or_list(config)
+    if isinstance(config, (dict, list)) or type(config) is tuple:
+        config = _prepare_input_container(config)
 
-    kwargs = _prepare_input_dict_or_list(kwargs)
+    kwargs = _prepare_input_container(kwargs)
 
     # Structured Config always converted first to OmegaConf
-    if is_structured_config(config) or isinstance(config, (dict, list)):
+    if (
+        is_structured_config(config)
+        or isinstance(config, (dict, list))
+        or type(config) is tuple
+    ):
         config = OmegaConf.structured(config, flags={"allow_objects": True})
 
     if OmegaConf.is_dict(config):
@@ -585,7 +601,7 @@ def instantiate(
             partial=_partial_,
             target_whitelist=target_whitelist,
         )
-    elif OmegaConf.is_list(config):
+    elif OmegaConf.is_sequence(config):
         # Finalize config (convert targets to strings, merge with kwargs)
         # Create copy to avoid mutating original
         if _skip_instantiate_full_deepcopy_:
@@ -605,8 +621,10 @@ def instantiate(
         _partial_ = kwargs.pop(_Keys.PARTIAL, False)
 
         if _partial_:
+            sequence_type = "tuple" if OmegaConf.is_tuple(config) else "list"
             raise InstantiationException(
-                "The _partial_ keyword is not compatible with top-level list instantiation"
+                "The _partial_ keyword is not compatible with "
+                f"top-level {sequence_type} instantiation"
             )
 
         return instantiate_node(
@@ -621,8 +639,8 @@ def instantiate(
         raise InstantiationException(
             dedent(f"""\
                 Cannot instantiate config of type {type(config).__name__}.
-                Top level config must be an OmegaConf DictConfig/ListConfig object,
-                a plain dict/list, or a Structured Config class or instance.""")
+                Top level config must be an OmegaConf DictConfig/ListConfig/TupleConfig object,
+                a plain dict/list/tuple, or a Structured Config class or instance.""")
         )
 
 
@@ -684,8 +702,9 @@ def instantiate_node(
             msg += f"\nfull_key: {full_key}"
         raise TypeError(msg)
 
-    # If OmegaConf list, create new list of instances if recursive
-    if OmegaConf.is_list(node):
+    # If OmegaConf sequence, create a new sequence of instances if recursive
+    if OmegaConf.is_sequence(node):
+        is_tuple = OmegaConf.is_tuple(node)
         items = [
             instantiate_node(
                 item,
@@ -697,15 +716,21 @@ def instantiate_node(
         ]
 
         if convert in (ConvertMode.ALL, ConvertMode.PARTIAL, ConvertMode.OBJECT):
-            # If ALL or PARTIAL or OBJECT, use plain list as container
-            return items
+            # If ALL or PARTIAL or OBJECT, use a plain sequence container
+            return tuple(items) if is_tuple else items
         else:
-            # Otherwise, use ListConfig as container
-            lst = OmegaConf.create([], flags={"allow_objects": True})
-            for item in items:
-                lst.append(_wrap_structured_config_as_object(item))
-            lst._set_parent(node)
-            return lst
+            # Otherwise, use the matching OmegaConf sequence container
+            if is_tuple:
+                seq = OmegaConf.create(
+                    tuple(_wrap_structured_config_as_object(item) for item in items),
+                    flags={"allow_objects": True},
+                )
+            else:
+                seq = OmegaConf.create([], flags={"allow_objects": True})
+                for item in items:
+                    seq.append(_wrap_structured_config_as_object(item))
+            seq._set_parent(node)
+            return seq
 
     elif OmegaConf.is_dict(node):
         if _Keys.TARGET_WHITELIST in node:

--- a/news/3287.feature
+++ b/news/3287.feature
@@ -1,0 +1,1 @@
+Add instantiate support for OmegaConf tuple configurations.

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,1 +1,1 @@
-omegaconf>=2.4.0.dev12
+omegaconf>=2.4.0.dev13

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -16,6 +16,7 @@ from omegaconf import (
     ListConfig,
     MissingMandatoryValue,
     OmegaConf,
+    TupleConfig,
 )
 from pytest import fixture, mark, param, raises, warns
 
@@ -672,18 +673,33 @@ def test_class_instantiate_omegaconf_node(instantiate_func: Any, config: Any) ->
 @mark.parametrize(
     "src",
     [
-        ListConfig(
-            [
-                {
-                    "_target_": "tests.instantiate.AClass",
-                    "b": 200,
-                    "c": {"x": 10, "y": "${0.b}"},
-                }
-            ]
-        )
+        param(
+            ListConfig(
+                [
+                    {
+                        "_target_": "tests.instantiate.AClass",
+                        "b": 200,
+                        "c": {"x": 10, "y": "${0.b}"},
+                    }
+                ]
+            ),
+            id="list",
+        ),
+        param(
+            OmegaConf.create(
+                (
+                    {
+                        "_target_": "tests.instantiate.AClass",
+                        "b": 200,
+                        "c": {"x": 10, "y": "${0.b}"},
+                    },
+                )
+            ),
+            id="tuple",
+        ),
     ],
 )
-def test_class_instantiate_list_item(instantiate_func: Any, config: Any) -> Any:
+def test_class_instantiate_sequence_item(instantiate_func: Any, config: Any) -> Any:
     obj = instantiate_func(config[0], a=10, d=AnotherClass(99))
     assert obj == AClass(a=10, b=200, c={"x": 10, "y": 200}, d=AnotherClass(99))
     assert OmegaConf.is_config(obj.c)
@@ -750,7 +766,8 @@ def test_instantiate_adam_conf(
     else:
         assert res.params == expected.params
     assert res.lr == expected.lr
-    assert list(res.betas) == list(expected.betas)  # OmegaConf converts tuples to lists
+    assert isinstance(res.betas, TupleConfig)
+    assert res.betas == expected.betas
     assert res.eps == expected.eps
     assert res.weight_decay == expected.weight_decay
     assert res.amsgrad == expected.amsgrad
@@ -762,8 +779,8 @@ def test_instantiate_adam_conf_with_convert(instantiate_func: Any) -> None:
     expected = Adam(lr=0.123, params=adam_params)
     assert res.params == expected.params
     assert res.lr == expected.lr
-    assert isinstance(res.betas, list)
-    assert list(res.betas) == list(expected.betas)  # OmegaConf converts tuples to lists
+    assert isinstance(res.betas, tuple)
+    assert res.betas == expected.betas
     assert res.eps == expected.eps
     assert res.weight_decay == expected.weight_decay
     assert res.amsgrad == expected.amsgrad
@@ -852,15 +869,72 @@ def test_instantiate_target_raising_exception_taking_no_arguments_nested(
         instantiate_func({"foo": {"_target_": _target_}})
 
 
-def test_toplevel_list_partial_not_allowed(instantiate_func: Any) -> None:
-    config = [{"_target_": "tests.instantiate.ClassA", "a": 10, "b": 20, "c": 30}]
+@mark.parametrize(
+    ("config", "sequence_type"),
+    [
+        param(
+            [{"_target_": "tests.instantiate.AClass", "a": 10, "b": 20, "c": 30}],
+            "list",
+            id="list",
+        ),
+        param(
+            ({"_target_": "tests.instantiate.AClass", "a": 10, "b": 20, "c": 30},),
+            "tuple",
+            id="tuple",
+        ),
+    ],
+)
+def test_toplevel_sequence_partial_not_allowed(
+    instantiate_func: Any, config: Any, sequence_type: str
+) -> None:
     with raises(
         InstantiationException,
         match=re.escape(
-            "The _partial_ keyword is not compatible with top-level list instantiation"
+            "The _partial_ keyword is not compatible with "
+            f"top-level {sequence_type} instantiation"
         ),
     ):
         instantiate_func(config, _partial_=True)
+
+
+@mark.parametrize(
+    "config",
+    [
+        param(
+            ({"_target_": "tests.instantiate.AClass", "a": 10, "b": 20, "c": 30},),
+            id="native",
+        ),
+        param(
+            OmegaConf.create(
+                (
+                    {
+                        "_target_": "tests.instantiate.AClass",
+                        "a": 10,
+                        "b": 20,
+                        "c": 30,
+                    },
+                )
+            ),
+            id="tuple-config",
+        ),
+    ],
+)
+@mark.parametrize(
+    ("convert", "expected_type"),
+    [
+        param(ConvertMode.NONE, TupleConfig, id="none"),
+        param(ConvertMode.PARTIAL, tuple, id="partial"),
+        param(ConvertMode.OBJECT, tuple, id="object"),
+        param(ConvertMode.ALL, tuple, id="all"),
+    ],
+)
+def test_instantiate_toplevel_tuple(
+    instantiate_func: Any, config: Any, convert: ConvertMode, expected_type: Any
+) -> None:
+    result = instantiate_func(config, _convert_=convert)
+
+    assert isinstance(result, expected_type)
+    assert result[0] == AClass(a=10, b=20, c=30)
 
 
 @mark.parametrize("is_partial", [True, False])
@@ -2255,6 +2329,26 @@ def test_instantiated_regular_class_container_types(
     assert isinstance(ret.b[0].b, expected_list)
 
 
+@mark.parametrize(
+    ("mode", "expected_tuple"),
+    [
+        param(ConvertMode.NONE, TupleConfig, id="none"),
+        param(ConvertMode.ALL, tuple, id="all"),
+        param(ConvertMode.PARTIAL, tuple, id="partial"),
+        param(ConvertMode.OBJECT, tuple, id="object"),
+    ],
+)
+def test_instantiated_regular_class_tuple_type(
+    instantiate_func: Any, mode: Any, expected_tuple: Any
+) -> None:
+    cfg = {"_target_": "tests.instantiate.SimpleClass", "a": (1, 2), "b": None}
+
+    ret = instantiate_func(cfg, _convert_=mode)
+
+    assert isinstance(ret.a, expected_tuple)
+    assert ret.a == (1, 2)
+
+
 def test_instantiated_regular_class_container_types_partial(
     instantiate_func: Any,
 ) -> None:
@@ -2329,7 +2423,11 @@ def test_nested_dataclass_targets_remain_objects_with_convert_none(
     assert ret_list[0] == top
 
     ret = instantiate_func(
-        {"nested": dataclass_target, "items": [dataclass_target]},
+        {
+            "nested": dataclass_target,
+            "items": [dataclass_target],
+            "tuple_items": (dataclass_target,),
+        },
         _convert_=ConvertMode.NONE,
     )
     assert isinstance(ret, DictConfig)
@@ -2338,6 +2436,9 @@ def test_nested_dataclass_targets_remain_objects_with_convert_none(
     assert isinstance(ret["items"], ListConfig)
     assert isinstance(ret["items"][0], SimpleDataClass)
     assert ret["items"][0] == top
+    assert isinstance(ret["tuple_items"], TupleConfig)
+    assert isinstance(ret["tuple_items"][0], SimpleDataClass)
+    assert ret["tuple_items"][0] == top
 
 
 @mark.parametrize(

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -18,6 +18,9 @@ Call/instantiate supports:
 - Constructing an object by calling the `__init__` method
 - Calling functions, static functions, class methods and other callable global objects
 
+Top-level list and tuple inputs are instantiated element by element. Partial
+instantiation is not supported for these sequence inputs.
+
 <details>
     <summary>Instantiate API (Expand for details)</summary>
 
@@ -34,15 +37,18 @@ Call/instantiate supports:
                                     may be overridden via a _recursive_ key in
                                     the kwargs
                        _convert_: Conversion strategy
-                            none    : Passed objects are DictConfig and ListConfig, default
-                            partial : Passed objects are converted to dict and list, with
-                                      the exception of Structured Configs (and their fields).
-                            object  : Passed objects are converted to dict and list.
+                            none    : Passed objects are DictConfig, ListConfig and
+                                      TupleConfig, default
+                            partial : Passed objects are converted to dict, list and
+                                      tuple, with the exception of Structured Configs
+                                      (and their fields).
+                            object  : Passed objects are converted to dict, list and tuple.
                                       Structured Configs are converted to instances of the
                                       backing dataclass / attr class.
-                            all     : Passed objects are dicts, lists and primitives without
-                                      a trace of OmegaConf containers. Structured configs
-                                      are converted to dicts / lists too.
+                            all     : Passed objects are dicts, lists, tuples and
+                                      primitives without a trace of OmegaConf containers.
+                                      Structured configs are converted to primitive
+                                      containers too.
                        _partial_: If True, return functools.partial wrapped method or object
                                   False by default. Configure per target.
         :param _target_whitelist_: A target string, list of target strings,
@@ -304,27 +310,28 @@ Trainer(
 
 ### Parameter conversion strategies
 By default, the parameters passed to the target are either primitives (int,
-float, bool etc) or OmegaConf containers (`DictConfig`, `ListConfig`).
-OmegaConf containers have many advantages over primitive dicts and lists,
+float, bool etc) or OmegaConf containers (`DictConfig`, `ListConfig`,
+`TupleConfig`). OmegaConf containers have many advantages over primitive dicts,
+lists, and tuples,
 including convenient attribute access for keys,
 [duck-typing as instances of dataclasses or attrs classes](https://omegaconf.readthedocs.io/en/latest/structured_config.html), and
 support for [variable interpolation](https://omegaconf.readthedocs.io/en/latest/usage.html#variable-interpolation)
 and [custom resolvers](https://omegaconf.readthedocs.io/en/latest/custom_resolvers.html).
 If the callable targeted by `instantiate` leverages OmegaConf's features, it
-will make sense to pass `DictConfig` and `ListConfig` instances directly to
-that callable.
+will make sense to pass `DictConfig`, `ListConfig`, and `TupleConfig` instances
+directly to that callable.
 
 That being said, in many cases it's desired to pass normal Python dicts and
-lists, rather than `DictConfig` or `ListConfig` instances, as arguments to your
-callable. You can change instantiate's argument conversion strategy using the
-`_convert_` parameter. Supported values are:
+lists and tuples, rather than `DictConfig`, `ListConfig`, or `TupleConfig`
+instances, as arguments to your callable. You can change instantiate's argument
+conversion strategy using the `_convert_` parameter. Supported values are:
 
 - `"none"` : Default behavior, Use OmegaConf containers
-- `"partial"` : Convert OmegaConf containers to dict and list, except
+- `"partial"` : Convert OmegaConf containers to dict, list, and tuple, except
   Structured Configs, which remain as DictConfig instances.
-- `"object"` : Convert OmegaConf containers to dict and list, except Structured
-  Configs, which are converted to instances of the backing dataclass / attr
-  class using `OmegaConf.to_object`.
+- `"object"` : Convert OmegaConf containers to dict, list, and tuple, except
+  Structured Configs, which are converted to instances of the backing dataclass
+  / attr class using `OmegaConf.to_object`.
 - `"all"` : Convert everything to primitive containers
 
 The conversion strategy applies recursively to all subconfigs of the instantiation target.


### PR DESCRIPTION

Handle TupleConfig throughout instantiate while preserving tuple containers across conversion modes and top-level sequence inputs.

Raise the OmegaConf minimum to 2.4.0.dev13, document tuple conversion behavior, and add regression coverage and a news fragment.

Closes #3287
