### PR TITLE
Fix macOS CI cache restoration

### DIFF
--- a/.github/actions/macos/action.yml
+++ b/.github/actions/macos/action.yml
@@ -8,7 +8,7 @@ runs:
   - name: restore_cache
     uses: actions/cache@v4.2.0
     with:
-      key: "-${{ inputs.cache_key_version }}-macos-sys-{{ .Branch }}-${{ inputs.py_version }}"
+      key: "macos-sys-v1-${{ runner.arch }}-${{ inputs.py_version }}"
       path: |-
         ~/miniconda3
         ~/Library/Caches/Homebrew
@@ -40,10 +40,3 @@ runs:
       conda create -n hydra python=${{ inputs.py_version }} -yqc conda-forge
       conda run -n hydra pip install nox --progress-bar off
     shell: bash
-  - name: save_cache
-    uses: actions/cache@v4.2.0
-    with:
-      path: |-
-        ~/miniconda3
-        ~/Library/Caches/Homebrew
-      key: "-${{ inputs.cache_key_version }}-macos-sys-{{ .Branch }}-${{ inputs.py_version }}"


### PR DESCRIPTION

Stop restoring the Miniconda cache again after environment setup. Use a versioned architecture-specific cache key to invalidate the stale environments that contain mismatched pip files.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookresearch/hydra/pull/3340).
* #3343
* #3342
* #3341
* __->__ #3340