### PR TITLE
Warn Hydra 1.3 users relying on Hydra 1.1 behavior

### DIFF
--- a/hydra/errors.py
+++ b/hydra/errors.py
@@ -43,3 +43,7 @@ class MissingConfigException(IOError, ConfigCompositionException):
 
 class HydraDeprecationError(HydraException):
     ...
+
+
+class Hydra14MigrationWarning(UserWarning):
+    """Warn about changes required before upgrading to Hydra 1.4."""

--- a/hydra/version.py
+++ b/hydra/version.py
@@ -2,19 +2,22 @@
 
 # Source of truth for Hydra's version
 
+import warnings
 from textwrap import dedent
 from typing import Any, Optional
 
 from packaging.version import Version
 
 from . import __version__
-from ._internal.deprecation_warning import deprecation_warning
 from .core.singleton import Singleton
-from .errors import HydraException
+from .errors import Hydra14MigrationWarning, HydraException
 
 _UNSPECIFIED_: Any = object()
 
 __compat_version__: Version = Version("1.1")
+_HYDRA_1_4_PREPARATION_GUIDE = (
+    "https://hydra.cc/docs/upgrades/1.3_to_1.4/prepare_for_1_4/"
+)
 
 
 class VersionBase(metaclass=Singleton):
@@ -61,13 +64,16 @@ def getbase() -> Optional[Version]:
 
 def setbase(ver: Any) -> None:
     if type(ver) is type(_UNSPECIFIED_):
-        deprecation_warning(
-            message=dedent(
+        warnings.warn(
+            dedent(
                 f"""
             The version_base parameter is not specified.
-            Please specify a compatability version level, or None.
-            Will assume defaults for version {__compat_version__}"""
+            Hydra will assume defaults for version {__compat_version__}.
+            Hydra 1.4 will remove this compatibility behavior.
+            Before upgrading to Hydra 1.4, set version_base="1.3" and test your application.
+            See {_HYDRA_1_4_PREPARATION_GUIDE} for preparation instructions."""
             ),
+            category=Hydra14MigrationWarning,
             stacklevel=3,
         )
         _version_base = __compat_version__
@@ -77,4 +83,16 @@ def setbase(ver: Any) -> None:
         _version_base = _get_version(ver)
         if _version_base < __compat_version__:
             raise HydraException(f'version_base must be >= "{__compat_version__}"')
+        if _version_base == __compat_version__:
+            warnings.warn(
+                dedent(
+                    f"""
+                version_base="{_version_base}" selects Hydra 1.1 compatibility behavior.
+                Hydra 1.4 will remove this compatibility behavior.
+                Before upgrading to Hydra 1.4, set version_base="1.3" and test your application.
+                See {_HYDRA_1_4_PREPARATION_GUIDE} for preparation instructions."""
+                ),
+                category=Hydra14MigrationWarning,
+                stacklevel=3,
+            )
     VersionBase.instance().setbase(_version_base)

--- a/news/3334.api_change
+++ b/news/3334.api_change
@@ -1,0 +1,2 @@
+Warn Hydra 1.3 applications that rely on Hydra 1.1 compatibility before
+upgrading to Hydra 1.4.

--- a/tests/defaults_list/test_defaults_list.py
+++ b/tests/defaults_list/test_defaults_list.py
@@ -15,7 +15,7 @@ from hydra.core.default_element import (
 )
 from hydra.core.override_parser.overrides_parser import OverridesParser
 from hydra.core.plugins import Plugins
-from hydra.errors import ConfigCompositionException
+from hydra.errors import ConfigCompositionException, Hydra14MigrationWarning
 from hydra.test_utils.test_utils import chdir_hydra_root
 from tests.defaults_list import create_repo
 
@@ -88,7 +88,8 @@ class TestDeprecatedOptional:
         expected_list: List[InputDefault],
         hydra_restore_singletons: Any,
     ) -> None:
-        version.setbase("1.1")
+        with warns(Hydra14MigrationWarning):
+            version.setbase("1.1")
         repo = create_repo()
         warning = dedent(
             """
@@ -1297,7 +1298,8 @@ def test_legacy_override_hydra_version_base_1_1(
     recwarn: Any,  # Testing deprecated behavior
     hydra_restore_singletons: Any,
 ) -> None:
-    version.setbase("1.1")
+    with warns(Hydra14MigrationWarning):
+        version.setbase("1.1")
     _test_defaults_list_impl(
         config_name=config_name,
         overrides=overrides,

--- a/tests/defaults_list/test_defaults_tree.py
+++ b/tests/defaults_list/test_defaults_tree.py
@@ -13,7 +13,7 @@ from hydra.core.default_element import (
     VirtualRoot,
 )
 from hydra.core.plugins import Plugins
-from hydra.errors import ConfigCompositionException
+from hydra.errors import ConfigCompositionException, Hydra14MigrationWarning
 from hydra.test_utils.test_utils import chdir_hydra_root
 from tests.defaults_list import _test_defaults_tree_impl
 
@@ -941,7 +941,8 @@ def test_legacy_override_hydra_version_base_1_1(
     expected: DefaultsTreeNode,
     hydra_restore_singletons: Any,
 ) -> None:
-    version.setbase("1.1")
+    with warns(Hydra14MigrationWarning):
+        version.setbase("1.1")
     msg = dedent(
         """\
         Invalid overriding of hydra/help:
@@ -2109,7 +2110,8 @@ def test_legacy_interpolation(
     Defaults list element '.*=.*' is using a deprecated interpolation form.
     See http://hydra.cc/docs/1.1/upgrades/1.0_to_1.1/defaults_list_interpolation for migration information."""
     )
-    version.setbase("1.1")
+    with warns(Hydra14MigrationWarning):
+        version.setbase("1.1")
     with warns(expected_warning=UserWarning, match=msg):
         _test_defaults_tree_impl(
             config_name=config_name,
@@ -2925,7 +2927,8 @@ def test_deprecated_package_header_keywords(
         See https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_package_header for more information"""
     )
 
-    version.setbase("1.1")
+    with warns(Hydra14MigrationWarning):
+        version.setbase("1.1")
 
     with warns(UserWarning, match=re.escape(msg)):
         _test_defaults_tree_impl(

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -14,7 +14,7 @@ from pytest import fixture, mark, param, raises, warns
 import hydra
 from hydra import version
 from hydra._internal.instantiate._instantiate2 import _resolve_target
-from hydra.errors import InstantiationException
+from hydra.errors import Hydra14MigrationWarning, InstantiationException
 from hydra.test_utils.test_utils import assert_multiline_regex_search
 from hydra.types import ConvertMode, TargetConf
 from tests.instantiate import (
@@ -656,7 +656,8 @@ def test_instantiate_adam_conf_with_convert(instantiate_func: Any) -> None:
 
 
 def test_targetconf_deprecated(hydra_restore_singletons: Any) -> None:
-    version.setbase("1.1")
+    with warns(Hydra14MigrationWarning):
+        version.setbase("1.1")
     with warns(
         expected_warning=UserWarning,
         match=re.escape(

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -2,6 +2,7 @@
 import re
 import subprocess
 import sys
+import warnings
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -23,7 +24,11 @@ from hydra._internal.config_search_path_impl import ConfigSearchPathImpl
 from hydra.core.config_search_path import SearchPathQuery
 from hydra.core.config_store import ConfigStore
 from hydra.core.global_hydra import GlobalHydra
-from hydra.errors import ConfigCompositionException, HydraException
+from hydra.errors import (
+    ConfigCompositionException,
+    Hydra14MigrationWarning,
+    HydraException,
+)
 from hydra.test_utils.test_utils import chdir_hydra_root
 
 chdir_hydra_root()
@@ -73,26 +78,45 @@ def test_initialize_bad_version_base(hydra_restore_singletons: Any) -> None:
         initialize(version_base=1.1)  # type: ignore
 
 
-def test_initialize_dev_version_base(hydra_restore_singletons: Any) -> None:
+def test_initialize_version_base_1_1(hydra_restore_singletons: Any) -> None:
     assert not GlobalHydra().is_initialized()
-    # packaging will compare "1.2.0.dev2" < "1.2", so need to ensure handled correctly
-    initialize(version_base="1.2.0.dev2")
-    assert version.base_at_least("1.2")
+    with warns(
+        Hydra14MigrationWarning,
+        match='version_base="1.1" selects Hydra 1.1 compatibility behavior',
+    ):
+        initialize(version_base="1.1", config_path=None)
+    assert version.getbase() == version.__compat_version__
+
+
+@mark.parametrize("version_base", ["1.2", "1.2.0.dev2", "1.3"])
+def test_initialize_supported_version_base_without_migration_warning(
+    hydra_restore_singletons: Any, version_base: str
+) -> None:
+    assert not GlobalHydra().is_initialized()
+    expected_version = version._get_version(version_base)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        initialize(version_base=version_base, config_path=None)
+    assert not any(isinstance(item.message, Hydra14MigrationWarning) for item in caught)
+    assert version.getbase() == expected_version
 
 
 def test_initialize_cur_version_base(hydra_restore_singletons: Any) -> None:
     assert not GlobalHydra().is_initialized()
-    initialize(version_base=None)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        initialize(version_base=None, config_path=None)
+    assert not any(isinstance(item.message, Hydra14MigrationWarning) for item in caught)
     assert version.base_at_least(__version__)
 
 
 def test_initialize_compat_version_base(hydra_restore_singletons: Any) -> None:
     assert not GlobalHydra().is_initialized()
-    with raises(
-        UserWarning,
-        match=f"Will assume defaults for version {version.__compat_version__}",
+    with warns(
+        Hydra14MigrationWarning,
+        match="Hydra 1.4 will remove this compatibility behavior",
     ):
-        initialize()
+        initialize(config_path=None)
     assert version.base_at_least(str(version.__compat_version__))
 
 
@@ -644,7 +668,9 @@ def test_deprecated_compose(hydra_restore_singletons: Any) -> None:
 
     msg = "hydra.experimental.compose() is no longer experimental. Use hydra.compose()"
 
-    with initialize(version_base="1.1"):
+    with warns(Hydra14MigrationWarning):
+        init = initialize(version_base="1.1")
+    with init:
         with warns(
             expected_warning=UserWarning,
             match=re.escape(msg),
@@ -664,9 +690,10 @@ def test_deprecated_initialize(hydra_restore_singletons: Any) -> None:
 
     msg = "hydra.experimental.initialize() is no longer experimental. Use hydra.initialize()"
 
-    version.setbase("1.1")
+    with warns(Hydra14MigrationWarning):
+        version.setbase("1.1")
     with warns(expected_warning=UserWarning, match=re.escape(msg)):
-        with expr_initialize():
+        with expr_initialize(config_path=None):
             assert compose() == {}
 
     version.setbase("1.2")
@@ -680,7 +707,8 @@ def test_deprecated_initialize_config_dir(hydra_restore_singletons: Any) -> None
 
     msg = "hydra.experimental.initialize_config_dir() is no longer experimental. Use hydra.initialize_config_dir()"
 
-    version.setbase("1.1")
+    with warns(Hydra14MigrationWarning):
+        version.setbase("1.1")
     with warns(
         expected_warning=UserWarning,
         match=re.escape(msg),
@@ -711,7 +739,8 @@ def test_deprecated_initialize_config_module(hydra_restore_singletons: Any) -> N
         " Use hydra.initialize_config_module()"
     )
 
-    version.setbase("1.1")
+    with warns(Hydra14MigrationWarning):
+        version.setbase("1.1")
     with warns(expected_warning=UserWarning, match=re.escape(msg)):
         with expr_initialize_config_module(
             config_module="examples.jupyter_notebooks.cloud_app.conf",
@@ -781,7 +810,8 @@ def test_deprecated_compose_strict_flag(
         """
     )
 
-    version.setbase("1.1")
+    with warns(Hydra14MigrationWarning):
+        version.setbase("1.1")
 
     with warns(
         expected_warning=UserWarning,

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -15,6 +15,7 @@ from hydra.core.override_parser.overrides_parser import OverridesParser
 from hydra.core.utils import env_override, setup_globals
 from hydra.errors import (
     ConfigCompositionException,
+    Hydra14MigrationWarning,
     HydraException,
     MissingConfigException,
 )
@@ -190,7 +191,8 @@ class TestConfigLoader:
         config_loader = ConfigLoaderImpl(
             config_search_path=create_config_search_path(path)
         )
-        version.setbase("1.1")
+        with warns(Hydra14MigrationWarning):
+            version.setbase("1.1")
         with warns(
             UserWarning,
             match=(

--- a/tests/test_hydra.py
+++ b/tests/test_hydra.py
@@ -3,15 +3,18 @@ import os
 import re
 import subprocess
 import sys
+import warnings
 from logging import getLogger
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, List, Optional, Set
 
 from omegaconf import DictConfig, OmegaConf
-from pytest import mark, param, raises
+from pytest import mark, param, raises, warns
 
+import hydra
 from hydra import MissingConfigException, version
+from hydra.errors import Hydra14MigrationWarning
 from hydra.test_utils.test_utils import (
     TSweepRunner,
     TTaskRunner,
@@ -27,6 +30,24 @@ from hydra.test_utils.test_utils import (
 )
 
 chdir_hydra_root()
+
+
+def test_hydra_main_version_base_1_1(hydra_restore_singletons: Any) -> None:
+    with warns(
+        Hydra14MigrationWarning,
+        match='version_base="1.1" selects Hydra 1.1 compatibility behavior',
+    ):
+        hydra.main(version_base="1.1", config_path=None)
+
+
+@mark.parametrize("version_base", [None, "1.2", "1.3"])
+def test_hydra_main_supported_version_base_without_migration_warning(
+    hydra_restore_singletons: Any, version_base: Optional[str]
+) -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        hydra.main(version_base=version_base, config_path=None)
+    assert not any(isinstance(item.message, Hydra14MigrationWarning) for item in caught)
 
 
 @mark.parametrize("calling_file, calling_module", [(".", None), (None, ".")])
@@ -1478,10 +1499,12 @@ def test_hydra_main_without_config_path(tmpdir: Path) -> None:
 
     expected = dedent(
         f"""
-        .*my_app.py:7: UserWarning:
+        .*my_app.py:7: Hydra14MigrationWarning:
         The version_base parameter is not specified.
-        Please specify a compatability version level, or None.
-        Will assume defaults for version {version.__compat_version__}
+        Hydra will assume defaults for version {version.__compat_version__}.
+        Hydra 1.4 will remove this compatibility behavior.
+        Before upgrading to Hydra 1.4, set version_base="1.3" and test your application.
+        See https://hydra.cc/docs/upgrades/1.3_to_1.4/prepare_for_1_4/ for preparation instructions.
           @hydra.main()
         .*my_app.py:7: UserWarning:
         config_path is not specified in @hydra.main().
@@ -1506,6 +1529,12 @@ def test_job_chdir_not_specified(tmpdir: Path) -> None:
 
     expected = dedent(
         """
+        .*Hydra14MigrationWarning:
+        version_base="1.1" selects Hydra 1.1 compatibility behavior.
+        Hydra 1.4 will remove this compatibility behavior.
+        Before upgrading to Hydra 1.4, set version_base="1.3" and test your application.
+        See https://hydra.cc/docs/upgrades/1.3_to_1.4/prepare_for_1_4/ for preparation instructions.
+          @hydra.main(version_base="1.1", config_path=".")
         .*UserWarning: Future Hydra versions will no longer change working directory at job runtime by default.
         See https://hydra.cc/docs/1.2/upgrades/1.1_to_1.2/changes_to_job_working_dir/ for more information..*
         .*

--- a/tests/test_overrides_parser.py
+++ b/tests/test_overrides_parser.py
@@ -31,7 +31,7 @@ from hydra.core.override_parser.types import (
     Transformer,
     ValueType,
 )
-from hydra.errors import HydraException
+from hydra.errors import Hydra14MigrationWarning, HydraException
 
 UNQUOTED_SPECIAL = r"/-\+.$%*@?|"  # special characters allowed in unquoted strings
 
@@ -1004,7 +1004,8 @@ def test_deprecated_name_package(hydra_restore_singletons: Any) -> None:
         "see https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_package_header"
     )
 
-    version.setbase("1.1")
+    with warns(Hydra14MigrationWarning):
+        version.setbase("1.1")
 
     with warns(
         UserWarning,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 import io
 import os
 import re
+import warnings
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, NoReturn, Optional
@@ -10,12 +11,12 @@ from unittest.mock import patch
 from omegaconf import DictConfig, OmegaConf
 from pytest import mark, param, raises, warns
 
-from hydra import utils
+from hydra import utils, version
 from hydra._internal.deprecation_warning import deprecation_warning
 from hydra._internal.utils import run_and_report
 from hydra.conf import HydraConf, RuntimeConf
 from hydra.core.hydra_config import HydraConfig
-from hydra.errors import HydraDeprecationError
+from hydra.errors import Hydra14MigrationWarning, HydraDeprecationError
 from hydra.test_utils.test_utils import (
     assert_multiline_regex_search,
     assert_regex_match,
@@ -93,6 +94,26 @@ def test_deprecation_warning(
     else:
         with warns(UserWarning, match=re.escape(msg)):
             deprecation_warning(msg)
+
+
+def test_suppress_migration_warning_category(hydra_restore_singletons: Any) -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warnings.filterwarnings("ignore", category=Hydra14MigrationWarning)
+        version.setbase(version._UNSPECIFIED_)
+        deprecation_warning("Unrelated warning")
+
+    assert len(caught) == 1
+    assert type(caught[0].message) is UserWarning
+    assert str(caught[0].message) == "Unrelated warning"
+
+
+def test_migration_warning_not_promoted_to_deprecation_error(
+    hydra_restore_singletons: Any, monkeypatch: Any
+) -> None:
+    monkeypatch.setenv("HYDRA_DEPRECATION_WARNINGS_AS_ERRORS", "1")
+    with warns(Hydra14MigrationWarning, match="Hydra 1.4 will remove"):
+        version.setbase(version._UNSPECIFIED_)
 
 
 class TestRunAndReport:


### PR DESCRIPTION
Add `Hydra14MigrationWarning` for omitted `version_base` and explicit `"1.1"`, while keeping explicit `None`, `"1.2"`, and `"1.3"` warning-free.

Link the warning to the separately maintained Hydra 1.4 preparation guide, which covers the temporary `version_base="1.3"` migration step, targeted suppression for applications pinned to Hydra 1.3, and the behavior being removed.

Fixes #3334