### PR TITLE
Remove Hydra 1.2 version_base compatibility

### DIFF
--- a/hydra/version.py
+++ b/hydra/version.py
@@ -11,7 +11,7 @@ from .errors import HydraException
 
 _UNSPECIFIED_: Any = object()
 
-__compat_version__ = "1.2"
+__compat_version__ = "1.3"
 
 _VERSION_PATTERN = re.compile(
     r"(?P<major>[0-9]+)\.(?P<minor>[0-9]+)"

--- a/news/3237.api_change
+++ b/news/3237.api_change
@@ -1,1 +1,1 @@
-Remove Hydra 1.1 compatibility behavior.
+Remove Hydra 1.1 behavior and the 1.2 `version_base` compatibility level.

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -65,7 +65,9 @@ def test_initialize(hydra_restore_singletons: Any) -> None:
     assert GlobalHydra().is_initialized()
 
 
-@mark.parametrize("version_base", ["1.0", "1.1"])
+@mark.parametrize(
+    "version_base", ["1.0", "1.1", "1.2", "1.2.0", "1.2.0.dev2", "1.2.0rc1"]
+)
 def test_initialize_old_version_base(
     hydra_restore_singletons: Any, version_base: str
 ) -> None:
@@ -86,13 +88,13 @@ def test_initialize_bad_version_base(hydra_restore_singletons: Any) -> None:
         initialize(version_base=1.1)  # type: ignore
 
 
-@mark.parametrize("version_base", ["1.2.0", "1.2.0.dev2", "1.2.0rc1"])
+@mark.parametrize("version_base", ["1.3", "1.3.0", "1.3.0.dev2", "1.3.0rc1", "1.4"])
 def test_initialize_hydra_version_string_base(
     hydra_restore_singletons: Any, version_base: str
 ) -> None:
     assert not GlobalHydra().is_initialized()
     initialize(version_base=version_base)
-    assert version.base_at_least("1.2")
+    assert version.base_at_least("1.3")
 
 
 def test_version_base_numeric_comparison(hydra_restore_singletons: Any) -> None:
@@ -797,7 +799,7 @@ def test_deprecated_compose(hydra_restore_singletons: Any) -> None:
 
     msg = "hydra.experimental.compose() is no longer experimental. Use hydra.compose()"
 
-    with initialize(version_base="1.2"):
+    with initialize(version_base="1.3"):
         with raises(
             ImportError,
             match=re.escape(msg),
@@ -810,7 +812,7 @@ def test_deprecated_initialize(hydra_restore_singletons: Any) -> None:
 
     msg = "hydra.experimental.initialize() is no longer experimental. Use hydra.initialize()"
 
-    version.setbase("1.2")
+    version.setbase("1.3")
     with raises(ImportError, match=re.escape(msg)):
         with expr_initialize():
             assert compose() == {}
@@ -821,7 +823,7 @@ def test_deprecated_initialize_config_dir(hydra_restore_singletons: Any) -> None
 
     msg = "hydra.experimental.initialize_config_dir() is no longer experimental. Use hydra.initialize_config_dir()"
 
-    version.setbase("1.2")
+    version.setbase("1.3")
     with raises(
         ImportError,
         match=re.escape(msg),
@@ -842,7 +844,7 @@ def test_deprecated_initialize_config_module(hydra_restore_singletons: Any) -> N
         " Use hydra.initialize_config_module()"
     )
 
-    version.setbase("1.2")
+    version.setbase("1.3")
     with raises(ImportError, match=re.escape(msg)):
         with expr_initialize_config_module(
             config_module="examples.jupyter_notebooks.cloud_app.conf",

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -30,7 +30,7 @@ from hydra.test_utils.test_utils import (
 chdir_hydra_root()
 
 
-@mark.parametrize("version_base", ["1.0", "1.1"])
+@mark.parametrize("version_base", ["1.0", "1.1", "1.2"])
 def test_hydra_main_old_version_base(
     hydra_restore_singletons: Any, version_base: str
 ) -> None:


### PR DESCRIPTION
## Summary

- reject explicit Hydra 1.2 `version_base` values
- continue accepting Hydra 1.3 and newer values
- update focused tests and the shared release note

## Scope

Hydra 1.2 does not have a distinct runtime behavior bucket from later Hydra
versions. This PR removes the nominal 1.2 compatibility level without mixing
in the broader `version_base` deprecation.

## Stack

This is the third PR in the stack and is based on
https://github.com/facebookresearch/hydra/pull/3337.

## Validation

- 273 focused tests passed
- focused Ruff checks and formatting passed
