### PR TITLE
Honor custom exception hooks

### DIFF
--- a/hydra/_internal/utils.py
+++ b/hydra/_internal/utils.py
@@ -6,9 +6,8 @@ import os
 import sys
 import traceback
 import warnings
-from dataclasses import dataclass
 from os.path import dirname, join, normpath, realpath
-from types import FrameType, TracebackType
+from types import TracebackType
 from typing import Any, List, Optional, Sequence, Tuple
 
 from omegaconf.errors import OmegaConfBaseException
@@ -253,42 +252,37 @@ def run_and_report(func: Any) -> Any:
                         sys.exit(1)
 
                     # strip OmegaConf frames from bottom of stack
-                    end: Optional[TracebackType] = tb
-                    num_frames = 0
-                    while end is not None:
-                        frame = end.tb_frame
+                    filtered_traceback: List[TracebackType] = []
+                    current_tb: Optional[TracebackType] = tb
+                    while current_tb is not None:
+                        frame = current_tb.tb_frame
                         mdl = inspect.getmodule(frame)
                         name = mdl.__name__ if mdl is not None else ""
                         if name.startswith("omegaconf."):
                             break
-                        end = end.tb_next
-                        num_frames = num_frames + 1
+                        filtered_traceback.append(current_tb)
+                        current_tb = current_tb.tb_next
 
-                    @dataclass
-                    class FakeTracebackType:
-                        tb_next: Any = None  # Optional["FakeTracebackType"]
-                        tb_frame: Optional[FrameType] = None
-                        tb_lasti: Optional[int] = None
-                        tb_lineno: Optional[int] = None
+                    final_tb: Optional[TracebackType] = None
+                    for traceback_frame in reversed(filtered_traceback):
+                        final_tb = TracebackType(
+                            final_tb,
+                            traceback_frame.tb_frame,
+                            traceback_frame.tb_lasti,
+                            traceback_frame.tb_lineno,
+                        )
+                    assert final_tb is not None
 
-                    iter_tb = tb
-                    final_tb = FakeTracebackType()
-                    cur = final_tb
-                    added = 0
-                    while True:
-                        cur.tb_lasti = iter_tb.tb_lasti
-                        cur.tb_lineno = iter_tb.tb_lineno
-                        cur.tb_frame = iter_tb.tb_frame
-
-                        if added == num_frames - 1:
-                            break
-                        added = added + 1
-                        cur.tb_next = FakeTracebackType()
-                        cur = cur.tb_next
-                        assert iter_tb.tb_next is not None
-                        iter_tb = iter_tb.tb_next
-
-                    traceback.print_exception(None, value=ex, tb=final_tb)  # type: ignore
+                    exception_hook = sys.excepthook
+                    if exception_hook is sys.__excepthook__ or not callable(
+                        exception_hook
+                    ):
+                        traceback.print_exception(None, value=ex, tb=final_tb)
+                    else:
+                        try:
+                            exception_hook(type(ex), ex, final_tb)
+                        except Exception:
+                            traceback.print_exception(None, value=ex, tb=final_tb)
                 sys.stderr.write(
                     "\nSet the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.\n"
                 )

--- a/news/1431.bugfix
+++ b/news/1431.bugfix
@@ -1,0 +1,1 @@
+Honor custom ``sys.excepthook`` handlers when rendering sanitized task exceptions.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,10 @@ import io
 import json
 import os
 import re
+import sys
 from pathlib import Path
 from textwrap import dedent
+from types import TracebackType
 from typing import Any, NoReturn, Optional
 from unittest.mock import patch
 
@@ -246,11 +248,73 @@ class TestRunAndReport:
     )
     def test_failure(self, demo_func: Any, expected_traceback_regex: str) -> None:
         mock_stderr = io.StringIO()
-        with raises(SystemExit, match="1"), patch("sys.stderr", new=mock_stderr):
+        with (
+            raises(SystemExit, match="1"),
+            patch("sys.excepthook", new=sys.__excepthook__),
+            patch("sys.stderr", new=mock_stderr),
+        ):
             run_and_report(demo_func)
         mock_stderr.seek(0)
         stderr_output = mock_stderr.read()
         assert_multiline_regex_search(expected_traceback_regex, stderr_output)
+
+    @mark.parametrize(
+        "demo_func,expected_frames",
+        [
+            param(
+                DemoFunctions.run_job_wrapper,
+                ["nested_error"],
+                id="strip_run_job_from_top_of_stack",
+            ),
+            param(
+                DemoFunctions.omegaconf_job_wrapper,
+                ["job_calling_omconf"],
+                id="strip_omegaconf_from_bottom_of_stack",
+            ),
+        ],
+    )
+    def test_custom_excepthook_receives_sanitized_traceback(
+        self, demo_func: Any, expected_frames: list[str]
+    ) -> None:
+        captured: list[tuple[type[BaseException], BaseException, TracebackType]] = []
+
+        def custom_excepthook(
+            exception_type: type[BaseException],
+            exception: BaseException,
+            tb: TracebackType,
+        ) -> None:
+            captured.append((exception_type, exception, tb))
+
+        with (
+            raises(SystemExit, match="1"),
+            patch("sys.excepthook", new=custom_excepthook),
+        ):
+            run_and_report(demo_func)
+
+        assert len(captured) == 1
+        exception_type, exception, tb = captured[0]
+        assert exception_type is type(exception)
+
+        frames = []
+        current_tb: Optional[TracebackType] = tb
+        while current_tb is not None:
+            frames.append(current_tb.tb_frame.f_code.co_name)
+            current_tb = current_tb.tb_next
+        assert frames == expected_frames
+
+    def test_custom_excepthook_failure_uses_default_renderer(self) -> None:
+        def broken_excepthook(*args: Any) -> NoReturn:
+            raise RuntimeError("hook failed")
+
+        mock_stderr = io.StringIO()
+        with (
+            raises(SystemExit, match="1"),
+            patch("sys.excepthook", new=broken_excepthook),
+            patch("sys.stderr", new=mock_stderr),
+        ):
+            run_and_report(self.DemoFunctions.run_job_wrapper)
+
+        assert "AssertionError: nested_err" in mock_stderr.getvalue()
 
     def test_simplified_traceback_with_no_module(self) -> None:
         """
@@ -268,7 +332,11 @@ class TestRunAndReport:
             Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace\.$
             """)
         mock_stderr = io.StringIO()
-        with raises(SystemExit, match="1"), patch("sys.stderr", new=mock_stderr):
+        with (
+            raises(SystemExit, match="1"),
+            patch("sys.excepthook", new=sys.__excepthook__),
+            patch("sys.stderr", new=mock_stderr),
+        ):
             # Patch `inspect.getmodule` so that it will return None. This simulates a
             # situation where a python module cannot be identified from a traceback
             # stack frame. This can occur when python extension modules or
@@ -296,6 +364,7 @@ class TestRunAndReport:
         mock_stderr = io.StringIO()
         with (
             raises(AssertionError, match="nested_err"),
+            patch("sys.excepthook", new=sys.__excepthook__),
             patch("sys.stderr", new=mock_stderr),
         ):
             # patch `traceback.print_exception` so that an exception will occur


### PR DESCRIPTION

Delegate sanitized task exceptions to custom sys.excepthook handlers while preserving Hydra's default renderer when no custom hook is installed.

Rebuild sanitized tracebacks as real traceback objects so third-party handlers can consume them, and fall back to default rendering when a custom handler fails. Add regression coverage for Hydra and OmegaConf frame stripping and handler failure.

Fixes #1431
