### PR TITLE
Disable Ray AWS test collection

### DIFF
--- a/plugins/hydra_ray_launcher/integration_test_tools/README.md
+++ b/plugins/hydra_ray_launcher/integration_test_tools/README.md
@@ -16,6 +16,9 @@ ec2.Image(id='ami-0d65d5647e065a180') current state pending
 Sometimes it could take hours for a new AMI to be created. Proceed to the next step once the 
 AMI becomes available.
 
-- Update the `AWS_RAY_AMI` env variable in `tests/test_ray_aws_launcher.py`
-- Run the test locally and debug if needed.
+- Run the tests locally with the new AMI:
+  ```shell
+  AWS_RAY_AMI=<ami-id> pytest ../tests/ray_aws_launcher_tests_disabled.py
+  ```
+- Debug if needed.
 - Create a PR and make sure all CI pass!

--- a/plugins/hydra_ray_launcher/integration_test_tools/create_integration_test_ami.py
+++ b/plugins/hydra_ray_launcher/integration_test_tools/create_integration_test_ami.py
@@ -9,7 +9,7 @@ dependencies changes or there's a newer version of python available for testing.
 This is needed because our testing EC2 instance doesn't not have outbound internet access and as a result cannot create
 conda env on demand.
 
-Please update env variable AWS_RAY_AMI locally and on circleCI with the new AMI id when the new AMI is available.
+Please update env variable AWS_RAY_AMI locally with the new AMI id when the new AMI is available.
 """
 
 import os

--- a/plugins/hydra_ray_launcher/tests/ray_aws_launcher_tests_disabled.py
+++ b/plugins/hydra_ray_launcher/tests/ray_aws_launcher_tests_disabled.py
@@ -1,4 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+"""Legacy Ray AWS tests disabled from automatic pytest collection.
+
+Hydra no longer has the AWS test infrastructure required to run these tests.
+"""
+
 import logging
 import os
 import random


### PR DESCRIPTION

Rename the legacy Ray AWS test module so normal plugin test runs no longer import it or probe AWS during collection.

Keep the tests available for explicit manual runs and update integration helper instructions to match the disabled CI path.
