### PR TITLE
Fix instantiate to set allow_objects flag when config is already an OmegaConf node

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -517,6 +517,14 @@ def instantiate(
         or type(config) is tuple
     ):
         config = OmegaConf.structured(config, flags={"allow_objects": True})
+    elif OmegaConf.is_config(config):
+        # If config is already an OmegaConf node, ensure allow_objects is set
+        # on the root to support custom resolvers that return objects
+        root = config
+        while root._get_parent() is not None:
+            root = root._get_parent()
+        if not root._metadata.flags.get("allow_objects", False):
+            root._metadata.flags["allow_objects"] = True
 
     if OmegaConf.is_dict(config):
         return instantiate_node(

--- a/news/1865.bugfix
+++ b/news/1865.bugfix
@@ -1,0 +1,1 @@
+Fix instantiate to set allow_objects flag on config root when input is already an OmegaConf node

--- a/test_issue_1865.py
+++ b/test_issue_1865.py
@@ -1,0 +1,51 @@
+import omegaconf
+from hydra.utils import instantiate
+from omegaconf import OmegaConf
+
+class MyObject:
+    def __init__(self, arg):
+        self.arg = arg
+
+omegaconf.OmegaConf.register_new_resolver("as_myobject", lambda arg: MyObject(arg))
+
+class ClassA:
+    def __init__(self, arg_A):
+        self.arg_A = arg_A
+
+class ClassB:
+    def __init__(self, arg_B: MyObject):
+        self.arg_B = arg_B
+
+# Create config
+config = OmegaConf.create({
+    "vec": {
+        "_target_": "__main__.ClassB",
+        "arg_B": "${as_myobject:abc}"
+    },
+    "pipe": {
+        "_target_": "__main__.ClassA",
+        "arg_A": "${vec}"
+    }
+})
+
+print("Testing instantiate(cfg)...")
+try:
+    result = instantiate(config)
+    print("Success!")
+except Exception as e:
+    print(f"Failed: {e}")
+
+print("\nTesting instantiate(cfg.vec)...")
+try:
+    result = instantiate(config.vec)
+    print("Success!")
+except Exception as e:
+    print(f"Failed: {e}")
+
+print("\nTesting instantiate(cfg.pipe)...")
+try:
+    result = instantiate(config.pipe)
+    print("Success! (This should work but currently fails)")
+except Exception as e:
+    print(f"Failed with expected error: {type(e).__name__}")
+    print(f"Error message: {e}")

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -3087,3 +3087,67 @@ def test_dict_as_none(instantiate_func: Any) -> None:
     cfg = OmegaConf.structured(DictValuesConf)
     obj = instantiate_func(config=cfg)
     assert obj.d is None
+
+
+def test_issue_1865_nested_instantiation_with_resolver_objects(
+    instantiate_func: Any,
+) -> None:
+    """
+    Test that instantiation works when _target_ arg interpolates to another
+    node with _target_ key and a custom resolver that returns objects.
+    
+    Regression test for https://github.com/facebookresearch/hydra/issues/1865
+    """
+
+    class MyObject:
+        def __init__(self, arg: str) -> None:
+            self.arg = arg
+
+    OmegaConf.register_new_resolver(
+        "test_1865_as_myobject", lambda arg: MyObject(arg), replace=True
+    )
+
+    class ClassA:
+        def __init__(self, arg_A: Any) -> None:
+            self.arg_A = arg_A
+
+    class ClassB:
+        def __init__(self, arg_B: MyObject) -> None:
+            self.arg_B = arg_B
+
+    config = OmegaConf.create(
+        {
+            "vec": {
+                "_target_": "tests.instantiate.test_instantiate.ClassB",
+                "arg_B": "${test_1865_as_myobject:abc}",
+            },
+            "pipe": {
+                "_target_": "tests.instantiate.test_instantiate.ClassA",
+                "arg_A": "${vec}",
+            },
+        }
+    )
+
+    # Store the classes in the test module so _locate can find them
+    import sys
+    import tests.instantiate.test_instantiate as test_mod
+
+    test_mod.ClassA = ClassA
+    test_mod.ClassB = ClassB
+
+    # Test instantiating the full config
+    result = instantiate_func(config)
+    assert isinstance(result, dict)
+
+    # Test instantiating vec directly - should work
+    result_vec = instantiate_func(config.vec)
+    assert isinstance(result_vec, ClassB)
+    assert isinstance(result_vec.arg_B, MyObject)
+    assert result_vec.arg_B.arg == "abc"
+
+    # Test instantiating pipe directly - this was failing before the fix
+    result_pipe = instantiate_func(config.pipe)
+    assert isinstance(result_pipe, ClassA)
+    assert isinstance(result_pipe.arg_A, ClassB)
+    assert isinstance(result_pipe.arg_A.arg_B, MyObject)
+    assert result_pipe.arg_A.arg_B.arg == "abc"


### PR DESCRIPTION
## Motivation

When calling `instantiate()` with a sub-node of an existing OmegaConf config (e.g., `instantiate(cfg.pipe)`), instantiation fails if the config contains interpolations to nodes with `_target_` keys that use custom resolvers returning objects. This occurs because the `allow_objects` flag was only set when converting plain dicts/structured configs to OmegaConf, but not when the config was already an OmegaConf node.

## Contributing Guidelines acknowledgment

Yes

## Design alignment

This fix addresses issue #1865, which was confirmed by maintainers and is tracked for Hydra 1.4.

## Test Plan

Added regression test `test_issue_1865_nested_instantiation_with_resolver_objects` that reproduces the exact failure scenario: instantiating a config node where an argument interpolates to another node with `_target_` and a custom resolver returning objects. The test verifies that:

1. Instantiating the full config works
2. Instantiating the interpolated node directly works  
3. Instantiating the parent node that references the interpolated node works (previously failed)

The fix ensures the `allow_objects` flag is set on the root of the config tree when an already-constructed OmegaConf node is passed to `instantiate()`, enabling custom resolvers to return object instances during interpolation resolution.

## Related Issues and PRs

Fixes #1865
