### PR TITLE
Restore Joblib multiprocessing backend

### DIFF
--- a/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/_core.py
+++ b/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/_core.py
@@ -1,7 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import logging
+import sys
 from pathlib import Path
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, List, Sequence, Tuple, cast
 
 from hydra.core.hydra_config import HydraConfig
 from hydra.core.singleton import Singleton
@@ -13,12 +14,20 @@ from hydra.core.utils import (
     setup_globals,
 )
 from hydra.types import HydraContext, TaskFunction
-from joblib import Parallel, delayed, parallel_backend  # type: ignore
+from joblib import (  # type: ignore
+    Parallel,
+    delayed,
+    effective_n_jobs,
+    parallel_backend,
+    wrap_non_picklable_objects,
+)
 from omegaconf import DictConfig, open_dict
 
 from .joblib_launcher import JoblibLauncher
 
 log = logging.getLogger(__name__)
+
+SUPPORTED_BACKENDS = {"loky", "multiprocessing"}
 
 
 def execute_job(
@@ -27,9 +36,13 @@ def execute_job(
     hydra_context: HydraContext,
     config: DictConfig,
     task_function: TaskFunction,
-    singleton_state: Dict[Any, Any],
-) -> JobReturn:
+    task_function_unwrap_depth: int,
+    singleton_state: Any,
+    wrap_result: bool,
+) -> Any:
     """Calls `run_job` in parallel"""
+    for _ in range(task_function_unwrap_depth):
+        task_function = cast(TaskFunction, getattr(task_function, "__wrapped__"))
     setup_globals()
     Singleton.set_state(singleton_state)
 
@@ -49,10 +62,72 @@ def execute_job(
         job_subdir_key="hydra.sweep.subdir",
     )
 
+    if wrap_result:
+        ret = wrap_non_picklable_objects(ret, keep_wrapper=False)
     return ret
 
 
+def _get_multiprocessing_task_function(
+    task_function: TaskFunction,
+) -> Tuple[TaskFunction, int]:
+    module_name = getattr(task_function, "__module__", None)
+    task_name = getattr(task_function, "__name__", None)
+    if module_name is None or task_name is None:
+        return task_function, 0
+
+    module = sys.modules.get(module_name)
+    module_task_function = (
+        getattr(module, task_name, None) if module is not None else None
+    )
+
+    unwrap_depth = 0
+    candidate = module_task_function
+    while candidate is not task_function:
+        candidate = getattr(candidate, "__wrapped__", None)
+        if candidate is None:
+            raise TypeError(
+                "The Joblib multiprocessing backend requires function tasks to be "
+                "defined at module scope and decorators around @hydra.main to use "
+                "functools.wraps"
+            )
+        unwrap_depth += 1
+
+    return cast(TaskFunction, module_task_function), unwrap_depth
+
+
 def process_joblib_cfg(joblib_cfg: Dict[str, Any]) -> None:
+    backend = joblib_cfg.get("backend") or "loky"
+    if backend not in SUPPORTED_BACKENDS:
+        raise ValueError(
+            f"Unsupported Joblib backend '{backend}'. "
+            f"Supported backends: {sorted(SUPPORTED_BACKENDS)}"
+        )
+    joblib_cfg["backend"] = backend
+
+    inner_max_num_threads = joblib_cfg.get("inner_max_num_threads")
+    if inner_max_num_threads is not None and backend != "loky":
+        raise ValueError("inner_max_num_threads is supported only by the loky backend")
+
+    maxtasksperchild = joblib_cfg.pop("maxtasksperchild", None)
+    if backend == "multiprocessing":
+        if maxtasksperchild not in (None, 1):
+            raise ValueError(
+                "The multiprocessing backend fixes maxtasksperchild at 1 "
+                "to preserve per-job process isolation"
+            )
+        batch_size = joblib_cfg.get("batch_size", "auto")
+        if batch_size not in ("auto", "1", 1):
+            raise ValueError(
+                "The multiprocessing backend requires batch_size=1 "
+                "to preserve per-job process isolation"
+            )
+        joblib_cfg["batch_size"] = 1
+        joblib_cfg["maxtasksperchild"] = 1
+    elif maxtasksperchild is not None:
+        raise ValueError(
+            "maxtasksperchild is supported only by the multiprocessing backend"
+        )
+
     for k in ["pre_dispatch", "batch_size", "max_nbytes"]:
         if k in joblib_cfg.keys():
             try:
@@ -82,16 +157,21 @@ def launch(
     sweep_dir = Path(str(launcher.config.hydra.sweep.dir))
     sweep_dir.mkdir(parents=True, exist_ok=True)
 
-    # Joblib's backend is hard-coded to loky since the threading
-    # backend is incompatible with Hydra
     joblib_cfg = dict(launcher.joblib)
-    joblib_cfg["backend"] = "loky"
     process_joblib_cfg(joblib_cfg)
+    selected_backend = joblib_cfg["backend"]
     inner_max_num_threads = joblib_cfg.pop("inner_max_num_threads", None)
 
     backend = None
     backend_cfg = None
     parallel_cfg = dict(joblib_cfg)
+    # Joblib runs n_jobs=1 in the caller, so keep one task in flight in a worker pool.
+    if (
+        selected_backend == "multiprocessing"
+        and effective_n_jobs(parallel_cfg.get("n_jobs")) == 1
+    ):
+        parallel_cfg["n_jobs"] = 2
+        parallel_cfg["pre_dispatch"] = 1
     if inner_max_num_threads is not None:
         backend = parallel_cfg.pop("backend")
         parallel_cfg.pop("prefer", None)
@@ -121,6 +201,16 @@ def launch(
         log.info("\t#{} : {}".format(idx, " ".join(filter_overrides(overrides))))
 
     singleton_state = Singleton.get_state()
+    task_function = launcher.task_function
+    task_function_unwrap_depth = 0
+    wrap_for_multiprocessing = selected_backend == "multiprocessing"
+    if wrap_for_multiprocessing:
+        singleton_state = wrap_non_picklable_objects(
+            singleton_state, keep_wrapper=False
+        )
+        task_function, task_function_unwrap_depth = _get_multiprocessing_task_function(
+            task_function
+        )
 
     calls = (
         delayed(execute_job)(
@@ -128,8 +218,10 @@ def launch(
             overrides,
             launcher.hydra_context,
             launcher.config,
-            launcher.task_function,
+            task_function,
+            task_function_unwrap_depth,
             singleton_state,
+            wrap_for_multiprocessing,
         )
         for idx, overrides in enumerate(job_overrides)
     )

--- a/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/config.py
+++ b/plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/config.py
@@ -15,8 +15,8 @@ class JobLibLauncherConf:
     # limit the number of threads used by third-party libraries in each worker process
     inner_max_num_threads: Optional[int] = None
 
-    # allows to hard-code backend, otherwise inferred based on prefer and require
-    backend: Optional[str] = None
+    # process backend: loky (default) or multiprocessing
+    backend: Optional[str] = "loky"
 
     # processes or threads, soft hint to choose backend
     prefer: str = "processes"

--- a/plugins/hydra_joblib_launcher/news/2187.feature
+++ b/plugins/hydra_joblib_launcher/news/2187.feature
@@ -1,0 +1,1 @@
+Restore Joblib multiprocessing with per-job process isolation.

--- a/plugins/hydra_joblib_launcher/news/3323.api_change
+++ b/plugins/hydra_joblib_launcher/news/3323.api_change
@@ -1,0 +1,1 @@
+Require Hydra Core 1.4 and Joblib 1.5.3.

--- a/plugins/hydra_joblib_launcher/setup.py
+++ b/plugins/hydra_joblib_launcher/setup.py
@@ -28,8 +28,8 @@ setup(
     ],
     python_requires=">=3.10",
     install_requires=[
-        "hydra-core>=1.1.0.dev7",
-        "joblib>=0.14.0",
+        "hydra-core>=1.4.0.dev1,<1.5.0.dev0",
+        "joblib>=1.5.3",
     ],
     include_package_data=True,
 )

--- a/plugins/hydra_joblib_launcher/tests/apps/multiprocessing_app.py
+++ b/plugins/hydra_joblib_launcher/tests/apps/multiprocessing_app.py
@@ -1,0 +1,50 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import os
+from functools import wraps
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable, NoReturn
+
+import hydra
+from hydra.core.hydra_config import HydraConfig
+from omegaconf import DictConfig, OmegaConf
+
+
+class UnpickleableModule(ModuleType):
+    def __reduce__(self) -> NoReturn:
+        raise TypeError("This module facade must not be serialized")
+
+
+module_facade = UnpickleableModule("module_facade")
+
+
+def outer_decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if args or kwargs:
+            raise AssertionError("The outer decorator must not run inside a job")
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@outer_decorator
+@hydra.main(version_base=None, config_path=None)
+def app(cfg: DictConfig) -> Any:
+    assert module_facade.__name__ == "module_facade"
+    output_dir = Path(HydraConfig.get().runtime.output_dir)
+    (output_dir / "result.txt").write_text(
+        f"{os.getpid()} {cfg.runtime_value}",
+        encoding="utf-8",
+    )
+    if cfg.get("return_lambda", False):
+        return lambda value: value
+    return None
+
+
+if __name__ == "__main__":
+    OmegaConf.register_resolver(
+        "runtime_test",
+        lambda value: f"resolved-{value}",
+    )
+    app()

--- a/plugins/hydra_joblib_launcher/tests/apps/multiprocessing_callable_app.py
+++ b/plugins/hydra_joblib_launcher/tests/apps/multiprocessing_callable_app.py
@@ -1,0 +1,25 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+from pathlib import Path
+
+import hydra
+from hydra.core.hydra_config import HydraConfig
+from omegaconf import DictConfig
+
+
+class CallableTask:
+    def __init__(self, marker: str) -> None:
+        self.marker = marker
+
+    def __call__(self, cfg: DictConfig) -> None:
+        output_dir = Path(HydraConfig.get().runtime.output_dir)
+        (output_dir / "result.txt").write_text(
+            f"{self.marker}-{cfg.job}",
+            encoding="utf-8",
+        )
+
+
+app = hydra.main(version_base=None, config_path=None)(CallableTask("callable"))
+
+
+if __name__ == "__main__":
+    app()

--- a/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
+++ b/plugins/hydra_joblib_launcher/tests/test_joblib_launcher.py
@@ -17,11 +17,17 @@ from hydra.test_utils.test_utils import (
     run_python_script,
 )
 from omegaconf import OmegaConf
-from pytest import mark
+from pytest import mark, raises
 
+from hydra_plugins.hydra_joblib_launcher import _core
 from hydra_plugins.hydra_joblib_launcher.joblib_launcher import JoblibLauncher
 
 chdir_plugin_root()
+
+
+class CallableTask:
+    def __call__(self, cfg: Any) -> None:
+        pass
 
 
 def test_discovery() -> None:
@@ -95,11 +101,141 @@ def test_example_app_loads_its_config(tmp_path: Path) -> None:
     assert (tmp_path / "1" / "my_app.log").exists()
 
 
+@mark.parametrize("n_jobs", [1, 2])
+def test_multiprocessing_backend_isolates_jobs_and_preserves_state(
+    tmp_path: Path, n_jobs: int
+) -> None:
+    run_python_script(
+        [
+            "tests/apps/multiprocessing_app.py",
+            "--multirun",
+            "hydra/launcher=joblib",
+            "hydra.launcher.backend=multiprocessing",
+            f"hydra.launcher.n_jobs={n_jobs}",
+            "+job=0,1,2,3",
+            "+runtime_value=${runtime_test:ok}",
+            f'hydra.sweep.dir="{tmp_path}"',
+        ],
+    )
+
+    results = [
+        (tmp_path / str(job_num) / "result.txt").read_text(encoding="utf-8")
+        for job_num in range(4)
+    ]
+    pids = {result.split()[0] for result in results}
+
+    assert len(pids) == 4
+    assert {result.split()[1] for result in results} == {"resolved-ok"}
+
+
+def test_multiprocessing_backend_runs_callable_task(tmp_path: Path) -> None:
+    run_python_script(
+        [
+            "tests/apps/multiprocessing_callable_app.py",
+            "--multirun",
+            "hydra/launcher=joblib",
+            "hydra.launcher.backend=multiprocessing",
+            "hydra.launcher.n_jobs=2",
+            "+job=0,1",
+            f'hydra.sweep.dir="{tmp_path}"',
+        ],
+    )
+
+    assert {
+        (tmp_path / str(job_num) / "result.txt").read_text(encoding="utf-8")
+        for job_num in range(2)
+    } == {"callable-0", "callable-1"}
+
+
+def test_multiprocessing_backend_transports_non_picklable_return_value(
+    tmp_path: Path,
+) -> None:
+    run_python_script(
+        [
+            "tests/apps/multiprocessing_app.py",
+            "--multirun",
+            "hydra/launcher=joblib",
+            "hydra.launcher.backend=multiprocessing",
+            "hydra.launcher.n_jobs=2",
+            "+job=0",
+            "+runtime_value=${runtime_test:ok}",
+            "+return_lambda=true",
+            f'hydra.sweep.dir="{tmp_path}"',
+        ],
+    )
+
+    assert (tmp_path / "0" / "result.txt").exists()
+
+
+@mark.parametrize("backend", ["threading", "sequential", "dask"])
+def test_rejects_unsupported_backend(backend: str) -> None:
+    with raises(ValueError, match="Unsupported Joblib backend"):
+        _core.process_joblib_cfg({"backend": backend})
+
+
+def test_null_backend_defaults_to_loky() -> None:
+    config = {"backend": None}
+
+    _core.process_joblib_cfg(config)
+
+    assert config["backend"] == "loky"
+
+
+def test_multiprocessing_enforces_process_isolation() -> None:
+    config = {"backend": "multiprocessing", "batch_size": "auto"}
+
+    _core.process_joblib_cfg(config)
+
+    assert config["batch_size"] == 1
+    assert config["maxtasksperchild"] == 1
+
+
+def test_multiprocessing_accepts_callable_task() -> None:
+    task = CallableTask()
+
+    resolved_task, unwrap_depth = _core._get_multiprocessing_task_function(task)
+
+    assert resolved_task is task
+    assert unwrap_depth == 0
+
+
+def test_multiprocessing_rejects_undiscoverable_function() -> None:
+    def task(cfg: Any) -> None:
+        pass
+
+    with raises(TypeError, match="requires function tasks to be defined"):
+        _core._get_multiprocessing_task_function(task)
+
+
+@mark.parametrize(
+    "config, message",
+    [
+        (
+            {"backend": "multiprocessing", "inner_max_num_threads": 1},
+            "inner_max_num_threads is supported only by the loky backend",
+        ),
+        (
+            {"backend": "loky", "maxtasksperchild": 1},
+            "maxtasksperchild is supported only by the multiprocessing backend",
+        ),
+        (
+            {"backend": "multiprocessing", "batch_size": 2},
+            "requires batch_size=1",
+        ),
+        (
+            {"backend": "multiprocessing", "maxtasksperchild": 2},
+            "fixes maxtasksperchild at 1",
+        ),
+    ],
+)
+def test_rejects_backend_specific_option(config: dict[str, Any], message: str) -> None:
+    with raises(ValueError, match=message):
+        _core.process_joblib_cfg(config)
+
+
 def test_inner_max_num_threads_configures_loky_backend(
     hydra_sweep_runner: TSweepRunner, monkeypatch: Any
 ) -> None:
-    from hydra_plugins.hydra_joblib_launcher import _core
-
     calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
     real_parallel_backend = _core.parallel_backend
 
@@ -130,8 +266,6 @@ def test_inner_max_num_threads_configures_loky_backend(
 def test_inner_max_num_threads_does_not_require_n_jobs(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
-    from hydra_plugins.hydra_joblib_launcher import _core
-
     backend_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
     parallel_calls: list[dict[str, Any]] = []
 

--- a/website/docs/plugins/joblib_launcher.md
+++ b/website/docs/plugins/joblib_launcher.md
@@ -13,6 +13,18 @@ import GithubLink,{ExampleGithubLink} from "@site/src/components/GithubLink"
 
 The Joblib Launcher plugin provides a launcher for parallel tasks based on [`Joblib.Parallel`](https://joblib.readthedocs.io/en/latest/parallel.html).
 
+### Process backends
+
+The launcher supports two process backends:
+
+| Backend | Advantages | Tradeoffs |
+| --- | --- | --- |
+| `loky` (default) | Robust process management and Cloudpickle support for dynamically defined Python objects. It remains the default for compatibility. | Workers are reused between Hydra jobs, so arbitrary application caches or process-global state can leak between jobs. Cloudpickling the task can also fail when it reaches some native-library objects. |
+| `multiprocessing` | Runs every Hydra job in a fresh worker process and sends module-level function tasks by reference instead of Cloudpickling them. This provides strict process isolation and avoids serializing module-level native-library objects referenced by the task. | Functions must be defined at module scope. Custom decorators around `@hydra.main` must use `functools.wraps`. |
+
+Loky runs jobs in the parent process when `n_jobs=1`. The multiprocessing
+backend retains per-job worker isolation while executing one job at a time.
+
 ### Installation
 ```commandline
 pip install hydra-joblib-launcher --upgrade
@@ -25,7 +37,9 @@ Once installed, add `hydra/launcher=joblib` to your command line. Alternatively,
 defaults:
   - override hydra/launcher: joblib
 ```
-By default, process-based parallelism using all available CPU cores is used. By overriding the default configuration, it is e.g. possible limit the number of parallel executions.
+By default, the launcher uses process-based parallelism with all available CPU
+cores. Set `hydra.launcher.n_jobs` to limit the number of jobs that can run
+concurrently.
 
 The JobLibLauncherConf backing the config is defined <GithubLink to="plugins/hydra_joblib_launcher/hydra_plugins/hydra_joblib_launcher/config.py">here</GithubLink>:
 
@@ -35,7 +49,7 @@ You can discover the Joblib Launcher parameters with:
 _target_: hydra_plugins.hydra_joblib_launcher.joblib_launcher.JoblibLauncher
 n_jobs: -1
 inner_max_num_threads: null
-backend: null
+backend: loky
 prefer: processes
 require: null
 verbose: 0
@@ -49,6 +63,11 @@ mmap_mode: r
 There are several standard approaches for configuring plugins. Check [this page](../patterns/configuring_plugins.md) for more information.
 
 See [`Joblib.Parallel` documentation](https://joblib.readthedocs.io/en/latest/parallel.html) for full details about the parameters above.
+
+`backend` selects the backend used by this launcher. Because a backend is
+always selected explicitly, `prefer` does not change it. `require` must be
+compatible with the selected backend; `require=sharedmem` is unsupported
+because this launcher does not support a thread-based backend.
 
 #### Controlling native library thread pools
 
@@ -64,7 +83,26 @@ hydra:
 This can help avoid oversubscription when multiple Hydra jobs run in parallel and each job calls into a multithreaded native library. For arbitrary environment variables, use [`hydra.job.env_set`](../configure_hydra/job.md#hydrajobenv_set) instead.
 
 <div class="alert alert--info" role="alert">
-NOTE: The only supported JobLib backend is Loky (process-based parallelism).
+Select the `multiprocessing` backend to execute every job in a fresh worker
+process:
+
+```yaml
+hydra:
+  launcher:
+    backend: multiprocessing
+    n_jobs: 4
+```
+
+The launcher automatically sets Joblib's `batch_size=1` so that each pool task
+contains one Hydra job, and `maxtasksperchild=1` so that the worker exits after
+that task. These are internal correctness settings, not user configuration.
+Conflicting values are rejected.
+
+`inner_max_num_threads` is supported only by `loky`. Custom decorators around
+`@hydra.main` must follow the
+[Hydra task-decorator requirements](../advanced/decorating_main.md). Callable
+task objects are copied to each worker, so all state stored on them must support
+Python pickling.
 </div><br/>
 
 An <GithubLink to="plugins/hydra_joblib_launcher/example">example application</GithubLink> using this launcher is provided in the plugin repository.
@@ -73,7 +111,7 @@ Starting the app with `python my_app.py --multirun task=1,2,3,4,5` will launch f
 
 ```text
 $ python my_app.py --multirun task=1,2,3,4,5
-[HYDRA] Joblib.Parallel(n_jobs=-1,verbose=0,timeout=None,pre_dispatch=2*n_jobs,batch_size=auto,temp_folder=None,max_nbytes=None,mmap_mode=r,backend=loky) is launching 5 jobs
+[HYDRA] Joblib.Parallel(n_jobs=10,backend=loky,prefer=processes,require=None,verbose=0,timeout=None,pre_dispatch=2*n_jobs,batch_size=auto,temp_folder=None,max_nbytes=None,mmap_mode=r) is launching 5 jobs
 [HYDRA] Launching jobs, sweep output dir : multirun/2020-02-18/10-00-00
 [__main__][INFO] - Process ID 14336 executing task 2 ...
 [__main__][INFO] - Process ID 14333 executing task 1 ...


### PR DESCRIPTION
Allow the Joblib launcher to select Loky or multiprocessing while keeping Loky as the default. Transport module-level function tasks by reference for multiprocessing, restore Hydra singleton state in workers, and ensure every Hydra job runs in a fresh worker process.

Transport multiprocessing singleton state and job results through Joblib's public serialization wrapper so arbitrary task return values are preserved without relying on Joblib internals.

Add integration coverage for isolated workers, n_jobs=1, runtime resolvers, decorators, callable tasks, and non-picklable task return values. Document backend behavior and tradeoffs. Require Hydra Core 1.4 and Joblib 1.5.3.

Closes #2187