### PR TITLE
Add non-target recursive instantiation coverage

### DIFF
--- a/news/2577.feature
+++ b/news/2577.feature
@@ -1,0 +1,1 @@
+Honor `_recursive_` on non-target config nodes during instantiation.

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -1726,6 +1726,25 @@ def test_recursive_override(
     assert obj == expected
 
 
+def test_non_target_node_obeys_recursive_false(instantiate_func: Any) -> None:
+    obj = instantiate_func(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "child": {
+                "_recursive_": False,
+                "grandchild": {
+                    "_target_": "tests.instantiate.SimpleClass",
+                    "value": 10,
+                },
+            },
+        }
+    )
+
+    child = obj.kwargs["child"]
+    assert isinstance(child, DictConfig)
+    assert isinstance(child.grandchild, DictConfig)
+
+
 @mark.parametrize(
     ("src", "passthrough", "expected"),
     [


### PR DESCRIPTION
## Summary

- Add an explicit regression test for `_recursive_: false` on a non-target config node.
- Add the corresponding feature news fragment.

## Context

The behavior requested by #2577 is already present on `main` after #3302 rewrote instantiation. This PR adds direct coverage for the motivating target → non-target → target shape and records the feature for the 1.4 release.

## Test plan

- `.venv/bin/pytest tests/instantiate/test_instantiate.py -k non_target_node_obeys_recursive_false`
- `PATH=/home/omry/dev/hydra/.venv/bin:$PATH .venv/bin/pytest`
- `.venv/bin/nox -s lint`