### PR TITLE
Make later Defaults List overrides take precedence

### DIFF
--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -117,13 +117,20 @@ class Overrides:
     def add_override(self, parent_config_path: str, default: GroupDefault) -> None:
         assert default.override
         key = default.get_override_key()
-        if key not in self.override_choices:
-            self.override_choices[key] = default.value
-            self.override_metadata[key] = OverrideMetadata(
-                external_override=False,
-                containing_config_path=parent_config_path,
-                relative_key=default.get_relative_override_key(),
-            )
+        prev = self.override_metadata.get(key)
+        # A later override in the defaults list replaces an earlier one, so that the
+        # last override in depth first order wins. Two earlier overrides are kept:
+        # an external (command line) override always wins over one coming from a
+        # config, and an override that was already applied to a default can no longer
+        # be replaced because the group it targets is already resolved.
+        if prev is not None and (prev.external_override or prev.used):
+            return
+        self.override_choices[key] = default.value
+        self.override_metadata[key] = OverrideMetadata(
+            external_override=False,
+            containing_config_path=parent_config_path,
+            relative_key=default.get_relative_override_key(),
+        )
 
     def is_overridden(self, default: InputDefault) -> bool:
         if isinstance(default, GroupDefault):

--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -117,20 +117,17 @@ class Overrides:
     def add_override(self, parent_config_path: str, default: GroupDefault) -> None:
         assert default.override
         key = default.get_override_key()
-        prev = self.override_metadata.get(key)
-        # A later override in the defaults list replaces an earlier one, so that the
-        # last override in depth first order wins. Two earlier overrides are kept:
-        # an external (command line) override always wins over one coming from a
-        # config, and an override that was already applied to a default can no longer
-        # be replaced because the group it targets is already resolved.
-        if prev is not None and (prev.external_override or prev.used):
-            return
-        self.override_choices[key] = default.value
-        self.override_metadata[key] = OverrideMetadata(
-            external_override=False,
-            containing_config_path=parent_config_path,
-            relative_key=default.get_relative_override_key(),
-        )
+        # Called during the reverse traversal of the defaults tree, so the first
+        # override registered for a key is the last one in depth first order and
+        # first-wins keeps it. External (command line) overrides are registered in
+        # __init__, before the traversal, and therefore always take priority.
+        if key not in self.override_choices:
+            self.override_choices[key] = default.value
+            self.override_metadata[key] = OverrideMetadata(
+                external_override=False,
+                containing_config_path=parent_config_path,
+                relative_key=default.get_relative_override_key(),
+            )
 
     def is_overridden(self, default: InputDefault) -> bool:
         if isinstance(default, GroupDefault):
@@ -488,7 +485,9 @@ def _update_overrides(
                             of an in interpolated config group (override {d.get_override_key()}={d.get_name()}).
                             """)
                     )
-                overrides.add_override(parent.get_config_path(), d)
+                # Overrides are registered when they are encountered during the
+                # reverse traversal in _create_defaults_tree_impl, not here, so
+                # that the last override in depth first order wins.
 
 
 def _has_config_content(cfg: DictConfig) -> bool:
@@ -575,6 +574,16 @@ def _create_defaults_tree_impl(
 
     _update_overrides(defaults_list, overrides, parent, interpolated_subtree)
 
+    # An externally appended group default is the one case where a group default
+    # may legally follow an override of the same group in a single defaults list.
+    # The reverse traversal below visits the appended entry before that override,
+    # so map each key to the list's last override for it, allowing the appended
+    # entry to register its override before resolving.
+    list_overrides: Dict[str, GroupDefault] = {}
+    for d in defaults_list:
+        if isinstance(d, GroupDefault) and d.is_override():
+            list_overrides[d.get_override_key()] = d
+
     def add_child(
         child_list: List[Union[InputDefault, DefaultsTreeNode]],
         new_root_: DefaultsTreeNode,
@@ -598,9 +607,16 @@ def _create_defaults_tree_impl(
             children.append(d)
         else:
             if d.is_override():
+                assert isinstance(d, GroupDefault)
+                overrides.add_override(parent.get_config_path(), d)
                 continue
 
             d.update_parent(parent.get_group_path(), parent.get_final_package())
+
+            if isinstance(d, GroupDefault) and d.is_external_append():
+                pending = list_overrides.get(d.get_override_key())
+                if pending is not None:
+                    overrides.add_override(parent.get_config_path(), pending)
 
             if overrides.is_overridden(d):
                 assert isinstance(d, GroupDefault)

--- a/news/3229.bugfix
+++ b/news/3229.bugfix
@@ -1,0 +1,1 @@
+Make a Defaults List override replace an earlier override of the same config group, so that the last override in depth first order wins.

--- a/tests/defaults_list/data/group_default_after_explicit_experiment.yaml
+++ b/tests/defaults_list/data/group_default_after_explicit_experiment.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - experiment: override_config_group
+  - group1: file1
+  - override group1: file3

--- a/tests/defaults_list/data/group_default_with_explicit_experiment_and_override.yaml
+++ b/tests/defaults_list/data/group_default_with_explicit_experiment_and_override.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - group1: file1
+  - experiment: override_config_group
+  - override group1: file3

--- a/tests/defaults_list/data/group_default_with_override.yaml
+++ b/tests/defaults_list/data/group_default_with_override.yaml
@@ -1,0 +1,3 @@
+defaults:
+  - group1: file1
+  - override group1: file3

--- a/tests/defaults_list/data/group_override_only.yaml
+++ b/tests/defaults_list/data/group_override_only.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - override group1: file2

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -212,6 +212,15 @@ def test_simple_defaults_tree_cases(
             ),
             id="include_nested_group:append",
         ),
+        param(
+            "group_override_only",
+            ["+group1=file1"],
+            DefaultsTreeNode(
+                node=ConfigDefault(path="group_override_only"),
+                children=[GroupDefault(group="group1", value="file2")],
+            ),
+            id="group_override_only:append_overridden_group",
+        ),
     ],
 )
 def test_tree_with_append_override(
@@ -1052,6 +1061,36 @@ def test_legacy_hydra_overrides_from_primary_config_2(
                 ],
             ),
             id="group_default_after_explicit_experiment",
+        ),
+        param(
+            "group_default_with_explicit_experiment_and_override",
+            [],
+            DefaultsTreeNode(
+                node=ConfigDefault(
+                    path="group_default_with_explicit_experiment_and_override"
+                ),
+                children=[
+                    GroupDefault(group="group1", value="file3"),
+                    GroupDefault(group="experiment", value="override_config_group"),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="group_default_with_explicit_experiment_and_override",
+        ),
+        param(
+            "group_default_with_explicit_experiment_and_override",
+            ["group1=file1"],
+            DefaultsTreeNode(
+                node=ConfigDefault(
+                    path="group_default_with_explicit_experiment_and_override"
+                ),
+                children=[
+                    GroupDefault(group="group1", value="file1"),
+                    GroupDefault(group="experiment", value="override_config_group"),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="group_default_with_explicit_experiment_and_override:with_external_override",
         ),
     ],
 )

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -1040,6 +1040,19 @@ def test_legacy_hydra_overrides_from_primary_config_2(
             ),
             id="group_default_with_explicit_experiment:with_external_override",
         ),
+        param(
+            "group_default_after_explicit_experiment",
+            [],
+            DefaultsTreeNode(
+                node=ConfigDefault(path="group_default_after_explicit_experiment"),
+                children=[
+                    GroupDefault(group="experiment", value="override_config_group"),
+                    GroupDefault(group="group1", value="file3"),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="group_default_after_explicit_experiment",
+        ),
     ],
 )
 def test_group_default_with_explicit_experiment(
@@ -1082,6 +1095,32 @@ def test_group_default_with_explicit_experiment(
                 ],
             ),
             id="group_default_with_appended_experiment:with_external_override",
+        ),
+        param(
+            "group_default_with_override",
+            ["+experiment=override_config_group"],
+            DefaultsTreeNode(
+                node=ConfigDefault(path="group_default_with_override"),
+                children=[
+                    GroupDefault(group="group1", value="file2"),
+                    ConfigDefault(path="_self_"),
+                    GroupDefault(group="experiment", value="override_config_group"),
+                ],
+            ),
+            id="group_default_with_override_with_appended_experiment",
+        ),
+        param(
+            "group_default_with_override",
+            ["group1=file1", "+experiment=override_config_group"],
+            DefaultsTreeNode(
+                node=ConfigDefault(path="group_default_with_override"),
+                children=[
+                    GroupDefault(group="group1", value="file1"),
+                    ConfigDefault(path="_self_"),
+                    GroupDefault(group="experiment", value="override_config_group"),
+                ],
+            ),
+            id="group_default_with_override_with_appended_experiment:with_external_override",
         ),
     ],
 )


### PR DESCRIPTION
Fixes #3229

## Problem

A Defaults List override inside a config appended with `+group=option` did not override an earlier override of the same config group. `Overrides.add_override` recorded only the first override for a key, so the first override won instead of the last one in depth-first order, contradicting the documented rule.

## Fix

Overrides were registered per-config in `_update_overrides`, before descending into that config's children — which encodes list position rather than depth-first position. Registration now happens in the reverse traversal in `_create_defaults_tree_impl`, at the point each `override` entry is encountered:

- Because the traversal is reversed, the first override registered for a key is the **last one in depth-first order**, and `add_override`'s existing first-wins behavior keeps it. `add_override` itself is unchanged from `main` apart from a comment.
- Command-line overrides are registered in `Overrides.__init__`, before any traversal, so they continue to take priority over Defaults List overrides.
- `_update_overrides` still validates ordering ("Overrides must be at the end of the defaults list") and rejects overrides in interpolated subtrees; it just no longer registers.
- One special case: an externally appended group default (`+db=mysql`) is the one legal way a group default can follow an override of the same group in a single defaults list, and the reverse traversal visits the appended entry before that override registers. Resolving an external append therefore first registers the current list's own override for its key, preserving `main`'s behavior for `defaults: [override db: sqlite]` composed with `+db=mysql`.

Override resolution remains part of defaults-tree construction, so configs selected during traversal can still introduce additional defaults and overrides.

*(An earlier version of this PR pre-registered a config's overrides before traversing its children, with a replace-unless-used rule. The review pointed out an ordering it gets wrong — two competing Defaults List overrides where the deeper one is registered later — and that case is now part of the regression tests below.)*

## Tests

- `group_default_with_override` + `+experiment=override_config_group` — the appended config's override wins (the #3229 ordering). Fails on `main`.
- the same, plus `group1=file1` on the command line — the command line still wins.
- `group_default_with_explicit_experiment_and_override` — `group1: file1`, `experiment: override_config_group`, `override group1: file3`: both competing overrides come from Defaults Lists and the later (`file3`) wins. Fails on the previous version of this patch.
- the same, plus a command-line `group1=file1` — CLI priority.
- `group_default_after_explicit_experiment` — a group resolved before a nested override for it is registered resolves per its own list; no spurious "Could not override" error.
- `group_override_only` + `+group1=file1` — a config whose defaults list only overrides a group, composed with an append of that group: the override applies. Fails without the external-append handling.

`pytest tests/defaults_list tests/test_compose.py` → 422 passed. Full suite excluding `test_completion` → 2055 passed (`test_completion` fails identically on an unmodified checkout in my environment).
