### PR TITLE
Align bundled plugin dependencies with Hydra 1.4 release line

### DIFF
--- a/news/3324.maintenance
+++ b/news/3324.maintenance
@@ -1,0 +1,1 @@
+Align bundled plugin dependencies with Hydra 1.4 release line.

--- a/plugins/hydra_ax_sweeper/setup.py
+++ b/plugins/hydra_ax_sweeper/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     python_requires=">=3.11,<3.15",
     install_requires=[
-        "hydra-core>=1.1.0.dev7",
+        "hydra-core>=1.4.0.dev1,<1.5.0.dev0",
         "ax-platform>=1.2.4,<1.3.0",
         "torch>=2.2",
     ],

--- a/plugins/hydra_colorlog/setup.py
+++ b/plugins/hydra_colorlog/setup.py
@@ -25,6 +25,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.10",
-    install_requires=["colorlog", "hydra-core>=1.0.0"],
+    install_requires=["colorlog", "hydra-core>=1.4.0.dev1,<1.5.0.dev0"],
     include_package_data=True,
 )

--- a/plugins/hydra_nevergrad_sweeper/setup.py
+++ b/plugins/hydra_nevergrad_sweeper/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     python_requires=">=3.10",
     install_requires=[
-        "hydra-core>=1.1.0.dev7",
+        "hydra-core>=1.4.0.dev1,<1.5.0.dev0",
         "nevergrad>=1.0.12",
     ],
     include_package_data=True,

--- a/plugins/hydra_optuna_sweeper/setup.py
+++ b/plugins/hydra_optuna_sweeper/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     python_requires=">=3.10",
     install_requires=[
-        "hydra-core>=1.1.0.dev7",
+        "hydra-core>=1.4.0.dev1,<1.5.0.dev0",
         "optuna>=4.9.0,<5.0.0",
     ],
     include_package_data=True,

--- a/plugins/hydra_ray_launcher/setup.py
+++ b/plugins/hydra_ray_launcher/setup.py
@@ -28,7 +28,7 @@ setup(
     python_requires=">=3.10",
     install_requires=[
         "boto3",
-        "hydra-core>=1.1.2",
+        "hydra-core>=1.4.0.dev1,<1.5.0.dev0",
         "ray[default]<3",
         "aiohttp<4",
         "cloudpickle<3",

--- a/plugins/hydra_rq_launcher/setup.py
+++ b/plugins/hydra_rq_launcher/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         "cloudpickle",
         "fakeredis>=2.36.2,<3",
-        "hydra-core>=1.1.0.dev7",
+        "hydra-core>=1.4.0.dev1,<1.5.0.dev0",
         "rq>=2.10.0,<3",
     ],
     include_package_data=True,

--- a/plugins/hydra_submitit_launcher/setup.py
+++ b/plugins/hydra_submitit_launcher/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     python_requires=">=3.10",
     install_requires=[
-        "hydra-core>=1.1.0.dev7",
+        "hydra-core>=1.4.0.dev1,<1.5.0.dev0",
         "submitit>=1.4.6",
     ],
     include_package_data=True,

--- a/tests/test_plugin_dependencies.py
+++ b/tests/test_plugin_dependencies.py
@@ -1,0 +1,42 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import ast
+from pathlib import Path
+import pytest
+
+PLUGINS_DIR = Path(__file__).parent.parent / "plugins"
+
+EXPECTED_HYDRA_CORE_REQUIREMENT = "hydra-core>=1.4.0.dev1,<1.5.0.dev0"
+
+
+def get_bundled_plugin_setup_files():
+    """Find setup.py for all bundled plugins."""
+    setup_files = sorted(PLUGINS_DIR.glob("*/setup.py"))
+    assert len(setup_files) > 0, "No bundled plugin setup.py files found"
+    return setup_files
+
+
+@pytest.mark.parametrize("setup_file", get_bundled_plugin_setup_files(), ids=lambda p: p.parent.name)
+def test_plugin_hydra_core_dependency_line_versioning(setup_file: Path) -> None:
+    """Verify that all bundled plugins specify line-versioning constraints on hydra-core."""
+    content = setup_file.read_text(encoding="utf-8")
+    tree = ast.parse(content, filename=str(setup_file))
+
+    install_requires_elements = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.keyword) and node.arg == "install_requires":
+            if isinstance(node.value, ast.List):
+                for elt in node.value.elts:
+                    if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                        install_requires_elements.append(elt.value)
+
+    hydra_core_deps = [req for req in install_requires_elements if req.startswith("hydra-core")]
+
+    assert len(hydra_core_deps) == 1, (
+        f"Expected exactly 1 hydra-core requirement in {setup_file.parent.name}/setup.py, "
+        f"found {hydra_core_deps}"
+    )
+
+    assert hydra_core_deps[0] == EXPECTED_HYDRA_CORE_REQUIREMENT, (
+        f"Plugin {setup_file.parent.name} has incorrect hydra-core dependency '{hydra_core_deps[0]}'. "
+        f"Expected '{EXPECTED_HYDRA_CORE_REQUIREMENT}'."
+    )


### PR DESCRIPTION
## Summary

Aligns all bundled plugin `setup.py` files under `plugins/` to enforce line-versioning constraints on `hydra-core` (`hydra-core>=1.4.0.dev1,<1.5.0.dev0`), consistent with PR #3323 and the Hydra 1.4 release line policy.

Fixes #3324.

## Changes Made
- Updated `install_requires` across all remaining 7 bundled plugins:
  - `plugins/hydra_ax_sweeper/setup.py`
  - `plugins/hydra_colorlog/setup.py`
  - `plugins/hydra_nevergrad_sweeper/setup.py`
  - `plugins/hydra_optuna_sweeper/setup.py`
  - `plugins/hydra_ray_launcher/setup.py`
  - `plugins/hydra_rq_launcher/setup.py`
  - `plugins/hydra_submitit_launcher/setup.py`
- Added news fragment `news/3324.maintenance`.
- Added unit test suite `tests/test_plugin_dependencies.py` to verify line-versioning bounds across all bundled plugins.

## Verification
- Ran `pytest tests/test_plugin_dependencies.py` (8/8 passed).