### PR TITLE
Replace configured value with a dict call-site argument

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -480,6 +480,8 @@ def instantiate(
     :param kwargs: Optional named parameters to override
                    parameters in the config object. Parameters not present
                    in the config objects are being passed as is to the target.
+                   A dict replaces a configured plain mapping, but merges into
+                   a configured Structured Config or target config.
                    Dataclass and attrs instances are passed through without
                    conversion or recursive instantiation.
     :return: if _target_ is a class name: the instantiated object
@@ -674,22 +676,28 @@ def _instantiate_override(
     return value
 
 
-def _configured_value_is_target(node: Any, key: str) -> bool:
-    """Whether the configured value for key is an instantiate config.
-
-    A value declared with a Structured Config type carries `_target_` through
-    that type even when its configured value is None, and `instantiate_node`
-    materializes it from the type before instantiating.
-    """
+def _get_dict_override_merge_base(
+    node: Any, key: str, *, is_target_parameter: bool
+) -> Optional[DictConfig]:
+    """Return the configured mapping to merge with a dict override, if any."""
     if key not in node:
-        return False
+        return None
     configured_value = node._get_node(key)
-    if OmegaConf.is_config(configured_value) and configured_value._is_none():
+    if not isinstance(configured_value, DictConfig):
+        return None
+    if configured_value._is_none() or configured_value._is_missing():
         ref_type = configured_value._metadata.ref_type
         if is_structured_config(ref_type):
-            return _is_target(OmegaConf.structured(ref_type))
-        return False
-    return _is_target(configured_value)
+            configured_value = OmegaConf.structured(ref_type)
+        else:
+            return None
+    if (
+        not is_target_parameter
+        or is_structured_config(OmegaConf.get_type(configured_value))
+        or _is_target(configured_value)
+    ):
+        return configured_value
+    return None
 
 
 def _instantiate_effective_value(
@@ -697,6 +705,7 @@ def _instantiate_effective_value(
     key: str,
     overrides: Optional[ConfigOverlay],
     *,
+    is_target_parameter: bool,
     convert: Union[str, ConvertMode],
     recursive: bool,
     target_whitelist: NormalizedTargetWhitelist,
@@ -704,21 +713,20 @@ def _instantiate_effective_value(
     if overrides is not None and key in overrides:
         override = overrides[key]
         dict_override = _get_dict_override(override)
-        # Patch a configured nested target with the named arguments. A
-        # configured value that is not a target is replaced instead, so a
-        # call-site argument does not inherit unrelated configured keys.
-        if (
-            recursive
-            and dict_override is not None
-            and _configured_value_is_target(node, key)
-        ):
-            return instantiate_node(
-                node._get_node(key),
-                overrides=dict_override,
-                convert=convert,
-                recursive=recursive,
-                target_whitelist=target_whitelist,
+        if dict_override is not None:
+            configured_value = _get_dict_override_merge_base(
+                node, key, is_target_parameter=is_target_parameter
             )
+            if configured_value is not None:
+                value = OmegaConf.merge(configured_value, dict_override)
+                if recursive:
+                    value = instantiate_node(
+                        value,
+                        convert=convert,
+                        recursive=recursive,
+                        target_whitelist=target_whitelist,
+                    )
+                return value
         return _instantiate_override(
             override,
             convert=convert,
@@ -831,6 +839,7 @@ def instantiate_node(
                         node,
                         key,
                         overrides,
+                        is_target_parameter=True,
                         convert=convert,
                         recursive=recursive,
                         target_whitelist=target_whitelist,
@@ -860,6 +869,7 @@ def instantiate_node(
                         node,
                         key,
                         overrides,
+                        is_target_parameter=False,
                         convert=convert,
                         recursive=recursive,
                         target_whitelist=target_whitelist,
@@ -876,6 +886,7 @@ def instantiate_node(
                             node,
                             key,
                             overrides,
+                            is_target_parameter=False,
                             convert=convert,
                             recursive=recursive,
                             target_whitelist=target_whitelist,

--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, 
 
 from omegaconf import AnyNode, DictConfig, OmegaConf, SCMode
 from omegaconf._utils import is_structured_config
+from omegaconf.errors import InterpolationResolutionError
 
 from hydra._internal.deprecation_warning import deprecation_warning
 from hydra._internal.utils import _locate
@@ -562,7 +563,39 @@ def _convert_node(node: Any, convert: Union[ConvertMode, str]) -> Any:
 def _wrap_structured_config_as_object(value: Any) -> Any:
     if is_structured_config(value):
         return AnyNode(value, flags={"allow_objects": True})
+    if isinstance(value, dict):
+        return {
+            key: _wrap_structured_config_as_object(item) for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_wrap_structured_config_as_object(item) for item in value]
+    if type(value) is tuple:
+        return tuple(_wrap_structured_config_as_object(item) for item in value)
     return value
+
+
+def _restore_nested_structured_config_objects(node: Any, value: Any) -> Any:
+    if is_structured_config(value):
+        return AnyNode(value, flags={"allow_objects": True})
+    if isinstance(value, dict) and isinstance(node, DictConfig):
+        content = node.__dict__["_content"]
+        for key, item in value.items():
+            child = node._get_node(key, validate_access=False)
+            restored = _restore_nested_structured_config_objects(child, item)
+            if restored is not child:
+                restored._set_parent(node)
+                restored._set_key(key)
+                content[key] = restored
+    elif isinstance(value, (list, tuple)) and OmegaConf.is_sequence(node):
+        content = node.__dict__["_content"]
+        for index, item in enumerate(value):
+            child = node._get_node(index)
+            restored = _restore_nested_structured_config_objects(child, item)
+            if restored is not child:
+                restored._set_parent(node)
+                restored._set_key(index)
+                content[index] = restored
+    return node
 
 
 def _create_sequence_result(
@@ -678,23 +711,31 @@ def _instantiate_override(
 
 def _get_dict_override_merge_base(
     node: Any, key: str, *, is_target_parameter: bool
-) -> Optional[DictConfig]:
+) -> Optional[ConfigOverlay]:
     """Return the configured mapping to merge with a dict override, if any."""
-    if key not in node:
-        return None
-    configured_value = node._get_node(key)
+    configured_value = node._get_node(key, validate_access=False)
+    if (
+        is_target_parameter
+        and configured_value is not None
+        and configured_value._is_interpolation()
+    ):
+        try:
+            configured_value = node[key]
+        except InterpolationResolutionError:
+            return None
+    if isinstance(configured_value, dict):
+        return configured_value if _is_target(configured_value) else None
     if not isinstance(configured_value, DictConfig):
         return None
-    if configured_value._is_none() or configured_value._is_missing():
-        ref_type = configured_value._metadata.ref_type
-        if is_structured_config(ref_type):
-            configured_value = OmegaConf.structured(ref_type)
-        else:
-            return None
     if (
         not is_target_parameter
-        or is_structured_config(OmegaConf.get_type(configured_value))
-        or _is_target(configured_value)
+        or is_structured_config(configured_value._metadata.ref_type)
+        or is_structured_config(configured_value._metadata.object_type)
+        or (
+            not configured_value._is_none()
+            and not configured_value._is_missing()
+            and _is_target(configured_value)
+        )
     ):
         return configured_value
     return None
@@ -719,6 +760,8 @@ def _instantiate_effective_value(
             )
             if configured_value is not None:
                 value = OmegaConf.merge(configured_value, dict_override)
+                if isinstance(dict_override, dict):
+                    _restore_nested_structured_config_objects(value, dict_override)
                 if recursive:
                     value = instantiate_node(
                         value,

--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -674,6 +674,24 @@ def _instantiate_override(
     return value
 
 
+def _configured_value_is_target(node: Any, key: str) -> bool:
+    """Whether the configured value for key is an instantiate config.
+
+    A value declared with a Structured Config type carries `_target_` through
+    that type even when its configured value is None, and `instantiate_node`
+    materializes it from the type before instantiating.
+    """
+    if key not in node:
+        return False
+    configured_value = node._get_node(key)
+    if OmegaConf.is_config(configured_value) and configured_value._is_none():
+        ref_type = configured_value._metadata.ref_type
+        if is_structured_config(ref_type):
+            return _is_target(OmegaConf.structured(ref_type))
+        return False
+    return _is_target(configured_value)
+
+
 def _instantiate_effective_value(
     node: Any,
     key: str,
@@ -686,12 +704,16 @@ def _instantiate_effective_value(
     if overrides is not None and key in overrides:
         override = overrides[key]
         dict_override = _get_dict_override(override)
-        if recursive and dict_override is not None:
-            configured_value = node._get_node(key) if key in node else None
-            if not OmegaConf.is_dict(configured_value):
-                configured_value = OmegaConf.create({})
+        # Patch a configured nested target with the named arguments. A
+        # configured value that is not a target is replaced instead, so a
+        # call-site argument does not inherit unrelated configured keys.
+        if (
+            recursive
+            and dict_override is not None
+            and _configured_value_is_target(node, key)
+        ):
             return instantiate_node(
-                configured_value,
+                node._get_node(key),
                 overrides=dict_override,
                 convert=convert,
                 recursive=recursive,

--- a/news/2350.api_change
+++ b/news/2350.api_change
@@ -1,2 +1,3 @@
-A `dict` call-site argument to `hydra.utils.instantiate()` now replaces a plain,
-non-target mapping configured for a target parameter instead of merging into it.
+A `dict` or `DictConfig` call-site argument to `hydra.utils.instantiate()` now
+replaces a plain, non-target mapping configured for a target parameter instead
+of merging into it.

--- a/news/2350.api_change
+++ b/news/2350.api_change
@@ -1,0 +1,6 @@
+A `dict` call-site argument to `hydra.utils.instantiate()` now replaces the
+configured value instead of merging into it, so the target no longer receives
+configured keys that the call-site argument did not name. A configured value
+that is itself an instantiate config keeps its documented patching behavior.
+See the
+[Hydra 1.4 instantiate migration guide](https://hydra.cc/docs/upgrades/1.3_to_1.4/instantiate_resolution/).

--- a/news/2350.api_change
+++ b/news/2350.api_change
@@ -1,6 +1,2 @@
-A `dict` call-site argument to `hydra.utils.instantiate()` now replaces the
-configured value instead of merging into it, so the target no longer receives
-configured keys that the call-site argument did not name. A configured value
-that is itself an instantiate config keeps its documented patching behavior.
-See the
-[Hydra 1.4 instantiate migration guide](https://hydra.cc/docs/upgrades/1.3_to_1.4/instantiate_resolution/).
+A `dict` call-site argument to `hydra.utils.instantiate()` now replaces a plain,
+non-target mapping configured for a target parameter instead of merging into it.

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,1 +1,1 @@
-omegaconf>=2.4.0.dev13
+omegaconf>=2.4.0.dev15

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -1127,6 +1127,18 @@ def test_regression_2350_dict_override_replaces_configured_dict(
     assert result.kwargs["value"] == {"runtime": 20}
 
 
+def test_dict_override_for_unconfigured_target_parameter(
+    instantiate_func: Any,
+) -> None:
+    @dataclass
+    class Config:
+        _target_: str = "tests.instantiate.ArgsClass"
+
+    result = instantiate_func(Config, extra={"value": 10})
+
+    assert result.kwargs["extra"] == {"value": 10}
+
+
 @mark.parametrize(
     "recursive,expected",
     [
@@ -1172,6 +1184,101 @@ def test_dict_override_merges_configured_target(
     assert value == expected
     if not recursive:
         assert isinstance(value, DictConfig)
+
+
+def test_dict_override_merges_interpolated_configured_target(
+    instantiate_func: Any,
+) -> None:
+    result = instantiate_func(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "template": {
+                "_target_": "tests.instantiate.Tree",
+                "value": 10,
+                "left": {
+                    "_target_": "tests.instantiate.Tree",
+                    "value": 30,
+                },
+            },
+            "value": "${template}",
+        },
+        value={"value": 20},
+    )
+
+    assert result.kwargs["value"] == Tree(value=20, left=Tree(value=30))
+
+
+def test_dict_override_merges_interpolated_structured_config(
+    instantiate_func: Any,
+) -> None:
+    @dataclass
+    class Value:
+        count: int = 10
+        label: str = "configured"
+
+    result = instantiate_func(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "template": OmegaConf.structured(Value),
+            "value": "${template}",
+        },
+        value={"count": 20},
+    )
+
+    value = result.kwargs["value"]
+    assert OmegaConf.get_type(value) is Value
+    assert value == {"count": 20, "label": "configured"}
+
+
+def test_dict_override_replaces_interpolated_configured_dict(
+    instantiate_func: Any,
+) -> None:
+    result = instantiate_func(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "template": {"configured": 10},
+            "value": "${template}",
+        },
+        value={"runtime": 20},
+    )
+
+    assert result.kwargs["value"] == {"runtime": 20}
+
+
+def test_dict_override_replaces_unresolvable_configured_interpolation(
+    instantiate_func: Any,
+) -> None:
+    result = instantiate_func(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "value": "${missing}",
+        },
+        value={"runtime": 20},
+    )
+
+    assert result.kwargs["value"] == {"runtime": 20}
+
+
+def test_dict_override_merges_resolver_result_target(
+    instantiate_func: Any,
+) -> None:
+    resolver_name = "hydra_instantiate_target_mapping"
+    OmegaConf.register_resolver(
+        resolver_name,
+        lambda: {"_target_": "builtins.dict", "configured": 10},
+    )
+    try:
+        result = instantiate_func(
+            {
+                "_target_": "tests.instantiate.ArgsClass",
+                "value": f"${{{resolver_name}:}}",
+            },
+            value={"runtime": 20},
+        )
+    finally:
+        OmegaConf.clear_resolver(resolver_name)
+
+    assert result.kwargs["value"] == {"configured": 10, "runtime": 20}
 
 
 def test_dict_override_merges_structured_config_fields(
@@ -1230,6 +1337,153 @@ def test_dict_override_merges_structured_config_fields(
 
     with raises(ValidationError):
         instantiate_func(Config, value={"count": "not an integer"})
+
+
+@mark.parametrize("convert", list(ConvertMode))
+@mark.parametrize("runtime_type", ["dataclass", "attrs"])
+@mark.parametrize("container", ["direct", "mapping", "list", "tuple"])
+def test_structured_config_dict_override_preserves_nested_runtime_object(
+    instantiate_func: Any,
+    container: str,
+    runtime_type: str,
+    convert: ConvertMode,
+) -> None:
+    @dataclass
+    class RuntimeValue:
+        _target_: str
+        value: int
+        token: InitVar[str]
+        runtime_token: str = field(init=False)
+
+        def __post_init__(self, token: str) -> None:
+            self.runtime_token = token
+
+    @attr.define
+    class AttrsRuntimeValue:
+        _target_: str
+        value: int
+
+    @dataclass
+    class Value:
+        payload: Any = None
+
+    @dataclass
+    class Config:
+        _target_: str = "tests.instantiate.ArgsClass"
+        value: Value = field(default_factory=Value)
+
+    runtime_value = (
+        RuntimeValue(
+            _target_="tests.instantiate.AnotherClass",
+            value=10,
+            token="secret",
+        )
+        if runtime_type == "dataclass"
+        else AttrsRuntimeValue("tests.instantiate.AnotherClass", 10)
+    )
+    payload = {
+        "direct": runtime_value,
+        "mapping": {"runtime": runtime_value},
+        "list": [runtime_value],
+        "tuple": (runtime_value,),
+    }[container]
+
+    result = instantiate_func(Config, value={"payload": payload}, _convert_=convert)
+    value = result.kwargs["value"]
+    actual = value.payload if hasattr(value, "payload") else value["payload"]
+    if container == "mapping":
+        actual = actual["runtime"]
+    elif container in ("list", "tuple"):
+        actual = actual[0]
+
+    assert actual is runtime_value
+
+
+@mark.parametrize("convert", list(ConvertMode))
+def test_structured_config_dict_override_preserves_typed_runtime_object(
+    instantiate_func: Any, convert: ConvertMode
+) -> None:
+    @dataclass
+    class Child:
+        value: int = 10
+
+    @dataclass
+    class Value:
+        child: Child = field(default_factory=Child)
+
+    @dataclass
+    class Config:
+        _target_: str = "tests.instantiate.ArgsClass"
+        value: Value = field(default_factory=Value)
+
+    child = Child(value=20)
+    result = instantiate_func(Config, value={"child": child}, _convert_=convert)
+    value = result.kwargs["value"]
+
+    assert (value.child if hasattr(value, "child") else value["child"]) is child
+
+
+@mark.parametrize("container", ["mapping", "sequence"])
+def test_nested_target_result_preserves_runtime_object(
+    instantiate_func: Any, container: str
+) -> None:
+    @dataclass
+    class RuntimeValue:
+        value: int
+
+    runtime_value = RuntimeValue(value=10)
+    target = OmegaConf.create({"_target_": "builtins.dict"})
+    target["object"] = structured_config_object_node(runtime_value)
+    config = {"result": target} if container == "mapping" else [target]
+
+    result = instantiate_func(config)
+    target_result = result["result"] if container == "mapping" else result[0]
+
+    assert target_result["object"] is runtime_value
+
+
+def test_dict_override_materializes_structured_config_with_allow_objects(
+    instantiate_func: Any,
+) -> None:
+    class RuntimeObject: ...
+
+    @dataclass
+    class Value:
+        payload: Any = RuntimeObject()
+
+    @dataclass
+    class Config:
+        _target_: str = "tests.instantiate.ArgsClass"
+        value: Optional[Value] = None
+
+    result = instantiate_func(Config, value={})
+
+    value = result.kwargs["value"]
+    assert OmegaConf.get_type(value) is Value
+    assert isinstance(value.payload, RuntimeObject)
+
+
+@mark.parametrize(
+    "configured_value",
+    [param(None, id="none"), param(MISSING, id="missing")],
+)
+def test_dict_override_materialized_structured_config_resolves_outside_subtree(
+    instantiate_func: Any, configured_value: Any
+) -> None:
+    @dataclass
+    class Value:
+        count: int = 10
+        inherited: int = "${..template}"  # type: ignore[assignment]
+
+    @dataclass
+    class Config:
+        _target_: str = "tests.instantiate.ArgsClass"
+        template: int = 20
+        value: Optional[Value] = configured_value
+
+    result = instantiate_func(Config, value={"count": 30})
+
+    assert result.kwargs["value"] == {"count": 30, "inherited": 20}
 
 
 @mark.parametrize(

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -1110,6 +1110,51 @@ def test_omegaconf_structured_runtime_override_merges_with_configured_value(
     assert result.kwargs["value"] == Tree(value=20, left=Tree(value=30))
 
 
+def test_regression_2350_dict_override_replaces_configured_dict(
+    instantiate_func: Any,
+) -> None:
+    """
+    In 2350, a dict call-site argument was recursively merged into the
+    configured dict, so keys that were only in the configuration survived.
+    A call-site argument replaces a plain configured dict instead.
+    """
+    result = instantiate_func(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "value": {"configured": 10},
+        },
+        value={"runtime": 20},
+    )
+
+    assert result.kwargs["value"] == {"runtime": 20}
+
+
+def test_dict_override_patches_configured_nested_target(
+    instantiate_func: Any,
+) -> None:
+    """
+    A configured value that is itself an instantiate config keeps the
+    documented patching behavior: the call-site dict overrides the arguments
+    it names and leaves the rest of the nested config in place.
+    """
+    result = instantiate_func(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "value": {
+                "_target_": "tests.instantiate.Tree",
+                "value": 10,
+                "left": {
+                    "_target_": "tests.instantiate.Tree",
+                    "value": 30,
+                },
+            },
+        },
+        value={"value": 20},
+    )
+
+    assert result.kwargs["value"] == Tree(value=20, left=Tree(value=30))
+
+
 def test_runtime_override_is_not_coerced_by_structured_config(
     instantiate_func: Any,
 ) -> None:
@@ -1494,6 +1539,7 @@ def test_instantiate_with_callable_target_keyword(
             ),
             id="recursive:map:dict",
         ),
+        # the configured dictionary is not a target, so it is replaced
         param(
             {
                 "_target_": "tests.instantiate.Mapping",
@@ -1508,7 +1554,6 @@ def test_instantiate_with_callable_target_keyword(
             },
             Mapping(
                 dictionary={
-                    "a": Mapping(),
                     "b": Mapping(),
                 }
             ),
@@ -1709,7 +1754,8 @@ def test_recursive_instantiation(
                 dictionary=cast(
                     Any,
                     {
-                        "a": partial(Mapping),
+                        # the configured dictionary is not a target, so it is
+                        # replaced by the call-site argument
                         "b": partial(Mapping),
                     },
                 ),

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -19,6 +19,7 @@ from omegaconf import (
     OmegaConf,
     TupleConfig,
 )
+from omegaconf.errors import ValidationError
 from pytest import fixture, mark, param, raises, warns
 
 from hydra._internal.instantiate import _instantiate2
@@ -1113,29 +1114,43 @@ def test_omegaconf_structured_runtime_override_merges_with_configured_value(
 def test_regression_2350_dict_override_replaces_configured_dict(
     instantiate_func: Any,
 ) -> None:
-    """
-    In 2350, a dict call-site argument was recursively merged into the
-    configured dict, so keys that were only in the configuration survived.
-    A call-site argument replaces a plain configured dict instead.
-    """
+    @dataclass
+    class Config:
+        _target_: str = "tests.instantiate.ArgsClass"
+        value: Dict[str, int] = field(default_factory=lambda: {"configured": 10})
+
     result = instantiate_func(
-        {
-            "_target_": "tests.instantiate.ArgsClass",
-            "value": {"configured": 10},
-        },
+        Config,
         value={"runtime": 20},
     )
 
     assert result.kwargs["value"] == {"runtime": 20}
 
 
-def test_dict_override_patches_configured_nested_target(
-    instantiate_func: Any,
+@mark.parametrize(
+    "recursive,expected",
+    [
+        param(
+            False,
+            {
+                "_target_": "tests.instantiate.Tree",
+                "value": 20,
+                "left": {
+                    "_target_": "tests.instantiate.Tree",
+                    "value": 30,
+                },
+            },
+            id="not_recursive",
+        ),
+        param(True, Tree(value=20, left=Tree(value=30)), id="recursive"),
+    ],
+)
+def test_dict_override_merges_configured_target(
+    instantiate_func: Any, recursive: bool, expected: Any
 ) -> None:
     """
-    A configured value that is itself an instantiate config keeps the
-    documented patching behavior: the call-site dict overrides the arguments
-    it names and leaves the rest of the nested config in place.
+    A configured target keeps merge behavior: the call-site dict overrides the
+    arguments it names and leaves the rest of the target config in place.
     """
     result = instantiate_func(
         {
@@ -1150,9 +1165,128 @@ def test_dict_override_patches_configured_nested_target(
             },
         },
         value={"value": 20},
+        _recursive_=recursive,
     )
 
-    assert result.kwargs["value"] == Tree(value=20, left=Tree(value=30))
+    value = result.kwargs["value"]
+    assert value == expected
+    if not recursive:
+        assert isinstance(value, DictConfig)
+
+
+def test_dict_override_merges_structured_config_fields(
+    instantiate_func: Any,
+) -> None:
+    @dataclass
+    class Child:
+        count: int = 10
+        label: str = "configured"
+
+    @dataclass
+    class Value:
+        count: int = 10
+        derived: int = "${.count}"  # type: ignore[assignment]
+        label: str = "configured"
+        child: Child = field(default_factory=Child)
+        tags: Dict[str, str] = field(
+            default_factory=lambda: {"env": "prod", "team": "ml"}
+        )
+
+    @dataclass
+    class Config:
+        _target_: str = "tests.instantiate.ArgsClass"
+        value: Value = field(default_factory=Value)
+
+    cfg = OmegaConf.structured(Config)
+    OmegaConf.set_readonly(cfg, True)
+    result = instantiate_func(
+        cfg,
+        value={
+            "count": "20",
+            "child": {"count": "30"},
+            "tags": {"env": "dev"},
+        },
+    )
+
+    value = result.kwargs["value"]
+    assert OmegaConf.get_type(value) is Value
+    assert value == {
+        "count": 20,
+        "derived": 20,
+        "label": "configured",
+        "child": {"count": 30, "label": "configured"},
+        "tags": {"env": "dev", "team": "ml"},
+    }
+    assert OmegaConf.get_type(value.child) is Child
+    assert cfg.value == {
+        "count": 10,
+        "derived": 10,
+        "label": "configured",
+        "child": {"count": 10, "label": "configured"},
+        "tags": {"env": "prod", "team": "ml"},
+    }
+    assert OmegaConf.is_readonly(cfg)
+    assert OmegaConf.is_interpolation(cfg.value, "derived")
+
+    with raises(ValidationError):
+        instantiate_func(Config, value={"count": "not an integer"})
+
+
+@mark.parametrize(
+    "recursive,expected",
+    [
+        param(
+            False,
+            {
+                "_target_": "tests.instantiate.Tree",
+                "value": 20,
+                "left": {
+                    "_target_": "tests.instantiate.Tree",
+                    "value": 30,
+                },
+            },
+            id="not_recursive",
+        ),
+        param(True, Tree(value=20, left=Tree(value=30)), id="recursive"),
+    ],
+)
+def test_dict_override_merges_target_nested_in_structured_config(
+    instantiate_func: Any, recursive: bool, expected: Any
+) -> None:
+    @dataclass
+    class Value:
+        child: Dict[str, Any] = field(
+            default_factory=lambda: {
+                "_target_": "tests.instantiate.Tree",
+                "value": 10,
+                "left": {
+                    "_target_": "tests.instantiate.Tree",
+                    "value": 30,
+                },
+            }
+        )
+
+    @dataclass
+    class Config:
+        _target_: str = "tests.instantiate.ArgsClass"
+        value: Value = field(default_factory=Value)
+
+    result = instantiate_func(
+        Config,
+        value={"child": {"value": 20}},
+        _recursive_=recursive,
+    )
+
+    assert result.kwargs["value"].child == expected
+
+
+def test_dict_override_merges_non_target_config(instantiate_func: Any) -> None:
+    result = instantiate_func(
+        {"value": {"configured": 10, "overridden": 20}},
+        value={"overridden": 30},
+    )
+
+    assert result == {"value": {"configured": 10, "overridden": 30}}
 
 
 def test_runtime_override_is_not_coerced_by_structured_config(

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -168,8 +168,27 @@ while resolving a later argument.
 
 Primitive values, native `list`, `tuple`, and `dict` containers, and OmegaConf
 containers passed at the call-site retain Hydra's normal configuration
-semantics, including recursive merging, instantiation, and conversion where
-applicable.
+semantics, including instantiation and conversion where applicable.
+
+A `dict` call-site argument replaces the configured value rather than merging
+into it, so the target does not receive configured keys that the call-site
+argument did not name. When the configured value is itself an instantiate
+config, the call-site dict instead overrides the arguments it names and leaves
+the rest of that nested config in place:
+
+```python
+cfg = OmegaConf.create(
+    {
+        "_target_": "my_app.Trainer",
+        "optimizer": {"_target_": "my_app.Optimizer", "lr": 0.1, "momentum": 0.5},
+        "tags": {"env": "prod", "team": "ml"},
+    }
+)
+
+# optimizer is a nested target, so momentum=0.5 is preserved
+# tags is a plain dict, so it is replaced and team is not passed
+instantiate(cfg, optimizer={"lr": 0.3}, tags={"env": "dev"})
+```
 
 Already-constructed dataclass and attrs instances are regular runtime objects.
 They remain unchanged, even if they define `_target_`. To use such an instance

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -172,8 +172,9 @@ Primitive values, native `list`, `tuple`, and `dict` containers, and OmegaConf
 containers passed at the call-site retain Hydra's normal configuration
 semantics, including instantiation and conversion where applicable.
 
-When a `dict` call-site argument overrides a parameter of the target being
-instantiated, it is handled according to the configured parameter value:
+When a `dict` or `DictConfig` call-site argument overrides a parameter of the
+target being instantiated, it is handled according to the configured parameter
+value:
 
 - If the configured value is a Structured Config node, Hydra merges the
   dictionary into a copy of the node, preserving its schema, validation, and
@@ -185,6 +186,10 @@ instantiated, it is handled according to the configured parameter value:
   controls whether the result is instantiated or passed through; it does not
   change this merge behavior.
 - Any other configured mapping is replaced entirely.
+
+Hydra uses the configured parameter's effective value after interpolation to
+select among these cases. If the interpolation cannot be resolved, the
+call-site dictionary replaces it.
 
 ```python
 cfg = OmegaConf.create(

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -159,22 +159,32 @@ Named arguments in the config can be overridden by passing named argument with t
 
 Call-site arguments are applied separately from the input configuration. They
 replace the corresponding arguments passed to the target without modifying the
-input configuration. They therefore do not affect interpolation resolution or
-Structured Config coercion in the input configuration. Configuration values are
-resolved lazily as instantiation proceeds instead of resolving and copying the
-full configuration tree up front. This avoids processing unrelated configuration
-values and allows runtime state established by an earlier target to be used
-while resolving a later argument.
+input configuration. Ordinary replacements therefore do not affect how its
+interpolations resolve. Call-site values are also not generally coerced against
+Structured Config fields. Dictionary overrides of Structured Config nodes are
+the exception, as described below. Configuration values are resolved lazily as
+instantiation proceeds instead of resolving and copying the full configuration
+tree up front. This avoids processing unrelated configuration values and allows
+runtime state established by an earlier target to be used while resolving a
+later argument.
 
 Primitive values, native `list`, `tuple`, and `dict` containers, and OmegaConf
 containers passed at the call-site retain Hydra's normal configuration
 semantics, including instantiation and conversion where applicable.
 
-A `dict` call-site argument replaces the configured value rather than merging
-into it, so the target does not receive configured keys that the call-site
-argument did not name. When the configured value is itself an instantiate
-config, the call-site dict instead overrides the arguments it names and leaves
-the rest of that nested config in place:
+When a `dict` call-site argument overrides a parameter of the target being
+instantiated, it is handled according to the configured parameter value:
+
+- If the configured value is a Structured Config node, Hydra merges the
+  dictionary into a copy of the node, preserving its schema, validation, and
+  fields that the dictionary does not name. Interpolations within that node
+  resolve against the merged values.
+- Otherwise, if the configured mapping contains `_target_`, Hydra merges the
+  dictionary into that target config, preserving its target, instantiation
+  settings, and arguments that the dictionary does not name. `_recursive_`
+  controls whether the result is instantiated or passed through; it does not
+  change this merge behavior.
+- Any other configured mapping is replaced entirely.
 
 ```python
 cfg = OmegaConf.create(

--- a/website/docs/upgrades/1.3_to_1.4/breaking_changes.md
+++ b/website/docs/upgrades/1.3_to_1.4/breaking_changes.md
@@ -57,6 +57,12 @@ have been removed:
 
 ### Instantiation
 
+- A `dict` call-site argument to `hydra.utils.instantiate()` replaces a plain
+  mapping configured for that target parameter instead of merging into it. As
+  an exception, a dictionary overriding a Structured Config node is merged and
+  schema-validated. Configured target values also retain merge behavior,
+  regardless of whether recursive instantiation is enabled. See
+  [Instantiate resolution and call-site overrides](/docs/upgrades/1.3_to_1.4/instantiate_resolution).
 - `hydra.utils.instantiate()` passes dataclass and attrs instances supplied as
   call-site arguments through unchanged instead of interpreting them as
   Structured Configs.

--- a/website/docs/upgrades/1.3_to_1.4/breaking_changes.md
+++ b/website/docs/upgrades/1.3_to_1.4/breaking_changes.md
@@ -57,11 +57,11 @@ have been removed:
 
 ### Instantiation
 
-- A `dict` call-site argument to `hydra.utils.instantiate()` replaces a plain
-  mapping configured for that target parameter instead of merging into it. As
-  an exception, a dictionary overriding a Structured Config node is merged and
-  schema-validated. Configured target values also retain merge behavior,
-  regardless of whether recursive instantiation is enabled. See
+- A `dict` or `DictConfig` call-site argument to `hydra.utils.instantiate()`
+  replaces a plain mapping configured for that target parameter instead of
+  merging into it. As an exception, a dictionary overriding a Structured Config
+  node is merged and schema-validated. Configured target values also retain
+  merge behavior, regardless of whether recursive instantiation is enabled. See
   [Instantiate resolution and call-site overrides](/docs/upgrades/1.3_to_1.4/instantiate_resolution).
 - `hydra.utils.instantiate()` passes dataclass and attrs instances supplied as
   call-site arguments through unchanged instead of interpreting them as

--- a/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
+++ b/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
@@ -33,17 +33,35 @@ This has several benefits:
 
 Call-site arguments are now a separate runtime overlay. They determine the
 arguments passed to the target, but they do not modify the input configuration
-or affect how its interpolations resolve.
+itself. Ordinary replacements do not affect how input interpolations resolve.
+A dictionary overriding a Structured Config node is the exception: Hydra
+updates a copy of that node, so its interpolations resolve against the updated
+values.
 
-They are also no longer coerced or validated against the corresponding field
-in an input Structured Config. Primitive values, native `list`, `tuple`, and
-`dict` containers, and OmegaConf containers remain supported configuration
-inputs. They retain Hydra's normal instantiation and conversion where
-applicable.
+Call-site arguments are not generally coerced or validated against the
+corresponding field in an input Structured Config. Dictionary overrides of
+Structured Config nodes are the exception, as described below. Primitive
+values, native `list`, `tuple`, and `dict` containers, and OmegaConf containers
+remain supported configuration inputs. They retain Hydra's normal
+instantiation and conversion where applicable.
 
-A `dict` call-site argument no longer merges into the configured value. Hydra
-1.3 merged the two, so the target received configured keys that the call-site
-argument did not name:
+When a `dict` call-site argument overrides a parameter of the target being
+instantiated, it is handled according to the configured parameter value:
+
+- If the configured value is a Structured Config node, Hydra validates the
+  merged dictionary against the schema. Fields that the dictionary does not
+  name retain their configured values, and interpolations within the node can
+  observe the merged values.
+- Otherwise, if the configured mapping contains `_target_`, Hydra merges the
+  dictionary into that target config, preserving its target, instantiation
+  settings, and arguments that the dictionary does not name. `_recursive_`
+  controls whether the result is instantiated or passed through; it does not
+  change this merge behavior.
+- Any other configured mapping is replaced entirely.
+
+The Structured Config behavior is an exception to replacement. Hydra 1.3
+instead merged dictionaries into configured plain mappings, so the target
+received configured keys that the call-site argument did not name:
 
 ```python
 from hydra.utils import instantiate
@@ -59,9 +77,7 @@ assert result["tags"] == {"env": "dev"}
 
 Hydra 1.3 returned `{"env": "dev", "team": "ml"}` for `tags`.
 
-A configured value that is itself an instantiate config keeps the documented
-patching behavior. The call-site dict overrides the arguments it names and
-leaves the rest of that nested config in place:
+For example, a configured target retains its merge behavior:
 
 ```python
 cfg = {
@@ -78,7 +94,7 @@ assert result["optimizer"] == {"lr": 0.3, "momentum": 0.5}
 ```
 
 To pass a merged value, merge it explicitly at the call-site, for example with
-`OmegaConf.merge(cfg.tags, {"env": "dev"})`.
+`OmegaConf.merge(cfg["tags"], {"env": "dev"})`.
 
 Hydra 1.4 intentionally changes the treatment of already-constructed dataclass
 and attrs instances passed as call-site arguments. They are now regular runtime

--- a/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
+++ b/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
@@ -45,8 +45,9 @@ values, native `list`, `tuple`, and `dict` containers, and OmegaConf containers
 remain supported configuration inputs. They retain Hydra's normal
 instantiation and conversion where applicable.
 
-When a `dict` call-site argument overrides a parameter of the target being
-instantiated, it is handled according to the configured parameter value:
+When a `dict` or `DictConfig` call-site argument overrides a parameter of the
+target being instantiated, it is handled according to the configured parameter
+value:
 
 - If the configured value is a Structured Config node, Hydra validates the
   merged dictionary against the schema. Fields that the dictionary does not
@@ -58,6 +59,10 @@ instantiated, it is handled according to the configured parameter value:
   controls whether the result is instantiated or passed through; it does not
   change this merge behavior.
 - Any other configured mapping is replaced entirely.
+
+Hydra uses the configured parameter's effective value after interpolation to
+select among these cases. If the interpolation cannot be resolved, the
+call-site dictionary replaces it.
 
 The Structured Config behavior is an exception to replacement. Hydra 1.3
 instead merged dictionaries into configured plain mappings, so the target

--- a/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
+++ b/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
@@ -38,8 +38,47 @@ or affect how its interpolations resolve.
 They are also no longer coerced or validated against the corresponding field
 in an input Structured Config. Primitive values, native `list`, `tuple`, and
 `dict` containers, and OmegaConf containers remain supported configuration
-inputs. They retain Hydra's normal recursive merging, instantiation, and
-conversion where applicable.
+inputs. They retain Hydra's normal instantiation and conversion where
+applicable.
+
+A `dict` call-site argument no longer merges into the configured value. Hydra
+1.3 merged the two, so the target received configured keys that the call-site
+argument did not name:
+
+```python
+from hydra.utils import instantiate
+
+cfg = {
+    "_target_": "builtins.dict",
+    "tags": {"env": "prod", "team": "ml"},
+}
+
+result = instantiate(cfg, tags={"env": "dev"}, _target_whitelist_="builtins.dict")
+assert result["tags"] == {"env": "dev"}
+```
+
+Hydra 1.3 returned `{"env": "dev", "team": "ml"}` for `tags`.
+
+A configured value that is itself an instantiate config keeps the documented
+patching behavior. The call-site dict overrides the arguments it names and
+leaves the rest of that nested config in place:
+
+```python
+cfg = {
+    "_target_": "builtins.dict",
+    "optimizer": {"_target_": "builtins.dict", "lr": 0.1, "momentum": 0.5},
+}
+
+result = instantiate(
+    cfg,
+    optimizer={"lr": 0.3},
+    _target_whitelist_="builtins.dict",
+)
+assert result["optimizer"] == {"lr": 0.3, "momentum": 0.5}
+```
+
+To pass a merged value, merge it explicitly at the call-site, for example with
+`OmegaConf.merge(cfg.tags, {"env": "dev"})`.
 
 Hydra 1.4 intentionally changes the treatment of already-constructed dataclass
 and attrs instances passed as call-site arguments. They are now regular runtime


### PR DESCRIPTION
## Motivation

Fixes #2350.

A `dict` passed at the `instantiate()` call-site was recursively merged into a
configured plain mapping, so the target received configured keys that the caller
never named:

```python
@dataclass
class Buildsf:
    _target_: str = "__main__.f"
    x: Dict[str, int] = field(default_factory=lambda: {"K_DEFAULT": 10101})

instantiate(Buildsf, x={"a": 1})
# before: {"K_DEFAULT": 10101, "a": 1}
# after:  {"a": 1}
```

This still reproduced on Hydra 1.4 development releases after the instantiate
rewrite.

## Final behavior

- A call-site `dict` or `DictConfig` replaces a configured plain mapping for a target parameter.
- When the configured value is a Structured Config node, Hydra validates and
  merges the dictionary into a copy of that node. Unnamed fields are preserved,
  and interpolations within the node observe the updated values.
- When the configured value is itself a target config, Hydra merges the
  dictionary into that config so `_target_`, instantiation settings, and unnamed
  arguments are preserved. `_recursive_` controls whether the merged result is
  instantiated; it does not change the merge behavior.
- Interpolated configured mappings are classified by their effective value:
  target and Structured Config results retain merge behavior, plain mappings are
  replaced, and an unresolvable interpolation remains replaceable.
- Already-constructed dataclass and attrs values supplied within the override
  retain their runtime identity instead of being reinterpreted as configuration.
- The input configuration is not modified.

The Structured Config and configured-target cases deliberately remain exceptions
to plain-mapping replacement. This preserves schema validation and established
nested-target argument patching without restoring the surprising merge behavior
reported in #2350.

## Implementation

The contributor change establishes replacement for plain mapping target
parameters. The follow-ups distinguish target parameters from non-target config
traversal, retain merge behavior for Structured Config and target config values,
and preserve nested runtime objects after schema validation.

OmegaConf 2.4.0.dev15 supplies the typed `None` and missing-node merge behavior
needed to preserve schema metadata, parent context, effective flags, and
interpolations outside the merged subtree.

## Test plan

- `pytest tests/instantiate`: 535 passed.
- `nox -s lint-core-3.11`: passed against OmegaConf 2.4.0.dev15 from PyPI.
- `nox -s test_core-3.11`: 2,733 passed, 216 skipped, 1 expected failure;
  standalone applications and example plugins also passed.
- `pnpm --dir website build`: passed with pre-existing documentation warnings.

Tests cover plain-mapping replacement, the original Structured Config/default
factory reproduction, schema coercion and validation, interpolation updates,
read-only input preservation, target configs under both recursive modes, effective mapping classification for
interpolations and custom resolvers, absent parameters, `None` and missing
Structured Config values, nested runtime-object
identity across conversion modes, and mapping and sequence result paths.

The instantiate reference documentation, Hydra 1.4 migration guide,
breaking-change list, and `news/2350.api_change` describe the same behavior.

## Related issues and PRs

- Fixes #2350.
- Builds on #3302, #3316, and #3325, and extends the migration notes added for
  #3216.
