### PR TITLE
Deprecate unreleased extend_list override

### DIFF
--- a/hydra/_internal/grammar/grammar_functions.py
+++ b/hydra/_internal/grammar/grammar_functions.py
@@ -441,6 +441,7 @@ def glob(
 
 def extend_list(*args: Any) -> ListExtensionOverrideValue:
     """
-    Extends an existing list in the config with the given values.
+    Deprecated in Hydra 1.4 and scheduled for removal in Hydra 1.5.
+    See https://github.com/facebookresearch/hydra/issues/3200.
     """
     return ListExtensionOverrideValue(values=list(args))

--- a/hydra/core/override_parser/overrides_visitor.py
+++ b/hydra/core/override_parser/overrides_visitor.py
@@ -11,6 +11,7 @@ from omegaconf.vendor.antlr4 import (  # type: ignore[attr-defined]
 from omegaconf.vendor.antlr4.error.ErrorListener import ErrorListener
 from omegaconf.vendor.antlr4.tree.Tree import TerminalNodeImpl
 
+from hydra._internal.deprecation_warning import deprecation_warning
 from hydra._internal.grammar.functions import FunctionCall, Functions
 from hydra._internal.grammar.utils import _ESC_QUOTED_STR
 from hydra.core.override_parser.types import (
@@ -196,6 +197,12 @@ class HydraOverrideVisitor(OverrideParserVisitor):
                             raise HydraException(
                                 "Trying to use override symbols when extending a list"
                             )
+                        deprecation_warning(
+                            "extend_list(...) is deprecated and will be removed in "
+                            "Hydra 1.5. See "
+                            "https://github.com/facebookresearch/hydra/issues/3200",
+                            stacklevel=2,
+                        )
                         override_type = OverrideType.EXTEND_LIST
                         value = value.values
 

--- a/news/1547.feature
+++ b/news/1547.feature
@@ -1,1 +1,0 @@
-Add extend_list function to override syntax

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -33,6 +33,11 @@ from hydra.types import RunMode
 
 chdir_hydra_root()
 
+EXTEND_LIST_DEPRECATION_WARNING = (
+    "extend_list(...) is deprecated and will be removed in Hydra 1.5. "
+    "See https://github.com/facebookresearch/hydra/issues/3200"
+)
+
 
 @fixture
 def initialize_hydra(config_path: Optional[str]) -> Any:
@@ -493,8 +498,12 @@ def test_extending_list(
     ConfigStore.instance().store(name="config", node=Config)
 
     if isinstance(expected, dict):
-        cfg = compose(config_name="config", overrides=overrides)
+        with warns(
+            UserWarning, match=re.escape(EXTEND_LIST_DEPRECATION_WARNING)
+        ) as records:
+            cfg = compose(config_name="config", overrides=overrides)
         assert cfg == expected
+        assert len(records) == len(overrides)
     else:
         with expected:
             compose(config_name="config", overrides=overrides)

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -47,6 +47,11 @@ JSON_STR_DEPRECATION_WARNING = (
     "See https://github.com/facebookresearch/hydra/pull/2930#issuecomment-5018616929"
 )
 
+EXTEND_LIST_DEPRECATION_WARNING = (
+    "extend_list(...) is deprecated and will be removed in Hydra 1.5. "
+    "See https://github.com/facebookresearch/hydra/issues/3200"
+)
+
 
 def parse_rule(value: str, rule_name: str) -> Any:
     return parser.parse_rule(value, rule_name)
@@ -1054,14 +1059,15 @@ def test_list_extend_override(
     expected_key: str,
     expected_value: Any,
 ) -> None:
-    test_override(
-        "",
-        value,
-        OverrideType.EXTEND_LIST,
-        expected_key,
-        expected_value,
-        ValueType.ELEMENT,
-    )
+    with warns(UserWarning, match=re.escape(EXTEND_LIST_DEPRECATION_WARNING)):
+        test_override(
+            "",
+            value,
+            OverrideType.EXTEND_LIST,
+            expected_key,
+            expected_value,
+            ValueType.ELEMENT,
+        )
 
 
 def test_deprecated_name_package(hydra_restore_singletons: Any) -> None:

--- a/website/docs/advanced/override_grammar/basic.md
+++ b/website/docs/advanced/override_grammar/basic.md
@@ -237,7 +237,7 @@ foo=[1,2,3]
 nested=[a,[b,[c]]]
 ```
 
-Lists are assigned, not merged. To extend an existing list, use the [`extend_list` function](extended.md#extending-lists).
+Lists are assigned, not merged.
 
 ### Dictionaries
 ```python

--- a/website/docs/advanced/override_grammar/extended.md
+++ b/website/docs/advanced/override_grammar/extended.md
@@ -134,46 +134,6 @@ tag(log,interval(0,1))          # 1.0 <= x < 1.0, tags=[log]
 tag(foo,bar,interval(0,1))      # 1.0 <= x < 1.0, tags=[foo,bar]
 ```
 
-## Extending lists
-
-### extend_list
-```python title="Signature"
-def extend_list(*args: Any) -> ListExtensionOverrideValue:
-    """
-    Extends an existing list in the config with the given values.
-    """
-```
-
-<div className="row">
-<div className="col col--6">
-
-```yaml title="Input config"
-tags:
-- database
-- log
-```
-
-</div>
-
-<div className="col  col--6">
-
-
-```yaml title="tag=extend_list(extended, experimental)"
-tags:
-- database
-- log
-- extended
-- experimental
-```
-
-</div>
-</div>
-
-Note that this cannot be used in conjunction with appending or removing config value. The following usages are invalid:
-* `+list_key=extend_list(val1, val2)`
-* `++list_key=extend_listval1, val2)`
-* `~list_key=extend_list(val1, val2)`
-
 ## Reordering lists and sweeps
 
 ### sort


### PR DESCRIPTION

Preserve extend_list behavior for Hydra 1.4 while warning that it will be removed in Hydra 1.5.

Remove its public feature documentation and unreleased news fragment. Keep the original invalid-override errors and cover accepted deprecation warnings.

Closes #3200
