### PR TITLE
Deprecate unreleased JSON override helpers

### DIFF
--- a/hydra/_internal/grammar/grammar_functions.py
+++ b/hydra/_internal/grammar/grammar_functions.py
@@ -6,6 +6,7 @@ import random
 from copy import copy
 from typing import Any, Callable, Dict, List, Optional, Union
 
+from hydra._internal.deprecation_warning import deprecation_warning
 from hydra._internal.grammar.utils import is_type_matching
 from hydra.core.override_parser.types import (
     ChoiceSweep,
@@ -158,6 +159,11 @@ def extract_text(*args: Any, value: Optional[Any] = None) -> Any:
 
 
 def cast_json_str(*args: Any, value: Optional[Any] = None) -> Any:
+    deprecation_warning(
+        "json_str(...) is deprecated and will be removed in Hydra 1.5. "
+        "See https://github.com/facebookresearch/hydra/pull/2930#issuecomment-5018616929",
+        stacklevel=2,
+    )
     value = _normalize_cast_value(*args, value=value)
     json_val = value
     if isinstance(value, QuotedString):

--- a/hydra/utils.py
+++ b/hydra/utils.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 import hydra._internal.instantiate._instantiate2
 import hydra.types
+from hydra._internal.deprecation_warning import deprecation_warning
 from hydra._internal.utils import _locate
 from hydra.core.hydra_config import HydraConfig
 
@@ -122,31 +123,34 @@ def to_absolute_path(path: str) -> str:
     return str(ret)
 
 
-def to_hydra_override_value_str(obj: Any) -> str:
-    """
-    Basic conversion of an object to a string that can be used in a Hydra override.
-    Does not explicitly support all types but should work for basic structures.
-
-    >>> obj = {"foo": 1, "bar": "baz"}
-    >>> compose(config_name="config", overrides=[f"a={to_hydra_override_value_str(obj)}", "x=1"])
-
-    :param obj: object to convert
-    :return: string representation of the object that can be used in a Hydra override
-    """
+def _to_hydra_override_value_str(obj: Any) -> str:
     if isinstance(obj, dict):
         return (
             "{"
             + ", ".join(
-                f"{key}: {to_hydra_override_value_str(value)}"
+                f"{key}: {_to_hydra_override_value_str(value)}"
                 for key, value in obj.items()
             )
             + "}"
         )
     elif isinstance(obj, list):
         return (
-            "[" + ", ".join([to_hydra_override_value_str(value) for value in obj]) + "]"
+            "["
+            + ", ".join([_to_hydra_override_value_str(value) for value in obj])
+            + "]"
         )
     elif isinstance(obj, str):
         new_str = obj.replace('\\"', '\\\\"').replace('"', '\\"')
         return f'"{new_str}"'
     return json.dumps(obj)
+
+
+def to_hydra_override_value_str(obj: Any) -> str:
+    """Deprecated basic conversion of an object to a Hydra override value string."""
+    deprecation_warning(
+        "to_hydra_override_value_str() is deprecated and will be removed in "
+        "Hydra 1.5. See "
+        "https://github.com/facebookresearch/hydra/pull/2930#issuecomment-5018616929",
+        stacklevel=2,
+    )
+    return _to_hydra_override_value_str(obj)

--- a/news/2929.feature
+++ b/news/2929.feature
@@ -1,1 +1,0 @@
-Add json_str function to override syntax

--- a/news/2934.feature
+++ b/news/2934.feature
@@ -1,1 +1,0 @@
-Add to_hydra_override_value_str util function

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -2,6 +2,7 @@
 import builtins
 import math
 import re
+from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Union
 
@@ -40,6 +41,11 @@ from hydra.errors import HydraException
 UNQUOTED_SPECIAL = r"/-\+.$%*@?|"  # special characters allowed in unquoted strings
 
 parser = OverridesParser(create_functions())
+
+JSON_STR_DEPRECATION_WARNING = (
+    "json_str(...) is deprecated and will be removed in Hydra 1.5. "
+    "See https://github.com/facebookresearch/hydra/pull/2930#issuecomment-5018616929"
+)
 
 
 def parse_rule(value: str, rule_name: str) -> Any:
@@ -1982,12 +1988,18 @@ def test_cast_conversions(value: Any, expected_value: Any) -> None:
     for field in ("int", "float", "bool", "str", "json_str"):
         cast_str = f"{field}({value})"
         expected = getattr(expected_value, field)
-        if isinstance(expected, RaisesContext):
-            with expected:
-                parser.parse_rule(cast_str, "function")
-        else:
-            result = parser.parse_rule(cast_str, "function")
-            assert eq(result, expected), f"{field} cast result mismatch"
+        warning = (
+            warns(UserWarning, match=re.escape(JSON_STR_DEPRECATION_WARNING))
+            if field == "json_str"
+            else nullcontext()
+        )
+        with warning:
+            if isinstance(expected, RaisesContext):
+                with expected:
+                    parser.parse_rule(cast_str, "function")
+            else:
+                result = parser.parse_rule(cast_str, "function")
+                assert eq(result, expected), f"{field} cast result mismatch"
 
 
 @mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,7 +96,14 @@ def test_to_absolute_path_without_hydra(
 def test_to_hydra_override_value_str_roundtrip(
     hydra_restore_singletons: Any, obj: Any
 ) -> None:
-    override_str = utils.to_hydra_override_value_str(obj)
+    msg = (
+        "to_hydra_override_value_str() is deprecated and will be removed in "
+        "Hydra 1.5. See "
+        "https://github.com/facebookresearch/hydra/pull/2930#issuecomment-5018616929"
+    )
+    with warns(UserWarning, match=re.escape(msg)) as records:
+        override_str = utils.to_hydra_override_value_str(obj)
+    assert len(records) == 1
     override_params = f"++ov={override_str}"
     o = OverridesParser.create().parse_override(override_params)
     assert o.value() == obj

--- a/website/docs/advanced/override_grammar/extended.md
+++ b/website/docs/advanced/override_grammar/extended.md
@@ -227,8 +227,7 @@ shuffle([a,b,c]), shuffle(list=[a,b,c])              # shuffled list [a,b,c]
 ```
 
 ## Type casting
-You can cast values and sweeps to `int`, `float`, `bool`, `str` or `json_str`. Note that unlike the
-others, `json_str` will affect the whole container rather than just the values.
+You can cast values and sweeps to `int`, `float`, `bool` or `str`.
 ```python title="Example"
 int(3.14)                  # 3 (int)
 int(value=3.14)            # 3 (int)
@@ -238,7 +237,6 @@ bool(1)                    # true (bool)
 float(range(1,10))         # range(1.0,10.0)
 str([1,2,3])               # ['1','2','3']
 str({a:10})                # {a:'10'}
-json_str({a:10})           # '{"a":10}'
 ```
 
 Below are pseudo code snippets that illustrates the differences between Python's casting and Hydra's casting.


### PR DESCRIPTION

Deprecate json_str and to_hydra_override_value_str while preserving their behavior until Hydra 1.5.

Remove their feature documentation and unreleased news fragments. Cover the exact warnings and ensure recursive conversion warns once.
