### PR TITLE
Fix error reporting for list-valued defaults after overrides

### DIFF
--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -402,9 +402,14 @@ def _update_overrides(
             pcp = parent.get_config_path()
             okey = last_override_seen.get_override_key()
             oval = last_override_seen.get_name()
+            dvalue = (
+                d.get_options()
+                if isinstance(d, GroupDefault) and d.is_options()
+                else d.get_name()
+            )
             raise ConfigCompositionException(
                 dedent(f"""\
-                    In {pcp}: Override '{okey} : {oval}' is defined before '{d.get_override_key()}: {d.get_name()}'.
+                    In {pcp}: Override '{okey} : {oval}' is defined before '{d.get_override_key()}: {dvalue}'.
                     Overrides must be at the end of the defaults list""")
             )
 

--- a/news/2236.bugfix
+++ b/news/2236.bugfix
@@ -1,0 +1,1 @@
+Report misplaced overrides followed by list-valued defaults clearly.

--- a/tests/defaults_list/data/override_list.yaml
+++ b/tests/defaults_list/data/override_list.yaml
@@ -1,0 +1,6 @@
+defaults:
+  # Error: overrides must come at the end of the defaults list
+  - override group1: file2
+  - group1:
+      - file1
+      - file2

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -624,6 +624,19 @@ def test_defaults_tree_with_package_overrides__group_override(
             ),
             id="test_override_wrong_order_in_defaults_list",
         ),
+        param(
+            "override_list",
+            [],
+            raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    dedent("""\
+                        In override_list: Override 'group1 : file2' is defined before 'group1: ['file1', 'file2']'.
+                        Overrides must be at the end of the defaults list""")
+                ),
+            ),
+            id="test_override_before_list_in_defaults_list",
+        ),
     ],
 )
 def test_override_option_from_defaults_list(


### PR DESCRIPTION
## Summary

- format list-valued defaults safely when reporting misplaced overrides
- add a regression test for a list-valued default after an override
- add a bugfix news fragment

Fixes #2236

## Tests

- `python -m pytest tests/defaults_list`
- `nox -s test_core-3.10 -- tests/defaults_list`
- `ruff format --check .`
- `ruff check .`
- `yamllint --strict tests/defaults_list/data/override_list.yaml`
- `towncrier build --draft --version 1.4.0.dev6`