### PR TITLE
Preserve lazy interpolation in instantiate arguments

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -1,6 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-import copy
 import functools
 import inspect
 import os
@@ -323,8 +322,6 @@ def _call_target(
     """Call target (type) with args and kwargs."""
     try:
         args, kwargs = _extract_pos_args(args, kwargs)
-        args = tuple(_prepare_call_argument(arg) for arg in args)
-        kwargs = {key: _prepare_call_argument(value) for key, value in kwargs.items()}
     except Exception as e:
         msg = (
             f"Error in collecting args and kwargs for '{_convert_target_to_string(_target_)}':"
@@ -438,17 +435,6 @@ def _resolve_target(
         msg = f"Expected a callable target, got '{target}' of type '{type(target).__name__}'"
         raise InstantiationException(_with_full_key(msg, full_key))
     return target
-
-
-def _prepare_call_argument(value: Any) -> Any:
-    if OmegaConf.is_config(value):
-        parent = value._get_parent()
-        value = copy.deepcopy(value)
-        value._set_parent(parent)
-        value._set_flag("readonly", False)
-        OmegaConf.resolve(value)
-        value._set_parent(None)
-    return value
 
 
 def instantiate(

--- a/news/3216.api_change
+++ b/news/3216.api_change
@@ -1,4 +1,14 @@
 `hydra.utils.instantiate()` no longer eagerly resolves the entire configuration
-tree before instantiation. Interpolations are now resolved lazily. Applications
-that rely on eager resolution must call `OmegaConf.resolve(config)` before
-`instantiate(config)`.
+tree. Interpolations are now resolved as recursive traversal needs them.
+With `_recursive_=False` and the default `_convert_="none"`, Hydra no longer
+makes a final copy of OmegaConf containers before the target call. Containers
+passed through from the input tree retain their identity, lazy interpolations,
+ancestor context, resolver cache, and inherited flags.
+Applications that rely on eager resolution must call `OmegaConf.resolve(config)`
+before `instantiate(config)`. Mutations made by a target to such a Config
+container now affect the original configuration. Constructors or other called
+code that mutate inherited `readonly` or `struct` containers may also raise
+`ReadonlyConfigError` or `ConfigKeyError`; use OmegaConf's `read_write()` or
+`open_dict()` context managers around intentional mutations. See the
+[Hydra 1.4 instantiate migration guide](https://hydra.cc/docs/upgrades/1.3_to_1.4/instantiate_resolution/)
+for creating an independent Config copy.

--- a/news/3216.feature
+++ b/news/3216.feature
@@ -1,3 +1,2 @@
-`hydra.utils.instantiate()` now resolves interpolations lazily, enabling more
-flexible instantiation flows. Avoiding a copy and eager resolution of the entire
-configuration tree also makes instantiation 4 to 10 times faster in benchmarks.
+`hydra.utils.instantiate()` no longer copies the entire configuration tree,
+making instantiation 4 to 10 times faster in benchmarks.

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core.py
@@ -1,12 +1,12 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import logging
 from pathlib import Path
-from typing import Sequence
+from typing import Sequence, cast
 
 import ray
 from hydra.core.singleton import Singleton
 from hydra.core.utils import JobReturn, configure_log, filter_overrides, setup_globals
-from omegaconf import open_dict
+from omegaconf import DictConfig, OmegaConf, open_dict
 
 from ._launcher_util import launch_job_on_ray, start_ray
 from .ray_launcher import RayLauncher
@@ -33,8 +33,12 @@ def launch(
     )
 
     # Avoid allocating too little memory in CI https://github.com/ray-project/ray/issues/11966#issuecomment-1318100747
-    launcher.ray_cfg.init.setdefault("object_store_memory", 78643200)
-    start_ray(launcher.ray_cfg.init)
+    ray_init = cast(
+        DictConfig,
+        OmegaConf.create(OmegaConf.to_container(launcher.ray_cfg.init, resolve=True)),
+    )
+    ray_init.setdefault("object_store_memory", 78643200)
+    start_ray(ray_init)
 
     runs = []
     for idx, overrides in enumerate(job_overrides):

--- a/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core_aws.py
+++ b/plugins/hydra_ray_launcher/hydra_plugins/hydra_ray_launcher/_core_aws.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Sequence, Union, cast
 import cloudpickle  # type: ignore
 from hydra.core.singleton import Singleton
 from hydra.core.utils import JobReturn, configure_log, filter_overrides, setup_globals
-from omegaconf import Node, OmegaConf, open_dict, read_write
+from omegaconf import DictConfig, OmegaConf, open_dict
 
 from ._launcher_util import JOB_RETURN_PICKLE, JOB_SPEC_PICKLE, ray_tmp_dir, rsync
 from .ray_aws_launcher import RayAWSLauncher
@@ -60,19 +60,21 @@ def launch(
     assert launcher.hydra_context is not None
     assert launcher.task_function is not None
 
-    setup_commands = launcher.env_setup.commands
+    setup_commands = list(launcher.env_setup.commands)
     packages = filter(
         lambda x: x[1] is not None, launcher.env_setup.pip_packages.items()
     )
-    with read_write(setup_commands):
-        setup_commands.extend(
-            [f"pip install {package}=={version}" for package, version in packages]
-        )
-        setup_commands.extend(launcher.ray_cfg.cluster.setup_commands)
-
-    assert isinstance(launcher.ray_cfg.cluster, Node)
-    with read_write(launcher.ray_cfg.cluster):
-        launcher.ray_cfg.cluster.setup_commands = setup_commands
+    setup_commands.extend(
+        [f"pip install {package}=={version}" for package, version in packages]
+    )
+    setup_commands.extend(launcher.ray_cfg.cluster.setup_commands)
+    ray_cluster = cast(
+        DictConfig,
+        OmegaConf.create(
+            OmegaConf.to_container(launcher.ray_cfg.cluster, resolve=True)
+        ),
+    )
+    ray_cluster["setup_commands"] = setup_commands
 
     configure_log(launcher.config.hydra.hydra_logging, launcher.config.hydra.verbose)
     logging_config = cast(
@@ -106,16 +108,20 @@ def launch(
             singleton_state=Singleton.get_state(),
         )
         return launch_jobs(
-            launcher, local_tmp_dir, Path(launcher.config.hydra.sweep.dir)
+            launcher,
+            local_tmp_dir,
+            Path(launcher.config.hydra.sweep.dir),
+            ray_cluster,
         )
 
 
 def launch_jobs(
-    launcher: RayAWSLauncher, local_tmp_dir: str, sweep_dir: Path
+    launcher: RayAWSLauncher,
+    local_tmp_dir: str,
+    sweep_dir: Path,
+    ray_cluster: DictConfig,
 ) -> Sequence[JobReturn]:
-    config = OmegaConf.to_container(
-        launcher.ray_cfg.cluster, resolve=True, enum_to_str=True
-    )
+    config = OmegaConf.to_container(ray_cluster, resolve=True, enum_to_str=True)
     sdk.create_or_update_cluster(
         config,
         **cast(Dict[str, Any], launcher.create_update_cluster),

--- a/plugins/hydra_ray_launcher/tests/test_ray_launcher.py
+++ b/plugins/hydra_ray_launcher/tests/test_ray_launcher.py
@@ -1,5 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
 
 from hydra.core.plugins import Plugins
 from hydra.plugins.launcher import Launcher
@@ -8,8 +11,11 @@ from hydra.test_utils.launcher_common_tests import (
     LauncherTestSuite,
 )
 from hydra.test_utils.test_utils import chdir_plugin_root
+from omegaconf import OmegaConf
 from pytest import mark
 
+from hydra_plugins.hydra_ray_launcher import _core_aws
+from hydra_plugins.hydra_ray_launcher.ray_aws_launcher import RayAWSLauncher
 from hydra_plugins.hydra_ray_launcher.ray_launcher import RayLauncher
 
 chdir_plugin_root()
@@ -56,3 +62,59 @@ class TestRayLauncherIntegration(IntegrationTestSuite):
     """
 
     pass
+
+
+def test_ray_aws_launch_does_not_mutate_launcher_config(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    cfg = OmegaConf.create(
+        {
+            "env_setup": {
+                "commands": ["base"],
+                "pip_packages": {"example": "1.0"},
+            },
+            "ray": {"cluster": {"setup_commands": ["cluster"]}},
+            "logging": {},
+            "hydra": {
+                "hydra_logging": {},
+                "verbose": False,
+                "sweep": {"dir": str(tmp_path)},
+            },
+        }
+    )
+    original = OmegaConf.to_container(cfg, resolve=False)
+    launcher = cast(
+        RayAWSLauncher,
+        SimpleNamespace(
+            config=cfg,
+            env_setup=cfg.env_setup,
+            hydra_context=object(),
+            logging=cfg.logging,
+            ray_cfg=cfg.ray,
+            task_function=lambda: None,
+        ),
+    )
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(_core_aws, "configure_log", lambda *args: None)
+    monkeypatch.setattr(_core_aws.sdk, "configure_logging", lambda **kwargs: None)
+    monkeypatch.setattr(_core_aws, "_pickle_jobs", lambda **kwargs: None)
+
+    def launch_jobs(
+        launcher: Any,
+        local_tmp_dir: str,
+        sweep_dir: Path,
+        ray_cluster: Any,
+    ) -> list[Any]:
+        captured["ray_cluster"] = ray_cluster
+        return []
+
+    monkeypatch.setattr(_core_aws, "launch_jobs", launch_jobs)
+
+    assert _core_aws.launch(launcher, [], 0) == []
+    assert OmegaConf.to_container(cfg, resolve=False) == original
+    assert captured["ray_cluster"].setup_commands == [
+        "base",
+        "pip install example==1.0",
+        "cluster",
+    ]

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -650,8 +650,12 @@ def test_interpolation_accessing_parent(
 
 
 def test_instantiate_does_not_copy_unrelated_root_siblings(
-    instantiate_func: Any, monkeypatch: Any
+    instantiate_func: Any,
 ) -> None:
+    class Uncopyable:
+        def __deepcopy__(self, memo: Any) -> Any:
+            raise AssertionError("instantiate() copied an unrelated root sibling")
+
     cfg = OmegaConf.create(
         {
             "node": {
@@ -661,47 +665,144 @@ def test_instantiate_does_not_copy_unrelated_root_siblings(
                 "c": 30,
             },
             "value": 10,
-            "unrelated": {"data": [1, 2, 3]},
+            "unrelated": Uncopyable(),
         },
+        flags={"allow_objects": True},
     )
-    original_deepcopy = copy.deepcopy
-
-    def deepcopy_except_root(value: Any, memo: Any = None) -> Any:
-        assert value is not cfg, "instantiate() copied the full configuration root"
-        if memo is None:
-            return original_deepcopy(value)
-        return original_deepcopy(value, memo)
-
-    monkeypatch.setattr(_instantiate2.copy, "deepcopy", deepcopy_except_root)
 
     assert instantiate_func(cfg.node) == AClass(a=10, b=20, c=30)
 
 
-def test_non_recursive_config_argument_is_copied_before_resolve_and_detach(
+def test_non_recursive_config_argument_is_passed_directly_without_resolving(
     instantiate_func: Any,
 ) -> None:
     cfg = OmegaConf.create(
         {
-            "value": 10,
             "node": {
                 "_target_": "tests.instantiate.ArgsClass",
                 "_recursive_": False,
-                "payload": {"value": "${value}"},
+                "payload": {
+                    "value": 10,
+                    "alias": "${.value}",
+                },
             },
-        }
+        },
+        flags={"allow_objects": True},
     )
     OmegaConf.set_readonly(cfg, True)
+    OmegaConf.set_struct(cfg, True)
     original_config = str(cfg)
     source_payload = cfg.node.payload
 
     result = instantiate_func(cfg.node)
     payload = result.kwargs["payload"]
 
-    assert payload == {"value": 10}
-    assert payload is not source_payload
-    assert payload._get_parent() is None
+    assert OmegaConf.to_container(payload, resolve=False) == {
+        "value": 10,
+        "alias": "${.value}",
+    }
+    assert payload is source_payload
+    assert payload._get_parent() is cfg.node
     assert source_payload._get_parent() is cfg.node
+    assert OmegaConf.is_readonly(payload)
+    assert OmegaConf.is_struct(payload)
+    assert payload._get_flag("allow_objects")
+    assert payload.alias == 10
     assert str(cfg) == original_config
+
+
+def test_non_recursive_config_argument_uses_source_resolver_cache(
+    instantiate_func: Any,
+) -> None:
+    resolver_name = "hydra_instantiate_cached_config_argument"
+    calls = 0
+
+    def resolver() -> int:
+        nonlocal calls
+        calls += 1
+        return calls
+
+    OmegaConf.register_resolver(
+        resolver_name,
+        resolver,
+        replace=True,
+        use_cache=True,
+    )
+    cfg = OmegaConf.create(
+        {
+            "first": f"${{{resolver_name}:}}",
+            "node": {
+                "_target_": "tests.instantiate.ArgsClass",
+                "_recursive_": False,
+                "payload": {"value": f"${{{resolver_name}:}}"},
+            },
+        }
+    )
+
+    try:
+        assert cfg.first == 1
+        result = instantiate_func(cfg.node)
+        payload = result.kwargs["payload"]
+
+        assert payload is cfg.node.payload
+        assert payload.value == 1
+        assert calls == 1
+    finally:
+        OmegaConf.clear_resolver(resolver_name)
+
+
+def test_non_recursive_runtime_config_argument_is_passed_directly_and_remains_lazy(
+    instantiate_func: Any,
+) -> None:
+    runtime_config = OmegaConf.create(
+        {
+            "num_classes": -1,
+            "model": {"num_class": "${num_classes}"},
+        }
+    )
+
+    result = instantiate_func(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "_recursive_": False,
+        },
+        cfg=runtime_config,
+    )
+    cfg = result.kwargs["cfg"]
+    cfg.num_classes = 10
+
+    assert cfg is runtime_config
+    assert cfg._get_parent() is None
+    assert cfg.model.num_class == 10
+    assert runtime_config.num_classes == 10
+    assert runtime_config.model.num_class == 10
+
+
+def test_non_recursive_runtime_config_supports_late_resolver_registration(
+    instantiate_func: Any,
+) -> None:
+    resolver_name = "hydra_instantiate_late_runtime_config"
+    OmegaConf.clear_resolver(resolver_name)
+    runtime_config = OmegaConf.create({"value": f"${{{resolver_name}:}}"})
+
+    try:
+        result = instantiate_func(
+            {
+                "_target_": "tests.instantiate.ArgsClass",
+                "_recursive_": False,
+            },
+            cfg=runtime_config,
+        )
+        cfg = result.kwargs["cfg"]
+        assert cfg is runtime_config
+        OmegaConf.register_resolver(resolver_name, lambda: 42)
+
+        assert OmegaConf.to_container(cfg, resolve=False) == {
+            "value": f"${{{resolver_name}:}}"
+        }
+        assert cfg.value == 42
+    finally:
+        OmegaConf.clear_resolver(resolver_name)
 
 
 def test_top_level_instantiation_control_keys_are_not_in_result(
@@ -781,10 +882,10 @@ def test_instantiate_adam(instantiate_func: Any, config: Any) -> None:
 @mark.parametrize("is_partial", [True, False])
 def test_regression_1483(instantiate_func: Any, is_partial: bool) -> None:
     """
-    In 1483, pickle is failing because the parent node of lst node contains
-    a generator, which is not picklable.
-    The solution is to resolve and retach from the parent before calling the function.
-    This tests verifies the expected behavior.
+    In 1483, call-site arguments were merged into one OmegaConf tree, so the
+    ListConfig argument retained an unpicklable generator through its parent.
+    Keeping call-site arguments separate leaves the ListConfig independently
+    picklable without eager resolution or detachment.
     """
 
     def gen() -> Any:
@@ -798,9 +899,11 @@ def test_regression_1483(instantiate_func: Any, is_partial: bool) -> None:
     )
     if is_partial:
         # res is of type functools.partial
-        pickle.dumps(res.keywords["lst"])  # type: ignore
+        lst = res.keywords["lst"]  # type: ignore
     else:
-        pickle.dumps(res.kwargs["lst"])
+        lst = res.kwargs["lst"]
+    assert lst._get_parent() is None
+    pickle.dumps(lst)
 
 
 def test_runtime_object_override_replaces_unresolvable_config_value(

--- a/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
+++ b/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
@@ -24,9 +24,10 @@ This has several benefits:
   forcing Hydra to resolve the replaced value first.
 - An earlier target can establish runtime state, such as registering a custom
   resolver, before a later argument is resolved.
-- OmegaConf containers passed to a target are still copied, resolved while
-  attached to their original parent, and then detached. This preserves the
-  serialization safety of previous Hydra versions.
+- With `_recursive_=False` and the default `_convert_="none"`, Hydra no longer
+  makes a final copy of OmegaConf containers before the target call. Containers
+  passed through from the input tree retain their identity, lazy
+  interpolations, ancestor context, resolver cache, and inherited flags.
 
 ## Compatibility impact
 
@@ -104,6 +105,43 @@ Hydra 1.3 merged `b=99` into a copied configuration before resolving `${b}`,
 so `c` also became `99`. Hydra 1.4 leaves `cfg` unchanged, resolves `${b}`
 against the original configuration, and independently passes the call-site
 value `b=99` to the target.
+
+With `_recursive_=False` and `_convert_="none"`, OmegaConf containers are also
+no longer copied and detached before the target call. The target receives the
+same `DictConfig`, `ListConfig`, or `TupleConfig` object from the input tree.
+Mutations made by the target are therefore visible through the original
+configuration, and an attached subtree retains its ancestor configuration when
+stored or serialized. Other conversion modes retain their documented
+conversion behavior.
+
+To pass an independent Config object instead, create one explicitly:
+
+```python
+cfg = OmegaConf.create(
+    {
+        "_target_": "builtins.dict",
+        "_recursive_": False,
+        "payload": {"value": 10, "alias": "${.value}"},
+    }
+)
+independent = OmegaConf.create(cfg.payload)
+result = instantiate(
+    cfg,
+    payload=independent,
+    _target_whitelist_="builtins.dict",
+)
+assert result["payload"] is independent
+```
+
+`OmegaConf.create()` preserves lazy interpolations within the copied container.
+If an interpolation depends on an ancestor outside that container, resolve it
+while copying:
+
+```python
+independent = OmegaConf.create(
+    OmegaConf.to_container(cfg.payload, resolve=True)
+)
+```
 
 If another argument should use the call-site value, pass that argument
 explicitly as well:


### PR DESCRIPTION

Pass OmegaConf containers directly to targets when recursive instantiation is disabled and conversion is none. Preserve container identity, ancestor context, resolver caches, inherited flags, and lazy interpolation behavior.

Keep Ray launcher augmentation local so the new identity semantics do not mutate the live Hydra configuration. Add regression coverage for direct container passing, resolver caching, serialization, runtime mutation, and Ray AWS configuration isolation.

Document the breaking behavior, conversion boundaries, and explicit-copy migration path. Separate the performance feature from the API compatibility notice.

Fixes #2268
