### PR TITLE
Store ConfigStore configs with an empty group at the repository root

### DIFF
--- a/hydra/core/config_store.py
+++ b/hydra/core/config_store.py
@@ -70,6 +70,12 @@ class ConfigStore(metaclass=Singleton):
         :param provider: the name of the module/app providing this config.
             Helps debugging.
         """
+        # An empty group path represents a config outside any config group and is
+        # stored at the repository root, exactly like group=None. Splitting ""
+        # would instead create a literal empty-string child group, which help
+        # generation then traverses as the root group without terminating.
+        if group == "":
+            group = None
 
         cur = self.repo
         if group is not None:

--- a/hydra/core/config_store.py
+++ b/hydra/core/config_store.py
@@ -70,10 +70,7 @@ class ConfigStore(metaclass=Singleton):
         :param provider: the name of the module/app providing this config.
             Helps debugging.
         """
-        # An empty group path represents a config outside any config group and is
-        # stored at the repository root, exactly like group=None. Splitting ""
-        # would instead create a literal empty-string child group, which help
-        # generation then traverses as the root group without terminating.
+        # An empty string group is treated as a config without a config group.
         if group == "":
             group = None
 

--- a/news/2121.bugfix
+++ b/news/2121.bugfix
@@ -1,0 +1,1 @@
+ConfigStore.store with an empty string group now stores the config at the repository root, exactly like group=None, instead of creating an empty-named config group that makes --help generation recurse without terminating.

--- a/tests/test_config_repository.py
+++ b/tests/test_config_repository.py
@@ -16,6 +16,7 @@ from hydra._internal.core_plugins.importlib_resources_config_source import (
 from hydra._internal.core_plugins.structured_config_source import StructuredConfigSource
 from hydra.core.config_store import ConfigStore
 from hydra.core.default_element import GroupDefault, InputDefault
+from hydra.core.object_type import ObjectType
 from hydra.core.plugins import Plugins
 from hydra.core.singleton import Singleton
 from hydra.plugins.config_source import ConfigLoadError, ConfigSource
@@ -76,6 +77,32 @@ def test_caching_repository_uses_current_config_store(
     result = repository.load_config("registered_after_repository_copy.yaml")
     assert result is not None
     assert result.config == {"value": 10}
+
+
+def test_config_store_empty_group_is_stored_at_root(
+    hydra_restore_singletons: Any,
+) -> None:
+    """An empty group path represents a config outside any config group and must
+    behave exactly like group=None. Storing it under a literal empty-string child
+    group instead makes help generation traverse that child as the root group
+    without terminating."""
+    Plugins.instance()
+    cs = ConfigStore.instance()
+    cs.store(group="", name="empty_group_cfg", node={"age": 18})
+
+    assert "" not in cs.repo
+    stored = cs.repo["empty_group_cfg.yaml"]
+    assert stored.group is None
+    assert stored.node == {"age": 18}
+
+    repository = ConfigRepository(
+        config_search_path=create_config_search_path("structured://")
+    )
+    assert repository.config_exists("empty_group_cfg.yaml")
+    loaded = repository.load_config("empty_group_cfg.yaml")
+    assert loaded is not None
+    assert loaded.config == {"age": 18}
+    assert "" not in repository.get_group_options("", ObjectType.GROUP)
 
 
 @mark.parametrize(


### PR DESCRIPTION
Fixes #2121

## Problem

`ConfigStore.store(group="")` created a literal empty-string child group, because `"".split("/")` yields `[""]`:

```python
cs.store(group="", name="option1", node=GroupConfig)
# cs.repo keys: ['hydra', '_dummy_empty_config_.yaml', '']   ← empty-named group
```

Help generation then traverses that child as the root group without terminating — `list_all_config_groups` recurses on `""` forever and `--help` dies with `RecursionError`. Reproduced on current `main` with the issue's minimal app.

## Fix

Per the triage comment on the issue: an empty group path represents a config outside any config group, so treat `group=""` exactly like `group=None` and store the config at the repository root. One normalization at the top of `store()`; the stored `ConfigNode.group` is `None`, identical to the `group=None` path.

## Tests

`test_config_store_empty_group_is_stored_at_root` asserts the config lands at the repository root (no `''` key in `cs.repo`, `ConfigNode.group is None`), is loadable through a `structured://` `ConfigRepository` like any root config, and that the root group listing contains no empty-named child — the condition that made the traversal unbounded. Fails on `main`, passes with the fix.

`pytest tests/test_config_repository.py tests/defaults_list tests/test_compose.py tests/test_config_loader.py` → 742 passed. Full suite excluding `test_completion` → 2067 passed.
