### PR TITLE
Fix macOS CI cache restoration

### DIFF
--- a/.github/actions/macos/action.yml
+++ b/.github/actions/macos/action.yml
@@ -8,7 +8,7 @@ runs:
   - name: restore_cache
     uses: actions/cache@v4.2.0
     with:
-      key: "-${{ inputs.cache_key_version }}-macos-sys-{{ .Branch }}-${{ inputs.py_version }}"
+      key: "macos-sys-v1-${{ runner.arch }}-${{ inputs.py_version }}"
       path: |-
         ~/miniconda3
         ~/Library/Caches/Homebrew
@@ -40,10 +40,3 @@ runs:
       conda create -n hydra python=${{ inputs.py_version }} -yqc conda-forge
       conda run -n hydra pip install nox --progress-bar off
     shell: bash
-  - name: save_cache
-    uses: actions/cache@v4.2.0
-    with:
-      path: |-
-        ~/miniconda3
-        ~/Library/Caches/Homebrew
-      key: "-${{ inputs.cache_key_version }}-macos-sys-{{ .Branch }}-${{ inputs.py_version }}"


### PR DESCRIPTION
## Summary

- stop restoring the Miniconda cache a second time after environment setup
- replace the malformed cache key with a versioned architecture/Python key

## Why

The second `actions/cache` invocation restored stale files over the newly
updated environment. That mixed incompatible pip versions and caused macOS CI
to fail with an import error before the tests started.

## Validation

- `.venv/bin/yamllint --strict .github/actions/macos/action.yml`
- the same change passed the previous Python 3.14 macOS failure point in
  https://github.com/facebookresearch/hydra/actions/runs/30768981331
