### PR TITLE
Preserve dataclass and attrs call-site arguments

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -386,7 +386,9 @@ def _prepare_input_container(
 def _prepare_input_value(
     value: Any,
 ) -> Any:
-    if isinstance(value, (dict, list)) or type(value) is tuple:
+    if not is_structured_config(value) and (
+        isinstance(value, (dict, list)) or type(value) is tuple
+    ):
         return _prepare_input_container(value)
     return value
 
@@ -491,8 +493,8 @@ def instantiate(
     :param kwargs: Optional named parameters to override
                    parameters in the config object. Parameters not present
                    in the config objects are being passed as is to the target.
-                   IMPORTANT: dataclasses instances in kwargs are interpreted as config
-                              and cannot be used as passthrough
+                   Dataclass and attrs instances are passed through without
+                   conversion or recursive instantiation.
     :return: if _target_ is a class name: the instantiated object
              if _target_ is a callable: the return value of the call
     """
@@ -613,14 +615,12 @@ def _create_sequence_result(
 
 
 def _get_dict_override(value: Any) -> Optional[ConfigOverlay]:
+    if is_structured_config(value):
+        return None
     if isinstance(value, dict):
         return value
     if OmegaConf.is_dict(value):
         return cast(DictConfig, value)
-    if is_structured_config(value) and not isinstance(value, type):
-        config = OmegaConf.structured(value, flags={"allow_objects": True})
-        assert OmegaConf.is_dict(config)
-        return cast(DictConfig, config)
     return None
 
 
@@ -657,6 +657,9 @@ def _instantiate_override(
     recursive: bool,
     target_whitelist: NormalizedTargetWhitelist,
 ) -> Any:
+    if is_structured_config(value):
+        return value
+
     dict_override = _get_dict_override(value)
     if not recursive:
         if isinstance(dict_override, DictConfig) and (

--- a/news/2364.api_change
+++ b/news/2364.api_change
@@ -1,0 +1,6 @@
+`instantiate()` now passes dataclass and attrs instances supplied as call-site
+arguments through unchanged instead of interpreting them as Structured Configs.
+Use `OmegaConf.structured(instance)` when an instance should still be merged and
+recursively instantiated as configuration. See the
+[Hydra 1.4 migration guide](/docs/upgrades/1.3_to_1.4/instantiate_resolution)
+for details and examples.

--- a/noxfile.py
+++ b/noxfile.py
@@ -580,7 +580,7 @@ def _get_standalone_apps_dirs() -> List[Union[str, Path]]:
 def test_core(session: Session) -> None:
     _upgrade_basic(session)
     install_hydra(session, INSTALL_COMMAND)
-    session.install("pytest")
+    session.install("attrs", "pytest")
 
     if not SKIP_CORE_TESTS:
         run_pytest(
@@ -614,7 +614,7 @@ def test_core(session: Session) -> None:
 @nox.session(python=PYTHON_VERSIONS)  # type: ignore
 def test_plugins_vs_core(session: Session) -> None:
     _upgrade_basic(session)
-    session.install("pytest")
+    session.install("attrs", "pytest")
     install_hydra(session, INSTALL_COMMAND)
 
     # install all plugins compatible with the current Python version
@@ -670,7 +670,7 @@ def coverage(session: Session) -> None:
         "COVERAGE_RCFILE": f"{BASE}/.coveragerc",
     }
 
-    session.install("coverage", "pytest")
+    session.install("attrs", "coverage", "pytest")
     install_hydra(session, ["pip", "install", "-e"])
     session.run("coverage", "erase", env=coverage_env)
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+attrs
 bandit
 ruff==0.15.22
 build

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -4,11 +4,12 @@ import inspect
 import os
 import pickle
 import re
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass, field
 from functools import partial
 from textwrap import dedent
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
+import attr
 from omegaconf import (
     MISSING,
     AnyNode,
@@ -868,20 +869,11 @@ def test_nested_runtime_object_override_replaces_unresolvable_config_value(
     assert result.left.value is runtime_value
 
 
-@mark.parametrize(
-    ("convert", "expected_type"),
-    [
-        param(ConvertMode.NONE, DictConfig, id="none"),
-        param(ConvertMode.PARTIAL, DictConfig, id="partial"),
-        param(ConvertMode.OBJECT, User, id="object"),
-        param(ConvertMode.ALL, dict, id="all"),
-    ],
-)
+@mark.parametrize("convert", list(ConvertMode))
 @mark.parametrize("recursive", [False, True])
-def test_structured_runtime_override_preserves_conversion_behavior(
+def test_structured_runtime_override_is_passed_through(
     instantiate_func: Any,
     convert: ConvertMode,
-    expected_type: Any,
     recursive: bool,
 ) -> None:
     user = User(name="Bond", age=7)
@@ -893,14 +885,128 @@ def test_structured_runtime_override_preserves_conversion_behavior(
         _recursive_=recursive,
     )
 
-    converted_user = result.kwargs["user"]
-    assert isinstance(converted_user, expected_type)
-    if OmegaConf.is_config(converted_user):
-        assert OmegaConf.get_type(converted_user) is User
-    if isinstance(converted_user, User):
-        assert converted_user == user
-    else:
-        assert converted_user == {"name": "Bond", "age": 7}
+    assert result.kwargs["user"] is user
+
+
+def test_structured_runtime_override_with_target_is_passed_through(
+    instantiate_func: Any,
+) -> None:
+    @dataclass
+    class RuntimeValue:
+        _target_: str
+        value: int
+        token: InitVar[str]
+        runtime_token: str = field(init=False)
+
+        def __post_init__(self, token: str) -> None:
+            self.runtime_token = token
+
+    runtime_value = RuntimeValue(
+        _target_="tests.instantiate.AnotherClass",
+        value=10,
+        token="secret",
+    )
+
+    result = instantiate_func(
+        {"_target_": "tests.instantiate.ArgsClass"},
+        value=runtime_value,
+        _convert_=ConvertMode.OBJECT,
+    )
+
+    assert result.kwargs["value"] is runtime_value
+    assert result.kwargs["value"].runtime_token == "secret"
+
+
+def test_attrs_runtime_override_is_passed_through(instantiate_func: Any) -> None:
+    @attr.define
+    class RuntimeValue:
+        value: int
+
+    runtime_value = RuntimeValue(value=10)
+
+    result = instantiate_func(
+        {"_target_": "tests.instantiate.ArgsClass"},
+        value=runtime_value,
+        _convert_=ConvertMode.OBJECT,
+    )
+
+    assert result.kwargs["value"] is runtime_value
+
+
+def test_dataclass_dict_subclass_runtime_override_is_passed_through(
+    instantiate_func: Any,
+) -> None:
+    @dataclass
+    class RuntimeValue(dict):  # type: ignore[type-arg]
+        pass
+
+    runtime_value = RuntimeValue()
+    runtime_value["value"] = 10
+
+    result = instantiate_func(
+        {"_target_": "tests.instantiate.ArgsClass"},
+        value=runtime_value,
+    )
+
+    assert result.kwargs["value"] is runtime_value
+
+
+def test_attrs_list_subclass_runtime_override_is_passed_through(
+    instantiate_func: Any,
+) -> None:
+    @attr.define(slots=False)
+    class RuntimeValue(list):  # type: ignore[type-arg]
+        pass
+
+    runtime_value = RuntimeValue()
+    runtime_value.append(10)
+
+    result = instantiate_func(
+        {"_target_": "tests.instantiate.ArgsClass"},
+        value=runtime_value,
+    )
+
+    assert result.kwargs["value"] is runtime_value
+
+
+def test_omegaconf_structured_runtime_override_is_instantiated(
+    instantiate_func: Any,
+) -> None:
+    runtime_config = OmegaConf.structured(TreeConf(value=10))
+
+    result = instantiate_func(
+        {"_target_": "tests.instantiate.ArgsClass"},
+        value=runtime_config,
+    )
+
+    assert result.kwargs["value"] == Tree(value=10)
+
+
+def test_omegaconf_structured_runtime_override_merges_with_configured_value(
+    instantiate_func: Any,
+) -> None:
+    @dataclass
+    class TreeValueOverride:
+        value: int
+
+    runtime_config = OmegaConf.structured(TreeValueOverride(value=20))
+
+    result = instantiate_func(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "value": {
+                "_target_": "tests.instantiate.Tree",
+                "value": 10,
+                "left": {
+                    "_target_": "tests.instantiate.Tree",
+                    "value": 30,
+                },
+            },
+        },
+        value=runtime_config,
+    )
+
+    assert result.kwargs["value"] == Tree(value=20, left=Tree(value=30))
 
 
 def test_runtime_override_is_not_coerced_by_structured_config(
@@ -1253,26 +1359,6 @@ def test_instantiate_with_callable_target_keyword(
             ),
             {"right": {"value": 22}},
             Tree(value=1, left=Tree(value=21), right=Tree(value=22)),
-            id="recursive:direct:dataclass:passthrough",
-        ),
-        param(
-            TreeConf(
-                value=1,
-                left=TreeConf(value=21),
-            ),
-            {"right": TreeConf(value=22)},
-            Tree(value=1, left=Tree(value=21), right=Tree(value=22)),
-            id="recursive:direct:dataclass:passthrough",
-        ),
-        param(
-            TreeConf(
-                value=1,
-                left=TreeConf(value=21),
-            ),
-            {
-                "right": TreeConf(value=IllegalType()),
-            },
-            Tree(value=1, left=Tree(value=21), right=Tree(value=IllegalType())),
             id="recursive:direct:dataclass:passthrough",
         ),
         # list

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -60,8 +60,8 @@ instantiation is not supported for these sequence inputs.
         :param kwargs: Optional named parameters to override
                        parameters in the config object. Parameters not present
                        in the config objects are being passed as is to the target.
-                       IMPORTANT: dataclasses instances in kwargs are interpreted as config
-                                  and cannot be used as passthrough
+                       Dataclass and attrs instances are passed through without
+                       conversion or recursive instantiation.
         :return: if _target_ is a class name: the instantiated object
                  if _target_ is a callable: the return value of the call
         """
@@ -165,6 +165,15 @@ resolved lazily as instantiation proceeds instead of resolving and copying the
 full configuration tree up front. This avoids processing unrelated configuration
 values and allows runtime state established by an earlier target to be used
 while resolving a later argument.
+
+Primitive values, native `list`, `tuple`, and `dict` containers, and OmegaConf
+containers passed at the call-site retain Hydra's normal configuration
+semantics, including recursive merging, instantiation, and conversion where
+applicable.
+
+Already-constructed dataclass and attrs instances are regular runtime objects.
+They remain unchanged, even if they define `_target_`. To use such an instance
+as configuration, explicitly convert it with `OmegaConf.structured(instance)`.
 
 See the [Hydra 1.4 upgrade guide](/docs/upgrades/1.3_to_1.4/instantiate_resolution)
 for the compatibility impact and an example.

--- a/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
+++ b/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
@@ -6,6 +6,11 @@ title: Instantiate resolution and call-site overrides
 Hydra 1.4 changes when `hydra.utils.instantiate()` resolves configuration
 values and how call-site arguments interact with the input configuration.
 
+The examples on this page pass `_target_whitelist_` because trusted call-site
+code is responsible for authorizing configured targets in Hydra 1.4. See the
+[target whitelist migration guide](/docs/upgrades/1.3_to_1.4/instantiate_target_whitelist)
+for the associated security and migration context.
+
 ## Benefits
 
 `instantiate()` no longer deep-copies and eagerly resolves the full input
@@ -30,8 +35,51 @@ arguments passed to the target, but they do not modify the input configuration
 or affect how its interpolations resolve.
 
 They are also no longer coerced or validated against the corresponding field
-in an input Structured Config. They remain runtime inputs, subject to Hydra's
-normal recursive instantiation and conversion of the supplied value.
+in an input Structured Config. Primitive values, native `list`, `tuple`, and
+`dict` containers, and OmegaConf containers remain supported configuration
+inputs. They retain Hydra's normal recursive merging, instantiation, and
+conversion where applicable.
+
+Hydra 1.4 intentionally changes the treatment of already-constructed dataclass
+and attrs instances passed as call-site arguments. They are now regular runtime
+objects and remain unchanged, even if they define `_target_`. Hydra no longer
+implicitly converts them to Structured Configs, merges them with the input
+configuration, or recursively instantiates them.
+
+To use a dataclass or attrs instance as configuration, explicitly convert it
+with `OmegaConf.structured(instance)`:
+
+```python
+from dataclasses import dataclass
+
+from omegaconf import OmegaConf
+
+from hydra.utils import instantiate
+
+
+@dataclass
+class ChildConfig:
+    _target_: str = "builtins.dict"
+    value: int = 10
+
+
+child = ChildConfig()
+cfg = {"_target_": "builtins.dict"}
+
+runtime_result = instantiate(
+    cfg,
+    child=child,
+    _target_whitelist_="builtins.dict",
+)
+assert runtime_result["child"] is child
+
+config_result = instantiate(
+    cfg,
+    child=OmegaConf.structured(child),
+    _target_whitelist_="builtins.dict",
+)
+assert config_result["child"] == {"value": 10}
+```
 
 For example:
 


### PR DESCRIPTION

Pass already-constructed dataclass and attrs instances to instantiate targets unchanged instead of implicitly converting them to Structured Configs.

Keep native and explicit OmegaConf containers on the configuration path. Add regression coverage for identity passthrough, special constructors, attrs, and explicit structured overrides.

Document the Hydra 1.4 breaking change and migration, and add attrs to the test environments.

Closes #2364
