### PR TITLE
Remove Hydra 1.1 compatibility

### DIFF
--- a/hydra/_internal/config_repository.py
+++ b/hydra/_internal/config_repository.py
@@ -2,7 +2,6 @@
 import copy
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from textwrap import dedent
 from typing import Dict, List, Optional, Tuple
 
 from omegaconf import (
@@ -15,13 +14,11 @@ from omegaconf import (
     read_write,
 )
 
-from hydra import version
 from hydra.core.config_search_path import ConfigSearchPath
 from hydra.core.object_type import ObjectType
 from hydra.plugins.config_source import ConfigResult, ConfigSource
 
 from ..core.default_element import ConfigDefault, GroupDefault, InputDefault
-from .deprecation_warning import deprecation_warning
 from .sources_registry import SourcesRegistry
 
 
@@ -170,24 +167,10 @@ class ConfigRepository(IConfigRepository):
         config_path: str,
         defaults: ListConfig,
     ) -> List[InputDefault]:
-        def issue_deprecated_name_warning() -> None:
-            # DEPRECATED: remove in 1.2
-            url = "https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_package_header"
-            deprecation_warning(
-                message=dedent(f"""\
-                    In {config_path}: Defaults List contains deprecated keyword _name_, see {url}
-                    """),
-            )
-
         res: List[InputDefault] = []
         for item in defaults._iter_ex(resolve=False):
             default: InputDefault
             if isinstance(item, DictConfig):
-                old_optional = None
-                if not version.base_at_least("1.2"):
-                    if len(item) > 1:
-                        if "optional" in item:
-                            old_optional = item.pop("optional")
                 keys = list(item.keys())
 
                 if len(keys) > 1:
@@ -205,24 +188,9 @@ class ConfigRepository(IConfigRepository):
                     config_path, config_group, keywords
                 )
 
-                if not version.base_at_least("1.2"):
-                    if not keywords.optional and old_optional is not None:
-                        keywords.optional = old_optional
-
                 node = item._get_node(key)
                 assert node is not None and isinstance(node, Node)
                 config_value = node._value()
-
-                if not version.base_at_least("1.2"):
-                    if old_optional is not None:
-                        msg = dedent(
-                            f"""
-                            In {config_path}: 'optional: true' is deprecated.
-                            Use 'optional {key}: {config_value}' instead.
-                            Support for the old style is removed for Hydra version_base >= 1.2"""
-                        )
-
-                        deprecation_warning(msg)
 
                 if config_value is not None and not isinstance(
                     config_value, (str, list)
@@ -244,10 +212,6 @@ class ConfigRepository(IConfigRepository):
                         options.append(vv)
                     config_value = options
 
-                if not version.base_at_least("1.2"):
-                    if package is not None and "_name_" in package:
-                        issue_deprecated_name_warning()
-
                 default = GroupDefault(
                     group=keywords.group,
                     value=config_value,
@@ -258,10 +222,6 @@ class ConfigRepository(IConfigRepository):
 
             elif isinstance(item, str):
                 path, package, _package2 = self._split_group(item)
-                if not version.base_at_least("1.2"):
-                    if package is not None and "_name_" in package:
-                        issue_deprecated_name_warning()
-
                 default = ConfigDefault(path=path, package=package)
             else:
                 raise ValueError(

--- a/hydra/_internal/defaults_list.py
+++ b/hydra/_internal/defaults_list.py
@@ -9,7 +9,7 @@ from typing import Callable, Dict, List, Optional, Set, Tuple, Union
 
 from omegaconf import DictConfig, OmegaConf
 
-from hydra import MissingConfigException, version
+from hydra import MissingConfigException
 from hydra._internal.config_repository import IConfigRepository
 from hydra.core.config_store import ConfigStore
 from hydra.core.default_element import (
@@ -23,8 +23,6 @@ from hydra.core.default_element import (
 from hydra.core.object_type import ObjectType
 from hydra.core.override_parser.types import Override
 from hydra.errors import ConfigCompositionException
-
-from .deprecation_warning import deprecation_warning
 
 cs = ConfigStore.instance()
 
@@ -364,23 +362,6 @@ def _check_not_missing(
     return False
 
 
-def _create_legacy_interpolation_map(
-    overrides: Overrides,
-    defaults_list: List[InputDefault],
-    self_added: bool,
-) -> DictConfig:
-    known_choices = OmegaConf.create(overrides.known_choices)
-    known_choices.defaults = []
-    for d in defaults_list:
-        if self_added and d.is_self():
-            continue
-        if isinstance(d, ConfigDefault):
-            known_choices.defaults.append(d.get_config_path())
-        elif isinstance(d, GroupDefault):
-            known_choices.defaults.append({d.get_override_key(): d.value})
-    return known_choices
-
-
 def _create_defaults_tree(
     repo: IConfigRepository,
     root: DefaultsTreeNode,
@@ -541,17 +522,7 @@ def _update_overrides(
             continue
         d.update_parent(parent.get_group_path(), parent.get_final_package())
 
-        legacy_hydra_override = False
-        if isinstance(d, GroupDefault):
-            assert d.group is not None
-            if not version.base_at_least("1.2"):
-                legacy_hydra_override = not d.is_override() and d.group.startswith(
-                    "hydra/"
-                )
-
-        if seen_override and not (
-            d.is_override() or d.is_external_append() or legacy_hydra_override
-        ):
+        if seen_override and not (d.is_override() or d.is_external_append()):
             assert isinstance(last_override_seen, GroupDefault)
             pcp = parent.get_config_path()
             okey = last_override_seen.get_override_key()
@@ -568,19 +539,8 @@ def _update_overrides(
             )
 
         if isinstance(d, GroupDefault):
-            if legacy_hydra_override:
-                d.override = True
-                url = "https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/defaults_list_override"
-                msg = dedent(f"""\
-                    In {parent.get_config_path()}: Invalid overriding of {d.group}:
-                    Default list overrides requires 'override' keyword.
-                    See {url} for more information.
-                    """)
-                deprecation_warning(msg)
-
             if d.override:
-                if not legacy_hydra_override:
-                    seen_override = True
+                seen_override = True
                 last_override_seen = d
                 if interpolated_subtree:
                     # Since interpolations are deferred for until all the config groups are already set,
@@ -664,7 +624,6 @@ def _create_defaults_tree_impl(
     if defaults_list is None:
         defaults_list = []
 
-    self_added = False
     if (
         len(defaults_list) > 0
         or is_root_config
@@ -674,7 +633,7 @@ def _create_defaults_tree_impl(
             loaded.config, DictConfig
         ) and _has_config_content(loaded.config)
 
-        self_added = _validate_self(
+        _validate_self(
             containing_node=parent,
             defaults=defaults_list,
             has_config_content=has_config_content,
@@ -756,49 +715,19 @@ def _create_defaults_tree_impl(
 
             else:
                 if d.is_interpolation():
-                    if version.base_at_least("1.2") or not d.is_legacy_interpolation():
-                        # Preserve which overrides are eligible at this point in
-                        # the reverse depth-first traversal.
-                        keys = (
-                            overrides.override_choices.keys()
-                            if eligible_override_keys is None
-                            else eligible_override_keys
-                        )
-                        deferred_interpolation_override_keys[id(d)] = set(keys)
+                    # Preserve which overrides are eligible at this point in
+                    # the reverse depth-first traversal.
+                    keys = (
+                        overrides.override_choices.keys()
+                        if eligible_override_keys is None
+                        else eligible_override_keys
+                    )
+                    deferred_interpolation_override_keys[id(d)] = set(keys)
                     children.append(d)
                     continue
 
                 new_root = DefaultsTreeNode(node=d, parent=root)
                 add_child(children, new_root)
-
-    # TODO: Remove Hydra 1.1 compatibility in
-    # https://github.com/facebookresearch/hydra/issues/3221.
-    if not version.base_at_least("1.2"):
-        known_choices = _create_legacy_interpolation_map(
-            overrides, defaults_list, self_added
-        )
-        for idx, dd in enumerate(children):
-            if (
-                isinstance(dd, InputDefault)
-                and dd.is_interpolation()
-                and dd.is_legacy_interpolation()
-            ):
-                dd.resolve_interpolation(known_choices)
-                _check_parent_traversal(dd, parent)
-                new_root = DefaultsTreeNode(node=dd, parent=root)
-                dd.update_parent(parent.get_group_path(), parent.get_final_package())
-                subtree = _create_defaults_tree_impl(
-                    repo=repo,
-                    root=new_root,
-                    is_root_config=False,
-                    skip_missing=skip_missing,
-                    interpolated_subtree=True,
-                    overrides=overrides,
-                    deferred_interpolation_override_keys=deferred_interpolation_override_keys,
-                    eligible_override_keys=eligible_override_keys,
-                )
-                if subtree.children is not None:
-                    children[idx] = subtree
 
     if len(children) > 0:
         root.children = list(reversed(children))

--- a/hydra/compose.py
+++ b/hydra/compose.py
@@ -1,14 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from textwrap import dedent
 from typing import List, Optional
 
-from omegaconf import DictConfig, OmegaConf, open_dict
+from omegaconf import DictConfig, open_dict
 
-from hydra import version
 from hydra.core.global_hydra import GlobalHydra
 from hydra.types import RunMode
-
-from ._internal.deprecation_warning import deprecation_warning
 
 
 def compose(
@@ -50,15 +46,6 @@ def compose(
                 del cfg["hydra"]
 
     if strict is not None:
-        if version.base_at_least("1.2"):
-            raise TypeError("got an unexpected 'strict' argument")
-        else:
-            deprecation_warning(
-                dedent("""
-                    The strict flag in the compose API is deprecated.
-                    See https://hydra.cc/docs/1.2/upgrades/0.11_to_1.0/strict_mode_flag_deprecated for more info.
-                    """)
-            )
-            OmegaConf.set_struct(cfg, strict)
+        raise TypeError("got an unexpected 'strict' argument")
 
     return cfg

--- a/hydra/core/default_element.py
+++ b/hydra/core/default_element.py
@@ -4,11 +4,8 @@ from dataclasses import dataclass, field
 from textwrap import dedent
 from typing import List, Optional, Pattern, Union
 
-from omegaconf import AnyNode, DictConfig, OmegaConf
-from omegaconf.errors import InterpolationResolutionError
+from omegaconf import AnyNode, DictConfig
 
-from hydra import version
-from hydra._internal.deprecation_warning import deprecation_warning
 from hydra.errors import ConfigCompositionException
 
 _defaults_list_interpolation_pattern: Pattern[str] = re.compile(r"\${\s*([^{}]*?)\s*}")
@@ -120,19 +117,6 @@ class InputDefault:
         if package_header is None:
             return
 
-        if not version.base_at_least("1.2"):
-            if "_group_" in package_header or "_name_" in package_header:
-                path = self.get_config_path()
-                url = "https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_package_header"
-                deprecation_warning(
-                    message=dedent(f"""\
-                        In '{path}': Usage of deprecated keyword in package header '# @package {package_header}'.
-                        See {url} for more information"""),
-                )
-
-            if package_header == "_group_":
-                return
-
         # package header is always interpreted as absolute.
         # if it does not have a _global_ prefix, add it.
         if package_header != "_global_" and not package_header.startswith("_global_."):
@@ -141,10 +125,6 @@ class InputDefault:
             else:
                 package_header = f"_global_.{package_header}"
 
-        if not version.base_at_least("1.2"):
-            package_header = package_header.replace(
-                "_group_", self.get_default_package()
-            )
         self.__dict__["package_header"] = package_header
 
     def get_package_header(self) -> Optional[str]:
@@ -170,13 +150,6 @@ class InputDefault:
 
         if package is None:
             package = self._relative_group_path().replace("/", ".")
-
-        if isinstance(name, str):
-            # name computation should be deferred to after the final config group choice is done
-
-            if not version.base_at_least("1.2"):
-                if "_name_" in package:
-                    package = package.replace("_name_", name)
 
         if parent_package == "":
             ret = package
@@ -241,18 +214,6 @@ class InputDefault:
         self, known_choices: DictConfig, val: Optional[str]
     ) -> str:
         assert val is not None
-
-        if not version.base_at_least("1.2") and re.search(
-            _legacy_interpolation_pattern, val
-        ):
-            node = OmegaConf.create({"_dummy_": val})
-            node._set_parent(known_choices)
-            try:
-                resolved = node["_dummy_"]
-                assert isinstance(resolved, str)
-                return resolved
-            except InterpolationResolutionError:
-                pass
 
         def replace(match: re.Match[str]) -> str:
             key = match.group(1).strip()
@@ -579,10 +540,7 @@ class GroupDefault(InputDefault):
 Defaults list element '{self.get_override_key()}={name}' is using a deprecated interpolation form.
 See http://hydra.cc/docs/1.1/upgrades/1.0_to_1.1/defaults_list_interpolation for migration information."""
                 )
-                if not version.base_at_least("1.2"):
-                    deprecation_warning(message=msg)
-                else:
-                    raise ConfigCompositionException(msg)
+                raise ConfigCompositionException(msg)
 
             self.value = self._resolve_interpolation_impl(known_choices, name)
 

--- a/hydra/core/override_parser/overrides_parser.py
+++ b/hydra/core/override_parser/overrides_parser.py
@@ -70,7 +70,6 @@ class OverridesParser:
         ret = visitor.visit(tree)
         if isinstance(ret, Override):
             ret.input_line = s
-            ret.validate()
         return ret
 
     def parse_override(self, s: str) -> Override:

--- a/hydra/core/override_parser/types.py
+++ b/hydra/core/override_parser/types.py
@@ -5,14 +5,11 @@ from copy import copy
 from dataclasses import dataclass, field
 from enum import Enum
 from random import shuffle
-from textwrap import dedent
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Union, cast
 
 from omegaconf import OmegaConf
 from omegaconf._utils import is_structured_config
 
-from hydra import version
-from hydra._internal.deprecation_warning import deprecation_warning
 from hydra._internal.grammar.utils import _ESC_QUOTED_STR, escape_special_characters
 from hydra.core.config_loader import ConfigLoader
 from hydra.core.object_type import ObjectType
@@ -498,13 +495,3 @@ class Override:
         return Override._get_value_element_as_str(
             self._value, space_after_sep=space_after_sep
         )
-
-    def validate(self) -> None:
-        if not version.base_at_least("1.2"):
-            if self.package is not None and "_name_" in self.package:
-                url = "https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_package_header"
-                deprecation_warning(
-                    message=dedent(f"""\
-                        In override {self.input_line}: _name_ keyword is deprecated in packages, see {url}
-                        """),
-                )

--- a/hydra/core/utils.py
+++ b/hydra/core/utils.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, List, Optional, Sequence, Union, cast
 
 from omegaconf import DictConfig, OmegaConf, open_dict, read_write
 
-from hydra import version
 from hydra._internal.deprecation_warning import deprecation_warning
 from hydra.core.hydra_config import HydraConfig
 from hydra.core.singleton import Singleton
@@ -168,18 +167,7 @@ def run_job(
         _chdir = hydra_cfg.hydra.job.chdir
 
         if _chdir is None:
-            if version.base_at_least("1.2"):
-                _chdir = False
-
-        if _chdir is None:
-            url = "https://hydra.cc/docs/1.2/upgrades/1.1_to_1.2/changes_to_job_working_dir/"
-            deprecation_warning(
-                message=dedent(f"""\
-                    Future Hydra versions will no longer change working directory at job runtime by default.
-                    See {url} for more information."""),
-                stacklevel=2,
-            )
-            _chdir = True
+            _chdir = False
 
         if _chdir:
             os.chdir(output_dir)

--- a/hydra/experimental/compose.py
+++ b/hydra/experimental/compose.py
@@ -3,9 +3,6 @@ from typing import List, Optional
 
 from omegaconf import DictConfig
 
-from hydra import version
-from hydra._internal.deprecation_warning import deprecation_warning
-
 
 def compose(
     config_name: Optional[str] = None,
@@ -13,19 +10,7 @@ def compose(
     return_hydra_config: bool = False,
     strict: Optional[bool] = None,
 ) -> DictConfig:
-    from hydra import compose as real_compose
-
     message = (
         "hydra.experimental.compose() is no longer experimental. Use hydra.compose()"
     )
-
-    if version.base_at_least("1.2"):
-        raise ImportError(message)
-
-    deprecation_warning(message=message)
-    return real_compose(
-        config_name=config_name,
-        overrides=overrides,
-        return_hydra_config=return_hydra_config,
-        strict=strict,
-    )
+    raise ImportError(message)

--- a/hydra/experimental/initialize.py
+++ b/hydra/experimental/initialize.py
@@ -1,26 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import copy
-from typing import Any, Optional
+from typing import Optional
 
-from hydra import version
-from hydra._internal.deprecation_warning import deprecation_warning
-from hydra.core.global_hydra import GlobalHydra
-from hydra.core.singleton import Singleton
 from hydra.initialize import _UNSPECIFIED_
-
-
-def get_gh_backup() -> Any:
-    if GlobalHydra in Singleton._instances:
-        return copy.deepcopy(Singleton._instances[GlobalHydra])
-    else:
-        return None
-
-
-def restore_gh_from_backup(_gh_backup: Any) -> Any:
-    if _gh_backup is None:
-        del Singleton._instances[GlobalHydra]
-    else:
-        Singleton._instances[GlobalHydra] = _gh_backup
 
 
 class initialize:
@@ -30,30 +11,11 @@ class initialize:
         job_name: Optional[str] = None,
         caller_stack_depth: int = 1,
     ) -> None:
-        from hydra import initialize as real_initialize
-
         message = (
             "hydra.experimental.initialize() is no longer experimental. "
             "Use hydra.initialize()"
         )
-
-        if version.base_at_least("1.2"):
-            raise ImportError(message)
-
-        deprecation_warning(message=message)
-
-        self.delegate = real_initialize(
-            config_path=config_path,
-            job_name=job_name,
-            caller_stack_depth=caller_stack_depth + 1,
-            version_base=str(version.getbase()),
-        )
-
-    def __enter__(self, *args: Any, **kwargs: Any) -> None:
-        self.delegate.__enter__(*args, **kwargs)
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self.delegate.__exit__(exc_type, exc_val, exc_tb)
+        raise ImportError(message)
 
     def __repr__(self) -> str:
         return "hydra.experimental.initialize()"
@@ -68,29 +30,11 @@ class initialize_config_module:
     """
 
     def __init__(self, config_module: str, job_name: str = "app") -> None:
-        from hydra import initialize_config_module as real_initialize_config_module
-
         message = (
             "hydra.experimental.initialize_config_module() is no longer experimental. "
             "Use hydra.initialize_config_module()."
         )
-
-        if version.base_at_least("1.2"):
-            raise ImportError(message)
-
-        deprecation_warning(message=message)
-
-        self.delegate = real_initialize_config_module(
-            config_module=config_module,
-            job_name=job_name,
-            version_base=str(version.getbase()),
-        )
-
-    def __enter__(self, *args: Any, **kwargs: Any) -> None:
-        self.delegate.__enter__(*args, **kwargs)
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self.delegate.__exit__(exc_type, exc_val, exc_tb)
+        raise ImportError(message)
 
     def __repr__(self) -> str:
         return "hydra.experimental.initialize_config_module()"
@@ -106,29 +50,11 @@ class initialize_config_dir:
     """
 
     def __init__(self, config_dir: str, job_name: str = "app") -> None:
-        from hydra import initialize_config_dir as real_initialize_config_dir
-
         message = (
             "hydra.experimental.initialize_config_dir() is no longer experimental. "
             "Use hydra.initialize_config_dir()."
         )
-
-        if version.base_at_least("1.2"):
-            raise ImportError(message)
-
-        deprecation_warning(message=message)
-
-        self.delegate = real_initialize_config_dir(
-            config_dir=config_dir,
-            job_name=job_name,
-            version_base=str(version.getbase()),
-        )
-
-    def __enter__(self, *args: Any, **kwargs: Any) -> None:
-        self.delegate.__enter__(*args, **kwargs)
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self.delegate.__exit__(exc_type, exc_val, exc_tb)
+        raise ImportError(message)
 
     def __repr__(self) -> str:
         return "hydra.experimental.initialize_config_dir()"

--- a/hydra/initialize.py
+++ b/hydra/initialize.py
@@ -1,11 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import copy
 import os
-from textwrap import dedent
 from typing import Any, Optional
 
 from hydra import version
-from hydra._internal.deprecation_warning import deprecation_warning
 from hydra._internal.hydra import Hydra
 from hydra._internal.utils import (
     create_config_search_path,
@@ -62,19 +60,7 @@ class initialize:
         version.setbase(version_base)
 
         if config_path is _UNSPECIFIED_:
-            if version.base_at_least("1.2"):
-                config_path = None
-            elif version_base is _UNSPECIFIED_:
-                url = "https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_hydra_main_config_path"
-                deprecation_warning(
-                    message=dedent(f"""\
-                    config_path is not specified in hydra.initialize().
-                    See {url} for more information."""),
-                    stacklevel=2,
-                )
-                config_path = "."
-            else:
-                config_path = "."
+            config_path = None
 
         if config_path is not None and os.path.isabs(config_path):
             raise HydraException("config_path in initialize() must be relative")

--- a/hydra/main.py
+++ b/hydra/main.py
@@ -4,13 +4,11 @@ import functools
 import pickle
 import warnings
 from pathlib import Path
-from textwrap import dedent
 from typing import Any, Callable, List, Optional
 
 from omegaconf import DictConfig, open_dict, read_write
 
 from . import version
-from ._internal.deprecation_warning import deprecation_warning
 from ._internal.utils import _run_hydra, get_args_parser
 from .core.hydra_config import HydraConfig
 from .core.utils import _flush_loggers, configure_log
@@ -60,19 +58,7 @@ def main(
     version.setbase(version_base)
 
     if config_path is _UNSPECIFIED_:
-        if version.base_at_least("1.2"):
-            config_path = None
-        elif version_base is _UNSPECIFIED_:
-            url = "https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_hydra_main_config_path"
-            deprecation_warning(
-                message=dedent(f"""
-                config_path is not specified in @hydra.main().
-                See {url} for more information."""),
-                stacklevel=2,
-            )
-            config_path = "."
-        else:
-            config_path = "."
+        config_path = None
 
     def main_decorator(task_function: TaskFunction) -> Callable[[], None]:
         @functools.wraps(task_function)

--- a/hydra/plugins/config_source.py
+++ b/hydra/plugins/config_source.py
@@ -6,8 +6,6 @@ from typing import Dict, List, Optional
 
 from omegaconf import Container
 
-from hydra import version
-from hydra._internal.deprecation_warning import deprecation_warning
 from hydra.core.default_element import InputDefault
 from hydra.core.object_type import ObjectType
 from hydra.errors import HydraException
@@ -116,18 +114,11 @@ class ConfigSource(Plugin):
     @staticmethod
     def _normalize_file_name(filename: str) -> str:
         supported_extensions = [".yaml"]
-        if version.base_at_least("1.2"):
-            if filename.endswith(".yml"):
-                raise ConfigLoadError(
-                    "Unsupported config file extension '.yml'. "
-                    "Hydra config files must use the '.yaml' extension."
-                )
-        else:
-            supported_extensions.append(".yml")
-            if filename.endswith(".yml"):
-                deprecation_warning(
-                    "Support for .yml files is deprecated. Use .yaml extension for Hydra config files"
-                )
+        if filename.endswith(".yml"):
+            raise ConfigLoadError(
+                "Unsupported config file extension '.yml'. "
+                "Hydra config files must use the '.yaml' extension."
+            )
         if not any(filename.endswith(ext) for ext in supported_extensions):
             filename += ".yaml"
         return filename

--- a/hydra/test_utils/launcher_common_tests.py
+++ b/hydra/test_utils/launcher_common_tests.py
@@ -302,7 +302,8 @@ class BatchedSweeperTestSuite:
             for idx, job_ret in enumerate(flat):
                 assert job_ret.overrides == expected_overrides[idx]
                 assert job_ret.cfg == expected_conf[idx]
-                dirs.add(job_ret.working_dir)
+                assert job_ret.hydra_cfg is not None
+                dirs.add(job_ret.hydra_cfg.hydra.runtime.output_dir)
                 verify_dir_outputs(job_ret, job_ret.overrides)
         assert len(dirs) == 6  # and a total of 6 unique output directories
 

--- a/hydra/test_utils/test_utils.py
+++ b/hydra/test_utils/test_utils.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Protocol, Tupl
 
 from omegaconf import Container, DictConfig, OmegaConf
 
+from hydra import version
 from hydra._internal.hydra import Hydra
 from hydra._internal.utils import detect_task_name
 from hydra.core.global_hydra import GlobalHydra
@@ -57,6 +58,8 @@ class TaskTestFunction:
 
     def __enter__(self) -> "TaskTestFunction":
         try:
+            if type(version.getbase()) is type(version._UNSPECIFIED_):
+                version.setbase(version._UNSPECIFIED_)
             validate_config_path(self.config_path)
 
             job_name = detect_task_name(self.calling_file, self.calling_module)
@@ -130,6 +133,8 @@ class SweepTaskFunction:
         return 100
 
     def __enter__(self) -> "SweepTaskFunction":
+        if type(version.getbase()) is type(version._UNSPECIFIED_):
+            version.setbase(version._UNSPECIFIED_)
         overrides = copy.deepcopy(self.overrides)
         assert overrides is not None
         if self.temp_dir:
@@ -230,12 +235,9 @@ def verify_dir_outputs(
     assert job_return.task_name is not None
     assert job_return.hydra_cfg is not None
 
-    assert os.path.exists(
-        os.path.join(job_return.working_dir, job_return.task_name + ".log")
-    )
-    hydra_dir = os.path.join(
-        job_return.working_dir, job_return.hydra_cfg.hydra.output_subdir
-    )
+    output_dir = job_return.hydra_cfg.hydra.runtime.output_dir
+    assert os.path.exists(os.path.join(output_dir, job_return.task_name + ".log"))
+    hydra_dir = os.path.join(output_dir, job_return.hydra_cfg.hydra.output_subdir)
     assert os.path.exists(os.path.join(hydra_dir, "config.yaml"))
     assert os.path.exists(os.path.join(hydra_dir, "overrides.yaml"))
     assert OmegaConf.load(

--- a/hydra/types.py
+++ b/hydra/types.py
@@ -5,10 +5,6 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from omegaconf import MISSING
 
-from hydra import version
-
-from ._internal.deprecation_warning import deprecation_warning
-
 TaskFunction = Callable[[Any], Any]
 
 
@@ -35,11 +31,7 @@ class TargetConf:
     _target_: str = MISSING
 
     def __post_init__(self) -> None:
-        if version.base_at_least("1.2"):
-            raise TypeError("TargetConf is unsupported since Hydra 1.2")
-        else:
-            msg = "\nTargetConf is deprecated since Hydra 1.1 and will be removed in Hydra 1.2."
-            deprecation_warning(message=msg)
+        raise TypeError("TargetConf is unsupported since Hydra 1.2")
 
 
 class RunMode(Enum):

--- a/hydra/version.py
+++ b/hydra/version.py
@@ -3,17 +3,15 @@
 # Source of truth for Hydra's version
 
 import re
-from textwrap import dedent
 from typing import Any, Optional, Tuple
 
 from . import __version__
-from ._internal.deprecation_warning import deprecation_warning
 from .core.singleton import Singleton
 from .errors import HydraException
 
 _UNSPECIFIED_: Any = object()
 
-__compat_version__ = "1.1"
+__compat_version__ = "1.2"
 
 _VERSION_PATTERN = re.compile(
     r"(?P<major>[0-9]+)\.(?P<minor>[0-9]+)"
@@ -77,18 +75,14 @@ def setbase(ver: Any) -> None:
     with older versions of Hydra.
     """
     if type(ver) is type(_UNSPECIFIED_):
-        deprecation_warning(
-            message=dedent(f"""
-            The version_base parameter is not specified.
-            Please specify a compatibility version level, or None.
-            Will assume defaults for version {__compat_version__}"""),
-            stacklevel=3,
-        )
-        _version_base = __compat_version__
+        _version_base = _get_version(__version__)
     elif ver is None:
         _version_base = _get_version(__version__)
     else:
         _version_base = _get_version(ver)
         if _parse_version(_version_base) < _parse_version(__compat_version__):
-            raise HydraException(f'version_base must be >= "{__compat_version__}"')
+            raise HydraException(
+                f"version_base={ver!r} is not supported in Hydra 1.4; "
+                "omit version_base to use the current behavior"
+            )
     VersionBase.instance().setbase(_version_base)

--- a/news/3237.api_change
+++ b/news/3237.api_change
@@ -1,0 +1,1 @@
+Remove Hydra 1.1 compatibility behavior.

--- a/tests/defaults_list/test_defaults_list.py
+++ b/tests/defaults_list/test_defaults_list.py
@@ -3,9 +3,8 @@ import re
 from textwrap import dedent
 from typing import Any, List, Optional
 
-from pytest import mark, param, raises, warns
+from pytest import mark, param, raises
 
-from hydra import version
 from hydra._internal.defaults_list import (
     _check_parent_traversal,
     create_defaults_list,
@@ -113,36 +112,13 @@ def test_missing_group_name_in_defaults_list(config_name: str) -> None:
         ),
     ],
 )
-class TestDeprecatedOptional:
-    def test_version_base_1_1(
+class TestRemovedOptionalSyntax:
+    def test_rejected(
         self,
         config_path: str,
         expected_list: List[InputDefault],
         hydra_restore_singletons: Any,
     ) -> None:
-        version.setbase("1.1")
-        repo = create_repo()
-        warning = dedent("""
-                In optional_deprecated: 'optional: true' is deprecated.
-                Use 'optional group1: file1' instead.
-                Support for the old style is removed for Hydra version_base >= 1.2""")
-        with warns(
-            UserWarning,
-            match=re.escape(warning),
-        ):
-            result = repo.load_config(config_path=config_path)
-        assert result is not None
-        assert result.defaults_list == expected_list
-
-    @mark.parametrize("version_base", ["1.2", None])
-    def test_version_base_1_2(
-        self,
-        config_path: str,
-        expected_list: List[InputDefault],
-        version_base: Optional[str],
-        hydra_restore_singletons: Any,
-    ) -> None:
-        version.setbase(version_base)
         repo = create_repo()
         err = "In optional_deprecated: Too many keys in default item {'group1': 'file1', 'optional': True}"
         with raises(
@@ -855,7 +831,7 @@ def test_include_nested_group_global_foo(
 
 
 @mark.parametrize(
-    "config_name, overrides, expected, warning_file",
+    "config_name, overrides, expected",
     [
         param(
             "include_nested_group_name_",
@@ -863,7 +839,7 @@ def test_include_nested_group_global_foo(
             [
                 ResultDefault(
                     config_path="group1/group2/file1",
-                    package="group1.file1",
+                    package="group1._name_",
                     parent="group1/group_item1_name_",
                 ),
                 ResultDefault(
@@ -878,16 +854,15 @@ def test_include_nested_group_global_foo(
                     is_self=True,
                 ),
             ],
-            "group1/group_item1_name_",
             id="include_nested_group_name_",
         ),
         param(
             "include_nested_group_name_",
-            ["group1/group2@group1.file1=file2"],
+            ["group1/group2@group1._name_=file2"],
             [
                 ResultDefault(
                     config_path="group1/group2/file2",
-                    package="group1.file2",
+                    package="group1._name_",
                     parent="group1/group_item1_name_",
                 ),
                 ResultDefault(
@@ -902,7 +877,6 @@ def test_include_nested_group_global_foo(
                     is_self=True,
                 ),
             ],
-            "group1/group_item1_name_",
             id="include_nested_group_name_",
         ),
         param(
@@ -911,7 +885,7 @@ def test_include_nested_group_global_foo(
             [
                 ResultDefault(
                     config_path="group1/group2/file1",
-                    package="group1.file1",
+                    package="group1._name_",
                     parent="group1/config_item_name_",
                 ),
                 ResultDefault(
@@ -927,7 +901,6 @@ def test_include_nested_group_global_foo(
                     primary=True,
                 ),
             ],
-            "group1/config_item_name_",
             id="include_nested_config_item_name_",
         ),
     ],
@@ -936,15 +909,10 @@ def test_include_nested_group_name_(
     config_name: str,
     overrides: List[str],
     expected: List[ResultDefault],
-    warning_file: str,
 ) -> None:
-    url = "https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_package_header"
-    msg = f"In {warning_file}: Defaults List contains deprecated keyword _name_, see {url}\n"
-
-    with warns(UserWarning, match=re.escape(msg)):
-        _test_defaults_list_impl(
-            config_name=config_name, overrides=overrides, expected=expected
-        )
+    _test_defaults_list_impl(
+        config_name=config_name, overrides=overrides, expected=expected
+    )
 
 
 @mark.parametrize(
@@ -1264,68 +1232,13 @@ def test_overriding_package_header_from_defaults_list(
         ),
     ],
 )
-@mark.parametrize("version_base", ["1.2", None])
-def test_legacy_override_hydra_version_base_1_2(
-    config_name: str,
-    overrides: List[str],
-    expected: List[ResultDefault],
-    recwarn: Any,  # Testing deprecated behavior
-    version_base: Optional[str],
-    hydra_restore_singletons: Any,
-) -> None:
-    version.setbase(version_base)
-    _test_defaults_list_impl(
-        config_name=config_name,
-        overrides=overrides,
-        expected=expected,
-        prepend_hydra=True,
-    )
-
-
-@mark.parametrize(
-    "config_name,overrides,expected",
-    [
-        param(
-            "legacy_override_hydra",
-            [],
-            [
-                ResultDefault(
-                    config_path="hydra/help/custom1",
-                    parent="hydra/config",
-                    package="hydra.help",
-                    is_self=False,
-                ),
-                ResultDefault(
-                    config_path="hydra/output/default",
-                    parent="hydra/config",
-                    package="hydra",
-                    is_self=False,
-                ),
-                ResultDefault(
-                    config_path="hydra/config",
-                    parent="<root>",
-                    package="hydra",
-                    is_self=True,
-                ),
-                ResultDefault(
-                    config_path="legacy_override_hydra",
-                    parent="<root>",
-                    package="",
-                    is_self=True,
-                ),
-            ],
-            id="override_hydra",
-        ),
-    ],
-)
-def test_legacy_override_hydra_version_base_1_1(
+def test_legacy_override_hydra_is_rejected(
     config_name: str,
     overrides: List[str],
     expected: List[ResultDefault],
     recwarn: Any,  # Testing deprecated behavior
     hydra_restore_singletons: Any,
 ) -> None:
-    version.setbase("1.1")
     _test_defaults_list_impl(
         config_name=config_name,
         overrides=overrides,
@@ -1817,15 +1730,12 @@ def test_duplicate_items(
         ),
     ],
 )
-@mark.parametrize("version_base", ["1.2", None])
 def test_name_collision(
     config_name: str,
     overrides: List[str],
     expected: List[ResultDefault],
-    version_base: Optional[str],
     hydra_restore_singletons: Any,
 ) -> None:
-    version.setbase(version_base)
     _test_defaults_list_impl(
         config_name=config_name,
         overrides=overrides,
@@ -1841,7 +1751,7 @@ def test_name_collision(
             [],
             [
                 ResultDefault(
-                    config_path="group1/file_with_group_header", package="group1"
+                    config_path="group1/file_with_group_header", package="_group_"
                 )
             ],
             id="group1/file_with_group_header",
@@ -1853,7 +1763,7 @@ def test_name_collision(
                 ResultDefault(config_path="empty", package="", is_self=True),
                 ResultDefault(
                     config_path="group1/file_with_group_header",
-                    package="group1",
+                    package="_group_",
                     parent="empty",
                 ),
             ],
@@ -1865,7 +1775,7 @@ def test_name_collision(
             [
                 ResultDefault(
                     config_path="group1/group2/file_with_group_header",
-                    package="group1.group2",
+                    package="_group_",
                 )
             ],
             id="group1/group2/file_with_group_header",
@@ -1877,7 +1787,7 @@ def test_name_collision(
                 ResultDefault(config_path="empty", package="", is_self=True),
                 ResultDefault(
                     config_path="group1/group2/file_with_group_header",
-                    package="group1.group2",
+                    package="_group_",
                     parent="empty",
                 ),
             ],
@@ -2108,7 +2018,7 @@ def test_with_missing_config(
         param(
             GroupDefault(group="group1", value="file"),
             "_group_",
-            "group1",
+            "_group_",
             id="gd:_group_",
         ),
         param(
@@ -2132,7 +2042,7 @@ def test_with_missing_config(
         param(
             GroupDefault(group="group1", value="file"),
             "_group_._name_",
-            "group1.file",
+            "_group_._name_",
             id="gd:_group_._name_",
         ),
     ],
@@ -2151,7 +2061,7 @@ def test_set_package_header_no_parent_pkg(
         param(
             GroupDefault(group="group1", value="file"),
             "_group_",
-            "parent_pkg.group1",
+            "_group_",
             id="gd:_group_",
         ),
     ],

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -4,9 +4,8 @@ from textwrap import dedent
 from typing import Any, Dict, List, Optional
 
 from omegaconf import OmegaConf
-from pytest import mark, param, raises, warns
+from pytest import mark, param, raises
 
-from hydra import version
 from hydra.core.default_element import (
     ConfigDefault,
     DefaultsTreeNode,
@@ -938,15 +937,12 @@ def test_hydra_overrides_from_primary_config(
         ),
     ],
 )
-@mark.parametrize("version_base", ["1.2", None])
-def test_legacy_override_hydra_version_base_1_2(
+def test_legacy_override_hydra_is_rejected(
     config_name: str,
     overrides: List[str],
     expected: DefaultsTreeNode,
-    version_base: Optional[str],
     hydra_restore_singletons: Any,
 ) -> None:
-    version.setbase(version_base)
     _test_defaults_tree_impl(
         config_name=config_name,
         input_overrides=overrides,
@@ -959,142 +955,28 @@ def test_legacy_override_hydra_version_base_1_2(
     "config_name,overrides,expected",
     [
         param(
-            "legacy_override_hydra",
-            [],
-            DefaultsTreeNode(
-                node=VirtualRoot(),
-                children=[
-                    DefaultsTreeNode(
-                        node=ConfigDefault(path="hydra/config"),
-                        children=[
-                            GroupDefault(group="help", value="custom1"),
-                            GroupDefault(group="output", value="default"),
-                            ConfigDefault(path="_self_"),
-                        ],
-                    ),
-                    DefaultsTreeNode(
-                        node=ConfigDefault(path="legacy_override_hydra"),
-                        children=[ConfigDefault(path="_self_")],
-                    ),
-                ],
-            ),
-            id="legacy_override_hydra",
-        ),
-        param(
             "legacy_override_hydra2",
             [],
-            DefaultsTreeNode(
-                node=VirtualRoot(),
-                children=[
-                    DefaultsTreeNode(
-                        node=ConfigDefault(path="hydra/config"),
-                        children=[
-                            GroupDefault(group="help", value="custom1"),
-                            GroupDefault(group="output", value="disabled"),
-                            ConfigDefault(path="_self_"),
-                        ],
-                    ),
-                    DefaultsTreeNode(
-                        node=ConfigDefault(path="legacy_override_hydra2"),
-                        children=[ConfigDefault(path="_self_")],
-                    ),
-                ],
+            raises(
+                ConfigCompositionException,
+                match=re.escape(
+                    "Multiple values for hydra/output. To override a value use "
+                    "'override hydra/output: disabled'"
+                ),
             ),
-            id="legacy_override_hydra2",
-        ),
-        param(
-            "legacy_override_hydra_wrong_order",
-            [],
-            DefaultsTreeNode(
-                node=VirtualRoot(),
-                children=[
-                    DefaultsTreeNode(
-                        node=ConfigDefault(path="hydra/config"),
-                        children=[
-                            GroupDefault(group="help", value="custom1"),
-                            GroupDefault(group="output", value="default"),
-                            ConfigDefault(path="_self_"),
-                        ],
-                    ),
-                    DefaultsTreeNode(
-                        node=ConfigDefault(path="legacy_override_hydra_wrong_order"),
-                        children=[
-                            GroupDefault(group="group1", value="file1"),
-                            ConfigDefault(path="_self_"),
-                        ],
-                    ),
-                ],
-            ),
-            id="legacy_override_hydra_wrong_order",
+            id="legacy_override_hydra2-error",
         ),
     ],
 )
-def test_legacy_override_hydra_version_base_1_1(
-    config_name: str,
-    overrides: List[str],
-    expected: DefaultsTreeNode,
-    hydra_restore_singletons: Any,
+def test_legacy_hydra_overrides_from_primary_config_are_rejected(
+    config_name: str, overrides: List[str], expected: DefaultsTreeNode
 ) -> None:
-    version.setbase("1.1")
-    msg_regex = r"Invalid overriding of hydra/(help|output):" + re.escape(
-        dedent("""
-            Default list overrides requires 'override' keyword.
-            See https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/defaults_list_override for more information.
-            """)
-    )
-    with warns(expected_warning=UserWarning, match=msg_regex):
-        _test_defaults_tree_impl(
-            config_name=config_name,
-            input_overrides=overrides,
-            expected=expected,
-            prepend_hydra=True,
-        )
-
-
-@mark.parametrize(
-    "config_name,overrides,expected",
-    [
-        param(
-            "legacy_override_hydra2",
-            [],
-            DefaultsTreeNode(
-                node=VirtualRoot(),
-                children=[
-                    DefaultsTreeNode(
-                        node=ConfigDefault(path="hydra/config"),
-                        children=[
-                            GroupDefault(group="help", value="custom1"),
-                            GroupDefault(group="output", value="disabled"),
-                            ConfigDefault(path="_self_"),
-                        ],
-                    ),
-                    DefaultsTreeNode(
-                        node=ConfigDefault(path="legacy_override_hydra2"),
-                        children=[ConfigDefault(path="_self_")],
-                    ),
-                ],
-            ),
-            id="legacy_override_hydra+external",
-        ),
-    ],
-)
-def test_legacy_hydra_overrides_from_primary_config_2(
-    config_name: str, overrides: List[str], expected: DefaultsTreeNode, recwarn: Any
-) -> None:
-    """
-    Override two Hydra config groups using legacy notation
-    """
-
     _test_defaults_tree_impl(
         config_name=config_name,
         input_overrides=overrides,
         expected=expected,
         prepend_hydra=True,
     )
-
-    assert len(recwarn) == 2
-    assert "Invalid overriding of hydra/help:" in recwarn.list[0].message.args[0]
-    assert "Invalid overriding of hydra/output:" in recwarn.list[1].message.args[0]
 
 
 @mark.parametrize(
@@ -1329,15 +1211,12 @@ def test_experiment_where_primary_config_has_override(
         ),
     ],
 )
-@mark.parametrize("version_base", ["1.2", None])
 def test_use_of_custom_subgroup_of_hydra(
     config_name: str,
     overrides: List[str],
     expected: DefaultsTreeNode,
-    version_base: Optional[str],
     hydra_restore_singletons: Any,
 ) -> None:
-    version.setbase(version_base)
     _test_defaults_tree_impl(
         config_name=config_name,
         input_overrides=overrides,
@@ -2492,15 +2371,6 @@ def test_legacy_interpolation(
     Defaults list element '.*=.*' is using a deprecated interpolation form.
     See http://hydra.cc/docs/1.1/upgrades/1.0_to_1.1/defaults_list_interpolation for migration information."""
     )
-    version.setbase("1.1")
-    with warns(expected_warning=UserWarning, match=msg):
-        _test_defaults_tree_impl(
-            config_name=config_name,
-            input_overrides=overrides,
-            expected=expected,
-        )
-
-    version.setbase("1.2")
     with raises(ConfigCompositionException, match=msg):
         _test_defaults_tree_impl(
             config_name=config_name,
@@ -2521,14 +2391,6 @@ def test_legacy_interpolation_multi_digit_index(
         {"defaults": [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {"group": "file1"}]}
     )
 
-    version.setbase("1.1")
-    default = GroupDefault(group="target", value="${defaults.10.group}")
-    default.update_parent("", "")
-    with warns(expected_warning=UserWarning, match=msg):
-        default.resolve_interpolation(known_choices)
-    assert default.value == "file1"
-
-    version.setbase("1.2")
     default = GroupDefault(group="target", value="${defaults.10.group}")
     default.update_parent("", "")
     with raises(ConfigCompositionException, match=msg):
@@ -2538,19 +2400,16 @@ def test_legacy_interpolation_multi_digit_index(
 def test_legacy_interpolation_in_config_path(
     hydra_restore_singletons: Any,
 ) -> None:
-    version.setbase("1.1")
-    _test_defaults_tree_impl(
-        config_name="interpolation_legacy_config_path",
-        input_overrides=[],
-        expected=DefaultsTreeNode(
-            node=ConfigDefault(path="interpolation_legacy_config_path"),
-            children=[
-                GroupDefault(group="group1", value="file1"),
-                ConfigDefault(path="file1/file"),
-                ConfigDefault(path="_self_"),
-            ],
-        ),
+    msg = re.escape(
+        "Error resolving interpolation '${defaults.0.group1}/file', "
+        "possible interpolation keys: group1"
     )
+    with raises(ConfigCompositionException, match=msg):
+        _test_defaults_tree_impl(
+            config_name="interpolation_legacy_config_path",
+            input_overrides=[],
+            expected=None,
+        )
 
 
 @mark.parametrize(
@@ -3363,27 +3222,18 @@ def test_choices(
         ),
     ],
 )
-def test_deprecated_package_header_keywords(
+def test_package_header_keywords_are_literal(
     config_name: Optional[str],
     overrides: List[str],
     package_header: str,
     expected: DefaultsTreeNode,
     hydra_restore_singletons: Any,
 ) -> None:
-    msg = dedent(
-        f"""\
-        In '{config_name}': Usage of deprecated keyword in package header '# @package {package_header}'.
-        See https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_package_header for more information"""
+    _test_defaults_tree_impl(
+        config_name=config_name,
+        input_overrides=overrides,
+        expected=expected,
     )
-
-    version.setbase("1.1")
-
-    with warns(UserWarning, match=re.escape(msg)):
-        _test_defaults_tree_impl(
-            config_name=config_name,
-            input_overrides=overrides,
-            expected=expected,
-        )
 
 
 @mark.parametrize(

--- a/tests/instantiate/__init__.py
+++ b/tests/instantiate/__init__.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, NoReturn, Optional, Tuple
 
 from omegaconf import MISSING, DictConfig, ListConfig
 
-from hydra.types import TargetConf
 from hydra.utils import UNSAFE_ALLOW_ALL_TARGETS, instantiate
 from tests.instantiate.module_shadowed_by_function import a_function
 
@@ -216,12 +215,6 @@ class AdamConf:
     eps: float = 1e-08
     weight_decay: int = 0
     amsgrad: bool = False
-
-
-@dataclass
-class BadAdamConf(TargetConf):
-    # Missing str annotation
-    _target_ = "tests.instantiate.Adam"
 
 
 @dataclass

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -21,7 +21,6 @@ from omegaconf import (
 )
 from pytest import fixture, mark, param, raises, warns
 
-from hydra import version
 from hydra._internal.instantiate import _instantiate2
 from hydra._internal.instantiate._instantiate2 import _resolve_target
 from hydra.errors import InstantiationException
@@ -35,7 +34,6 @@ from tests.instantiate import (
     AnotherClass,
     ArgsClass,
     ASubclass,
-    BadAdamConf,
     BClass,
     CallableClass,
     CenterCrop,
@@ -1191,41 +1189,12 @@ def test_instantiate_adam_conf_with_convert(instantiate_func: Any) -> None:
     assert res.amsgrad == expected.amsgrad
 
 
-def test_targetconf_deprecated(hydra_restore_singletons: Any) -> None:
-    version.setbase("1.1")
-    with warns(
-        expected_warning=UserWarning,
-        match=re.escape(
-            "TargetConf is deprecated since Hydra 1.1 and will be removed in Hydra 1.2."
-        ),
-    ):
-        TargetConf()
-
-
 def test_targetconf_disabled(hydra_restore_singletons: Any) -> None:
-    version.setbase("1.2")
     with raises(
         TypeError,
         match=re.escape("TargetConf is unsupported since Hydra 1.2"),
     ):
         TargetConf()
-
-
-def test_instantiate_bad_adam_conf(instantiate_func: Any, recwarn: Any) -> None:
-    msg = re.escape(
-        dedent(
-            """\
-            Config has missing value for key `_target_`, cannot instantiate.
-            Config type: BadAdamConf
-            Check that the `_target_` key in your dataclass is properly annotated and overridden.
-            A common problem is forgetting to annotate _target_ as a string : '_target_: str = ...'"""
-        )
-    )
-    with raises(
-        InstantiationException,
-        match=msg,
-    ):
-        instantiate_func(BadAdamConf())
 
 
 def test_instantiate_with_missing_module(instantiate_func: Any) -> None:

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -2,10 +2,10 @@
 import re
 import subprocess
 import sys
+import warnings
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from textwrap import dedent
 from typing import Any, Dict, List, Optional
 
 from omegaconf import MISSING, OmegaConf
@@ -65,13 +65,19 @@ def test_initialize(hydra_restore_singletons: Any) -> None:
     assert GlobalHydra().is_initialized()
 
 
-def test_initialize_old_version_base(hydra_restore_singletons: Any) -> None:
+@mark.parametrize("version_base", ["1.0", "1.1"])
+def test_initialize_old_version_base(
+    hydra_restore_singletons: Any, version_base: str
+) -> None:
     assert not GlobalHydra().is_initialized()
     with raises(
         HydraException,
-        match=f'version_base must be >= "{version.__compat_version__}"',
+        match=(
+            f"version_base={version_base!r} is not supported in Hydra 1.4; "
+            "omit version_base to use the current behavior"
+        ),
     ):
-        initialize(version_base="1.0")
+        initialize(version_base=version_base)
 
 
 def test_initialize_bad_version_base(hydra_restore_singletons: Any) -> None:
@@ -113,14 +119,10 @@ def test_initialize_cur_version_base(hydra_restore_singletons: Any) -> None:
     assert version.base_at_least(__version__)
 
 
-def test_initialize_compat_version_base(hydra_restore_singletons: Any) -> None:
+def test_initialize_omitted_version_base(hydra_restore_singletons: Any) -> None:
     assert not GlobalHydra().is_initialized()
-    with raises(
-        UserWarning,
-        match=f"Will assume defaults for version {version.__compat_version__}",
-    ):
-        initialize()
-    assert version.base_at_least(str(version.__compat_version__))
+    initialize()
+    assert version.getbase() == version._get_version(__version__)
 
 
 def test_initialize_with_config_path(hydra_restore_singletons: Any) -> None:
@@ -795,13 +797,6 @@ def test_deprecated_compose(hydra_restore_singletons: Any) -> None:
 
     msg = "hydra.experimental.compose() is no longer experimental. Use hydra.compose()"
 
-    with initialize(version_base="1.1"):
-        with warns(
-            expected_warning=UserWarning,
-            match=re.escape(msg),
-        ):
-            assert expr_compose() == {}
-
     with initialize(version_base="1.2"):
         with raises(
             ImportError,
@@ -815,11 +810,6 @@ def test_deprecated_initialize(hydra_restore_singletons: Any) -> None:
 
     msg = "hydra.experimental.initialize() is no longer experimental. Use hydra.initialize()"
 
-    version.setbase("1.1")
-    with warns(expected_warning=UserWarning, match=re.escape(msg)):
-        with expr_initialize():
-            assert compose() == {}
-
     version.setbase("1.2")
     with raises(ImportError, match=re.escape(msg)):
         with expr_initialize():
@@ -830,16 +820,6 @@ def test_deprecated_initialize_config_dir(hydra_restore_singletons: Any) -> None
     from hydra.experimental import initialize_config_dir as expr_initialize_config_dir
 
     msg = "hydra.experimental.initialize_config_dir() is no longer experimental. Use hydra.initialize_config_dir()"
-
-    version.setbase("1.1")
-    with warns(
-        expected_warning=UserWarning,
-        match=re.escape(msg),
-    ):
-        with expr_initialize_config_dir(
-            config_dir=str(Path(".").absolute()),
-        ):
-            assert compose() == {}
 
     version.setbase("1.2")
     with raises(
@@ -862,13 +842,6 @@ def test_deprecated_initialize_config_module(hydra_restore_singletons: Any) -> N
         " Use hydra.initialize_config_module()"
     )
 
-    version.setbase("1.1")
-    with warns(expected_warning=UserWarning, match=re.escape(msg)):
-        with expr_initialize_config_module(
-            config_module="examples.jupyter_notebooks.cloud_app.conf",
-        ):
-            assert compose() == {}
-
     version.setbase("1.2")
     with raises(ImportError, match=re.escape(msg)):
         with expr_initialize_config_module(
@@ -878,21 +851,10 @@ def test_deprecated_initialize_config_module(hydra_restore_singletons: Any) -> N
 
 
 def test_initialize_without_config_path(tmpdir: Path) -> None:
-    expected0 = dedent(f"""
-        The version_base parameter is not specified.
-        Please specify a compatibility version level, or None.
-        Will assume defaults for version {version.__compat_version__}""")
-    expected1 = dedent(
-        """\
-        config_path is not specified in hydra.initialize().
-        See https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_hydra_main_config_path for more information."""
-    )
-    with warns(expected_warning=UserWarning) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         with initialize():
             pass
-    assert len(record) == 2
-    assert str(record[0].message) == expected0
-    assert str(record[1].message) == expected1
 
 
 @mark.usefixtures("initialize_hydra_no_path")
@@ -931,22 +893,8 @@ def test_error_assigning_null_to_logging_config(
 def test_deprecated_compose_strict_flag(
     strict: bool, hydra_restore_singletons: Any
 ) -> None:
-    msg = dedent("""\
-
-        The strict flag in the compose API is deprecated.
-        See https://hydra.cc/docs/1.2/upgrades/0.11_to_1.0/strict_mode_flag_deprecated for more info.
-        """)
-
-    version.setbase("1.1")
-
-    with warns(
-        expected_warning=UserWarning,
-        match=re.escape(msg),
-    ):
-        cfg = compose(overrides=[], strict=strict)
-
-    assert cfg == {}
-    assert OmegaConf.is_struct(cfg) is strict
+    with raises(TypeError, match="got an unexpected 'strict' argument"):
+        compose(overrides=[], strict=strict)
 
 
 @mark.usefixtures("initialize_hydra_no_path")

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -8,7 +8,6 @@ from omegaconf import MISSING, DictConfig, OmegaConf, ValidationError, open_dict
 from omegaconf.errors import InterpolationResolutionError
 from pytest import mark, param, raises, warns
 
-from hydra import version
 from hydra._internal.config_loader_impl import ConfigLoaderImpl
 from hydra._internal.utils import create_config_search_path
 from hydra.core.config_store import ConfigStore, ConfigStoreWithProvider
@@ -192,7 +191,6 @@ class TestConfigLoader:
         config_loader = ConfigLoaderImpl(
             config_search_path=create_config_search_path(path)
         )
-        version.setbase("1.2")
         with raises(
             ConfigLoadError,
             match=re.escape(
@@ -205,24 +203,6 @@ class TestConfigLoader:
                 overrides=[],
                 run_mode=RunMode.RUN,
             )
-        version.setbase("1.1")
-        with warns(
-            UserWarning,
-            match=(
-                "Support for .yml files is deprecated. Use .yaml extension for Hydra"
-                " config files"
-            ),
-        ):
-            cfg = config_loader.load_configuration(
-                config_name="config.yml",
-                overrides=[],
-                run_mode=RunMode.RUN,
-            )
-
-        with open_dict(cfg):
-            del cfg["hydra"]
-
-        assert cfg == {"yml_file_here": True}
 
     def test_override_with_equals(self, path: str) -> None:
         config_loader = ConfigLoaderImpl(

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -11,8 +11,8 @@ from typing import Any, List, Optional, Set
 from omegaconf import DictConfig, OmegaConf
 from pytest import mark, param, raises
 
-from hydra import MissingConfigException, version
-from hydra.errors import ConfigCompositionException
+from hydra import MissingConfigException, main, version
+from hydra.errors import ConfigCompositionException, HydraException
 from hydra.test_utils.test_utils import (
     TSweepRunner,
     TTaskRunner,
@@ -28,6 +28,25 @@ from hydra.test_utils.test_utils import (
 )
 
 chdir_hydra_root()
+
+
+@mark.parametrize("version_base", ["1.0", "1.1"])
+def test_hydra_main_old_version_base(
+    hydra_restore_singletons: Any, version_base: str
+) -> None:
+    with raises(
+        HydraException,
+        match=(
+            f"version_base={version_base!r} is not supported in Hydra 1.4; "
+            "omit version_base to use the current behavior"
+        ),
+    ):
+        main(version_base=version_base)
+
+
+def test_hydra_main_omitted_version_base(hydra_restore_singletons: Any) -> None:
+    main()
+    assert version.getbase() == version._get_version(version.__version__)
 
 
 @mark.parametrize("calling_file, calling_module", [(".", None), (None, ".")])
@@ -1588,45 +1607,8 @@ def test_hydra_main_without_config_path(tmpdir: Path) -> None:
         f'hydra.run.dir="{tmpdir}"',
         "hydra.job.chdir=True",
     ]
-    _, err = run_python_script(cmd, allow_warnings=True)
-
-    expected = dedent(f"""
-        .*my_app.py:7: UserWarning:
-        The version_base parameter is not specified.
-        Please specify a compatibility version level, or None.
-        Will assume defaults for version {version.__compat_version__}
-          @hydra.main()
-        .*my_app.py:7: UserWarning:
-        config_path is not specified in @hydra.main().
-        See https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_hydra_main_config_path for more information.
-          @hydra.main()
-        """)
-    assert_regex_match(
-        from_line=expected,
-        to_line=err,
-        from_name="Expected error",
-        to_name="Actual error",
-    )
-
-
-def test_job_chdir_not_specified(tmpdir: Path) -> None:
-    cmd = [
-        "tests/test_apps/app_with_no_chdir_override/my_app.py",
-        f'hydra.run.dir="{tmpdir}"',
-    ]
-    out, err = run_python_script(cmd, allow_warnings=True)
-
-    expected = dedent("""
-        .*UserWarning: Future Hydra versions will no longer change working directory at job runtime by default.
-        See https://hydra.cc/docs/1.2/upgrades/1.1_to_1.2/changes_to_job_working_dir/ for more information..*
-        .*
-        """)
-    assert_regex_match(
-        from_line=expected,
-        to_line=err,
-        from_name="Expected error",
-        to_name="Actual error",
-    )
+    _, err = run_python_script(cmd)
+    assert err == ""
 
 
 def test_app_with_unicode_config(tmpdir: Path) -> None:

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -12,7 +12,6 @@ except ImportError:
     from _pytest.python_api import RaisesContext  # type: ignore[attr-defined,no-redef]
 from pytest import mark, param, raises, warns
 
-from hydra import version
 from hydra._internal.grammar import grammar_functions
 from hydra._internal.grammar.functions import Functions
 from hydra._internal.grammar.utils import escape_special_characters
@@ -1070,27 +1069,16 @@ def test_list_extend_override(
         )
 
 
-def test_deprecated_name_package(hydra_restore_singletons: Any) -> None:
-    msg = (
-        "In override key@_name_=value: _name_ keyword is deprecated in packages, "
-        "see https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_package_header"
+def test_name_package_is_literal() -> None:
+    assert parse_rule("key@_name_=value", "override") == Override(
+        type=OverrideType.CHANGE,
+        key_or_group="key",
+        value_type=ValueType.ELEMENT,
+        _value="value",
+        package="_name_",
+        input_line="key@_name_=value",
+        config_loader=None,
     )
-
-    version.setbase("1.1")
-
-    with warns(
-        UserWarning,
-        match=re.escape(msg),
-    ):
-        assert parse_rule("key@_name_=value", "override") == Override(
-            type=OverrideType.CHANGE,
-            key_or_group="key",
-            value_type=ValueType.ELEMENT,
-            _value="value",
-            package="_name_",
-            input_line="key@_name_=value",
-            config_loader=None,
-        )
 
 
 @mark.parametrize(


### PR DESCRIPTION
## Summary

- make omitted `version_base` select current Hydra behavior
- reject `version_base="1.1"` and older values
- remove runtime branches and deprecated APIs that existed only for the 1.1
  behavior bucket

## Stack

This is the second PR in the `version_base` cleanup stack and is based on
https://github.com/facebookresearch/hydra/pull/3336.

Later PRs will separately remove the 1.2 compatibility level and deprecate
the parameter while cleaning up docs and examples.

## Validation

- 1,661 focused core tests passed
- `.venv/bin/nox -s lint` passed all 15 core and plugin lint sessions
