### PR TITLE
Standardize Nevergrad sweeper search space config

### DIFF
--- a/plugins/hydra_nevergrad_sweeper/example/config.yaml
+++ b/plugins/hydra_nevergrad_sweeper/example/config.yaml
@@ -13,28 +13,18 @@ hydra:
       num_workers: 10
       # maximize: true  # comment out for maximization
     # default parametrization of the search space
-    parametrization:
+    params:
       # either one or the other
-      db:
-        - mnist
-        - cifar
+      db: choice(mnist, cifar)
       # a log-distributed positive scalar, evolving by factors of 2 on average
-      lr:
-        init: 0.02
-        step: 2.0
-        log: true
+      lr: {init: 0.02, step: 2.0, log: true}
       # a linearly-distributed scalar between 0 and 1
-      dropout:
-        lower: 0.0
-        upper: 1.0
+      dropout: interval(0, 1)
       # an integer scalar going from 4 to 16
       # init and step parameters could also be provided,
       # by default init is set to the middle of the range
       # and step is set to a sixth of the range
-      batch_size:
-        lower: 4
-        upper: 16
-        integer: true
+      batch_size: int(interval(4, 16))
 
 db: cifar
 lr: 0.01

--- a/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/_impl.py
+++ b/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/_impl.py
@@ -13,6 +13,7 @@ from typing import (
 )
 
 import nevergrad as ng
+from hydra._internal.deprecation_warning import deprecation_warning
 from hydra.core import utils
 from hydra.core.override_parser.overrides_parser import OverridesParser
 from hydra.core.override_parser.types import (
@@ -60,6 +61,8 @@ def create_nevergrad_param_from_config(
 def create_nevergrad_parameter_from_override(override: Override) -> Any:
     val = override.value()
     if not override.is_sweep_override():
+        if isinstance(val, dict):
+            return create_nevergrad_param_from_config(val)
         return override.get_value_element_as_str()
     if override.is_choice_sweep():
         assert isinstance(val, ChoiceSweep)
@@ -86,21 +89,51 @@ class NevergradSweeperImpl(Sweeper):
     def __init__(
         self,
         optim: OptimConf,
-        parametrization: Optional[DictConfig],
+        parametrization: Optional[DictConfig] = None,
+        params: Optional[DictConfig] = None,
     ):
         self.opt_config = optim
         self.config: Optional[DictConfig] = None
         self.launcher: Optional[Launcher] = None
         self.hydra_context: Optional[HydraContext] = None
         self.job_results = None
-        self.parametrization: Dict[str, Any] = {}
-        if parametrization is not None:
-            assert isinstance(parametrization, DictConfig)
-            self.parametrization = {
-                str(x): create_nevergrad_param_from_config(y)
-                for x, y in parametrization.items()
-            }
+        self.parametrization = parametrization
+        self.params = params
         self.job_idx: Optional[int] = None
+
+    def _process_parameter_config(self) -> Tuple[Dict[str, Any], List[str]]:
+        if self.params is not None and self.parametrization is not None:
+            raise ValueError(
+                "hydra.sweeper.params and hydra.sweeper.parametrization "
+                "cannot both be configured"
+            )
+        if self.parametrization is not None:
+            deprecation_warning(
+                message=(
+                    "`hydra.sweeper.parametrization` is deprecated in Hydra 1.4 "
+                    "and will be removed in Hydra 1.5. "
+                    "Use `hydra.sweeper.params` instead. "
+                    "See https://hydra.cc/docs/next/upgrades/1.3_to_1.4/"
+                    "nevergrad_sweeper/"
+                ),
+            )
+            return (
+                {
+                    str(key): create_nevergrad_param_from_config(value)
+                    for key, value in self.parametrization.items()
+                },
+                [],
+            )
+
+        params: Dict[str, Any] = {}
+        overrides = []
+        if self.params is not None:
+            for key, value in self.params.items():
+                if isinstance(value, MutableMapping):
+                    params[str(key)] = create_nevergrad_param_from_config(value)
+                else:
+                    overrides.append(f"{key}={value}")
+        return params, overrides
 
     def setup(
         self,
@@ -120,13 +153,15 @@ class NevergradSweeperImpl(Sweeper):
         assert self.config is not None
         assert self.launcher is not None
         assert self.job_idx is not None
+
+        params, params_conf = self._process_parameter_config()
+        params_conf.extend(arguments)
+
         direction = -1 if self.opt_config.maximize else 1
         name = "maximization" if self.opt_config.maximize else "minimization"
-        # Override the parametrization from commandline
-        params = dict(self.parametrization)
 
         parser = OverridesParser.create()
-        parsed = parser.parse_overrides(arguments)
+        parsed = parser.parse_overrides(params_conf)
 
         for override in parsed:
             params[override.get_key_element()] = (

--- a/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/config.py
+++ b/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/config.py
@@ -75,12 +75,11 @@ class NevergradSweeperConf:
     # configuration of the optimizer
     optim: OptimConf = field(default_factory=OptimConf)
 
-    # default parametrization of the search space
-    # can be specified:
-    # - as a string, like commandline arguments
-    # - as a list, for categorical variables
-    # - as a full scalar specification
-    parametrization: Dict[str, Any] = field(default_factory=dict)
+    # Deprecated search-space configuration.
+    parametrization: Optional[Dict[str, Any]] = None
+
+    # Search-space configuration using Hydra's override grammar.
+    params: Optional[Dict[str, Any]] = None
 
 
 ConfigStore.instance().store(

--- a/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/nevergrad_sweeper.py
+++ b/plugins/hydra_nevergrad_sweeper/hydra_plugins/hydra_nevergrad_sweeper/nevergrad_sweeper.py
@@ -12,10 +12,15 @@ from .config import OptimConf
 class NevergradSweeper(Sweeper):
     """Class to interface with Nevergrad"""
 
-    def __init__(self, optim: OptimConf, parametrization: Optional[DictConfig]):
+    def __init__(
+        self,
+        optim: OptimConf,
+        parametrization: Optional[DictConfig] = None,
+        params: Optional[DictConfig] = None,
+    ):
         from ._impl import NevergradSweeperImpl
 
-        self.sweeper = NevergradSweeperImpl(optim, parametrization)
+        self.sweeper = NevergradSweeperImpl(optim, parametrization, params)
 
     def setup(
         self,

--- a/plugins/hydra_nevergrad_sweeper/news/1890.config
+++ b/plugins/hydra_nevergrad_sweeper/news/1890.config
@@ -1,0 +1,1 @@
+Add `params` and deprecate `parametrization` in the Nevergrad Sweeper.

--- a/plugins/hydra_nevergrad_sweeper/tests/test_nevergrad_sweeper_plugin.py
+++ b/plugins/hydra_nevergrad_sweeper/tests/test_nevergrad_sweeper_plugin.py
@@ -2,7 +2,7 @@
 import sys
 import warnings
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import nevergrad as ng
 from hydra.core.override_parser.overrides_parser import OverridesParser
@@ -15,9 +15,11 @@ from hydra.test_utils.test_utils import (
     run_python_script,
 )
 from omegaconf import DictConfig, OmegaConf
-from pytest import mark
+from pytest import mark, raises, warns
 
 from hydra_plugins.hydra_nevergrad_sweeper import _impl
+from hydra_plugins.hydra_nevergrad_sweeper._impl import NevergradSweeperImpl
+from hydra_plugins.hydra_nevergrad_sweeper.config import OptimConf
 from hydra_plugins.hydra_nevergrad_sweeper.nevergrad_sweeper import NevergradSweeper
 
 chdir_plugin_root()
@@ -64,6 +66,10 @@ def get_scalar_with_integer_bounds(lower: int, upper: int, type: Any) -> ng.p.Sc
             {"lower": 1, "upper": 12, "log": True, "integer": True},
             get_scalar_with_integer_bounds(1, 12, ng.p.Log),
         ),
+        (
+            {"init": 0.02, "step": 2.0, "log": True},
+            ng.p.Log(init=0.02, lower=None, upper=None, exponent=2.0),
+        ),
     ],
 )
 def test_create_nevergrad_parameter_from_config(
@@ -104,6 +110,10 @@ def test_create_nevergrad_parameter_from_config(
         ("key=0", "0"),
         ("key=true", "True"),
         ("key=null", "null"),
+        (
+            "key={init: 0.02, step: 2.0, log: true}",
+            ng.p.Log(init=0.02, lower=None, upper=None, exponent=2.0),
+        ),
     ],
 )
 def test_create_nevergrad_parameter_from_override(
@@ -198,3 +208,82 @@ def test_failure_rate(max_failure_rate: float, tmpdir: Path) -> None:
         assert error_string in err
     else:
         assert error_string not in err
+
+
+def create_sweeper(
+    *,
+    parametrization: Optional[DictConfig] = None,
+    params: Optional[DictConfig] = None,
+) -> NevergradSweeperImpl:
+    return NevergradSweeperImpl(
+        optim=OptimConf(),
+        parametrization=parametrization,
+        params=params,
+    )
+
+
+def test_empty_parameter_config() -> None:
+    sweeper = create_sweeper()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        parametrization, overrides = sweeper._process_parameter_config()
+    assert parametrization == {}
+    assert overrides == []
+
+
+def test_parametrization_is_deprecated_but_supported() -> None:
+    sweeper = create_sweeper(
+        parametrization=OmegaConf.create({"key": [1, 2, 3]}),
+    )
+    with warns(
+        UserWarning,
+        match=(
+            r"`hydra\.sweeper\.parametrization` is deprecated in Hydra 1\.4 "
+            r"and will be removed in Hydra 1\.5\."
+        ),
+    ):
+        parametrization, overrides = sweeper._process_parameter_config()
+    assert_ng_param_equals(ng.p.Choice([1, 2, 3]), parametrization["key"])
+    assert overrides == []
+
+
+def test_params_and_parametrization_are_mutually_exclusive() -> None:
+    sweeper = create_sweeper(
+        parametrization=OmegaConf.create({"key": [1, 2, 3]}),
+        params=OmegaConf.create({"key": "choice(1,2,3)"}),
+    )
+    with raises(
+        ValueError,
+        match=(
+            r"hydra\.sweeper\.params and hydra\.sweeper\.parametrization "
+            r"cannot both be configured"
+        ),
+    ):
+        sweeper._process_parameter_config()
+
+
+@mark.parametrize("value", ["'a&c'", "'a,b'"])
+def test_process_parameter_config_preserves_override_quotes(value: str) -> None:
+    sweeper = create_sweeper(params=OmegaConf.create({"key": value}))
+    parametrization, overrides = sweeper._process_parameter_config()
+    assert parametrization == {}
+    assert overrides == [f"key={value}"]
+
+    override = OverridesParser.create().parse_overrides(overrides)[0]
+    assert not override.is_sweep_override()
+    assert_ng_param_equals(
+        _impl.create_nevergrad_parameter_from_override(override),
+        value,
+    )
+
+
+def test_process_parameter_config_supports_scalar_dict() -> None:
+    sweeper = create_sweeper(
+        params=OmegaConf.create({"key": {"init": 0.02, "step": 2.0, "log": True}})
+    )
+    parametrization, overrides = sweeper._process_parameter_config()
+    assert_ng_param_equals(
+        ng.p.Log(init=0.02, lower=None, upper=None, exponent=2.0),
+        parametrization["key"],
+    )
+    assert overrides == []

--- a/website/docs/plugins/nevergrad_sweeper.md
+++ b/website/docs/plugins/nevergrad_sweeper.md
@@ -45,21 +45,11 @@ optim:
   maximize: false
   seed: null
   max_failure_rate: 0.0
-parametrization:
-  db:
-  - mnist
-  - cifar
-  lr:
-    init: 0.02
-    step: 2.0
-    log: true
-  dropout:
-    lower: 0.0
-    upper: 1.0
-  batch_size:
-    lower: 4
-    upper: 16
-    integer: true
+params:
+  db: choice(mnist, cifar)
+  lr: {init: 0.02, step: 2.0, log: true}
+  dropout: interval(0, 1)
+  batch_size: int(interval(4, 16))
 ```
 
 The function decorated with `@hydra.main()` returns a float which we want to minimize, the minimum is 0 and reached for:
@@ -150,19 +140,29 @@ key=tag(ordered, choice(1,2,3))
 key=interval(1,12)             # Intervals are floats by default
 key=int(interval(1,8))         # Scalar bounds are cast to an int
 key=tag(log, interval(1,12))   # call ng.p.Log if tagged with log
+key={init: 0.02, step: 2.0, log: true}  # Unbounded log-scale scalar
 ```
 
 ### Defining through config file
-#### Choices
-Choices are defined with a list in a config file.
+The search space can be defined under `hydra.sweeper.params`.
+The definition is consistent with the equivalent command-line override.
 
-```yaml
-db:
-  - mnist
-  - cifar
-```
+:::warning
+`hydra.sweeper.parametrization` is deprecated in Hydra 1.4 and will be removed
+in Hydra 1.5. Use `hydra.sweeper.params` instead.
+:::
+
+#### Choices
+Choices use the same syntax as command-line overrides. For example, translate
+`key=shuffle(range(1, 8))` to `key: shuffle(range(1, 8))` in the config file.
+
+Fixed strings containing override grammar characters must retain quotes as part
+of the configured value. For example, use `label: "'a,b'"` to configure the
+literal string `a,b`; `label: a,b` defines a choice sweep.
+
 #### Scalars
-Scalars can be defined in config files, with fields:
+`Scalar` definitions also support the override syntax shown above. The
+following keys can be passed in a dictionary to define unbounded scalars:
   - `init`: optional initial value
   - `lower` : optional lower bound
   - `upper`: optional upper bound
@@ -171,4 +171,3 @@ Scalars can be defined in config files, with fields:
   - `integer`: set to `true` for integers (favor floats over integers whenever possible)
 
 Providing only `lower` and `upper` bound will set the initial value to the middle of the range and the step to a sixth of the range.
-**Note**: unbounded scalars (scalars with no upper and/or lower bounds) can only be defined through a config file.

--- a/website/docs/upgrades/1.3_to_1.4/nevergrad_sweeper.md
+++ b/website/docs/upgrades/1.3_to_1.4/nevergrad_sweeper.md
@@ -1,0 +1,27 @@
+---
+id: nevergrad_sweeper
+title: Nevergrad Sweeper search-space configuration
+---
+
+Hydra 1.4 standardizes the Nevergrad Sweeper search-space configuration under
+`hydra.sweeper.params`. The previous `hydra.sweeper.parametrization` field is
+deprecated in Hydra 1.4 and will be removed in Hydra 1.5.
+
+Move each search-space entry to `params` and express it using Hydra's override
+grammar:
+
+```yaml
+hydra:
+  sweeper:
+    params:
+      db: choice(mnist, cifar)
+      lr: {init: 0.02, step: 2.0, log: true}
+      dropout: interval(0, 1)
+      batch_size: int(interval(4, 16))
+```
+
+The old configuration continues to work in Hydra 1.4 and emits a deprecation
+warning. Configuring both fields at the same time is an error.
+
+See the [Nevergrad Sweeper documentation](/plugins/nevergrad_sweeper.md) for
+the complete search-space syntax.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -166,6 +166,7 @@ module.exports = AddFBInternalOnly({
                     'upgrades/1.3_to_1.4/hydra_job_override_dirname',
                     'upgrades/1.3_to_1.4/instantiate_resolution',
                     'upgrades/1.3_to_1.4/instantiate_target_whitelist',
+                    'upgrades/1.3_to_1.4/nevergrad_sweeper',
                 ],
             },
             {


### PR DESCRIPTION

Add hydra.sweeper.params support using Hydra's override grammar while preserving Nevergrad scalar dictionaries and command-line precedence.

Deprecate hydra.sweeper.parametrization for Hydra 1.4, reject simultaneous use of both fields, and document the Hydra 1.5 removal.

Update examples, migration docs, release news, and regression coverage.

Refs #1890
