### PR TITLE
Fail composition when a dangling override is rescued by an append

### DIFF
--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -574,16 +574,6 @@ def _create_defaults_tree_impl(
 
     _update_overrides(defaults_list, overrides, parent, interpolated_subtree)
 
-    # An externally appended group default is the one case where a group default
-    # may legally follow an override of the same group in a single defaults list.
-    # The reverse traversal below visits the appended entry before that override,
-    # so map each key to the list's last override for it, allowing the appended
-    # entry to register its override before resolving.
-    list_overrides: Dict[str, GroupDefault] = {}
-    for d in defaults_list:
-        if isinstance(d, GroupDefault) and d.is_override():
-            list_overrides[d.get_override_key()] = d
-
     def add_child(
         child_list: List[Union[InputDefault, DefaultsTreeNode]],
         new_root_: DefaultsTreeNode,
@@ -612,11 +602,6 @@ def _create_defaults_tree_impl(
                 continue
 
             d.update_parent(parent.get_group_path(), parent.get_final_package())
-
-            if isinstance(d, GroupDefault) and d.is_external_append():
-                pending = list_overrides.get(d.get_override_key())
-                if pending is not None:
-                    overrides.add_override(parent.get_config_path(), pending)
 
             if overrides.is_overridden(d):
                 assert isinstance(d, GroupDefault)

--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -146,6 +146,20 @@ class Overrides:
     def ensure_overrides_used(self) -> None:
         for key, meta in self.override_metadata.items():
             if not meta.used:
+                if not meta.external_override:
+                    # A Defaults List override must target a Group Default that
+                    # precedes it in the effective depth-first Defaults List.
+                    # Later entries, such as command line appends, are not
+                    # eligible targets and are not suggested as candidates.
+                    value = self.override_choices[key]
+                    msg = (
+                        f"Invalid Defaults List override '{meta.relative_key}: {value}'."
+                        f"\nNo earlier Group Default for '{key}' exists to override."
+                    )
+                    if meta.containing_config_path is not None:
+                        msg = f"In '{meta.containing_config_path}': {msg}"
+                    raise ConfigCompositionException(msg)
+
                 group = key.split("@")[0]
                 choices = (
                     self.known_choices_per_group[group]

--- a/news/3318.bugfix
+++ b/news/3318.bugfix
@@ -1,0 +1,1 @@
+A Defaults List override that does not target an earlier Group Default now fails to compose even when a command line append introduces a matching group, instead of silently discarding the appended value.

--- a/tests/defaults_list/data/dangling_nested_override.yaml
+++ b/tests/defaults_list/data/dangling_nested_override.yaml
@@ -1,0 +1,3 @@
+defaults:
+  - group1: file1
+  - override group1/group2: file2

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -215,11 +215,15 @@ def test_simple_defaults_tree_cases(
         param(
             "group_override_only",
             ["+group1=file1"],
-            DefaultsTreeNode(
-                node=ConfigDefault(path="group_override_only"),
-                children=[GroupDefault(group="group1", value="file2")],
+            raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    dedent("""\
+                        In 'group_override_only': Could not override 'group1'.
+                        Did you mean to override group1?""")
+                ),
             ),
-            id="group_override_only:append_overridden_group",
+            id="group_override_only:append_does_not_rescue_dangling_override",
         ),
     ],
 )
@@ -2624,6 +2628,15 @@ def test_missing_config_errors(
                 match="Could not override 'group1'. No match in the defaults list.",
             ),
             id="error_invalid_override",
+        ),
+        param(
+            "group_override_only",
+            [],
+            raises(
+                ConfigCompositionException,
+                match="Could not override 'group1'. No match in the defaults list.",
+            ),
+            id="dangling_override_without_append",
         ),
         param(
             "group_default",

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -218,12 +218,84 @@ def test_simple_defaults_tree_cases(
             raises(
                 ConfigCompositionException,
                 match=re.escape(
-                    dedent("""\
-                        In 'group_override_only': Could not override 'group1'.
-                        Did you mean to override group1?""")
+                    "In 'group_override_only': Invalid Defaults List override 'group1: file2'."
+                    "\nNo earlier Group Default for 'group1' exists to override."
                 ),
             ),
             id="group_override_only:append_does_not_rescue_dangling_override",
+        ),
+        param(
+            "dangling_nested_override",
+            ["group1=group_item1"],
+            DefaultsTreeNode(
+                node=ConfigDefault(path="dangling_nested_override"),
+                children=[
+                    DefaultsTreeNode(
+                        node=GroupDefault(group="group1", value="group_item1"),
+                        children=[
+                            GroupDefault(group="group2", value="file2"),
+                            ConfigDefault(path="_self_"),
+                        ],
+                    ),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="dangling_nested_override:selection_introduces_target",
+        ),
+        param(
+            "dangling_nested_override",
+            [],
+            raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "In 'dangling_nested_override': "
+                    "Invalid Defaults List override 'group1/group2: file2'."
+                    "\nNo earlier Group Default for 'group1/group2' exists to override."
+                ),
+            ),
+            id="dangling_nested_override:selection_does_not_introduce_target",
+        ),
+        param(
+            "dangling_nested_override",
+            ["group1/group2=file3"],
+            raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Could not override 'group1/group2'. No match in the defaults list."
+                ),
+            ),
+            id="dangling_nested_override:cli_override_does_not_recover",
+        ),
+        param(
+            "dangling_nested_override",
+            ["+group1/group2=file3"],
+            raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "In 'dangling_nested_override': "
+                    "Invalid Defaults List override 'group1/group2: file2'."
+                    "\nNo earlier Group Default for 'group1/group2' exists to override."
+                ),
+            ),
+            id="dangling_nested_override:cli_append_does_not_recover",
+        ),
+        param(
+            "dangling_nested_override",
+            ["group1=group_item1", "group1/group2=file3"],
+            DefaultsTreeNode(
+                node=ConfigDefault(path="dangling_nested_override"),
+                children=[
+                    DefaultsTreeNode(
+                        node=GroupDefault(group="group1", value="group_item1"),
+                        children=[
+                            GroupDefault(group="group2", value="file3"),
+                            ConfigDefault(path="_self_"),
+                        ],
+                    ),
+                    ConfigDefault(path="_self_"),
+                ],
+            ),
+            id="dangling_nested_override:cli_override_wins_when_target_introduced",
         ),
     ],
 )
@@ -347,7 +419,8 @@ def test_simple_group_override(
             raises(
                 ConfigCompositionException,
                 match=re.escape(
-                    "In 'invalid_override_in_defaults': Could not override 'foo'. No match in the defaults list."
+                    "In 'invalid_override_in_defaults': Invalid Defaults List override 'foo: bar'."
+                    "\nNo earlier Group Default for 'foo' exists to override."
                 )
                 + "$",
             ),
@@ -2625,7 +2698,10 @@ def test_missing_config_errors(
             [],
             raises(
                 ConfigCompositionException,
-                match="Could not override 'group1'. No match in the defaults list.",
+                match=re.escape(
+                    "In 'error_invalid_override': Invalid Defaults List override 'group1: file'."
+                    "\nNo earlier Group Default for 'group1' exists to override."
+                ),
             ),
             id="error_invalid_override",
         ),
@@ -2634,7 +2710,10 @@ def test_missing_config_errors(
             [],
             raises(
                 ConfigCompositionException,
-                match="Could not override 'group1'. No match in the defaults list.",
+                match=re.escape(
+                    "In 'group_override_only': Invalid Defaults List override 'group1: file2'."
+                    "\nNo earlier Group Default for 'group1' exists to override."
+                ),
             ),
             id="dangling_override_without_append",
         ),
@@ -2672,8 +2751,8 @@ def test_missing_config_errors(
             raises(
                 ConfigCompositionException,
                 match=re.escape(
-                    "In 'group1/override_invalid': Could not override 'group1/group2@group1.foo'."
-                    "\nDid you mean to override group1/group2?"
+                    "In 'group1/override_invalid': Invalid Defaults List override 'group2@foo: file1'."
+                    "\nNo earlier Group Default for 'group1/group2@group1.foo' exists to override."
                 ),
             ),
             id="nested_override_invalid_group",
@@ -2684,8 +2763,8 @@ def test_missing_config_errors(
             raises(
                 ConfigCompositionException,
                 match=re.escape(
-                    "In 'group1/override_invalid2': Could not override 'group1/group2'."
-                    "\nDid you mean to override group1/group2@group1.foo?"
+                    "In 'group1/override_invalid2': Invalid Defaults List override 'group2: file1'."
+                    "\nNo earlier Group Default for 'group1/group2' exists to override."
                 ),
             ),
             id="nested_override_invalid_group",
@@ -3495,7 +3574,8 @@ def test_select_multi_pkg(
                 ConfigCompositionException,
                 match=re.escape(
                     "In 'experiment/error_override_without_abs_and_header': "
-                    "Could not override 'experiment/group1'. No match in the defaults list"
+                    "Invalid Defaults List override 'group1: file1'."
+                    "\nNo earlier Group Default for 'experiment/group1' exists to override."
                 ),
             ),
             id="experiment/error_override_without_abs_and_header",
@@ -3507,7 +3587,8 @@ def test_select_multi_pkg(
                 ConfigCompositionException,
                 match=re.escape(
                     "In 'experiment/error_override_without_global': "
-                    "Could not override 'group1@experiment.group1'. No match in the defaults list"
+                    "Invalid Defaults List override '/group1: file1'."
+                    "\nNo earlier Group Default for 'group1@experiment.group1' exists to override."
                 ),
             ),
             id="experiment/error_override_without_global",


### PR DESCRIPTION
Fixes #3318

Rebased onto `main` now that #3315 has landed — single commit.

## Problem

Per #3318: a Defaults List override with no earlier Group Default correctly fails on its own, but a matching command line append made the composition succeed and silently discarded the appended value:

```yaml
# config.yaml
defaults:
  - override db: sqlite
```

```
$ python app.py +db=mysql      # composed db=sqlite on main and on #3315
```

## Fix

#3315 preserved this behavior deliberately (registering the list's own override when an externally appended group default of the same key resolves), on the principle that a precedence fix shouldn't change unrelated semantics. With #3318 ruling the behavior itself invalid, that registration path is removed. The appended entry now composes without consulting the dangling override, the override is reported unused, and composition fails exactly as it does without the append:

```
In 'config': Could not override 'db'.
Did you mean to override db?
```

- The failure is identical in cause to the no-append case (`ensure_overrides_used`), so `+db=mysql` never rescues the invalid Defaults List.
- Command line **overrides** of appended groups (`+db=mysql db=postgres`) are registered before traversal and still apply — covered by the existing suites.
- Both precedence behaviors from #3315 (the #3229 ordering and the review's two-defaults-list ordering) are unaffected; their regression tests still pass.

Per review, config-sourced dangling overrides are now reported directly instead of through the command-line-oriented candidate message:

```
In '<config>': Invalid Defaults List override '<key>: <value>'.
No earlier Group Default for '<full key>' exists to override.
```

The diagnostic is byte-identical with and without a command-line append and never suggests candidates. Command-line overrides keep their existing messages. Validity is evaluated against the effective depth-first Defaults List after command-line selections apply — an earlier selection that introduces the target makes a later config override valid, while later appends never do — covered by the five-case `dangling_nested_override` matrix from review.

## Tests

- `group_override_only` + `+group1=file1` → `ConfigCompositionException`. This test **fails on #3315** (where it composed), pinning the new semantics.
- `group_override_only` with no append → same failure as before the change, guarding against the fix drifting the base case.

`pytest tests/defaults_list tests/test_compose.py` → 423 passed. Full suite excluding `test_completion` → 2056 passed.
