### PR TITLE
Resolve configured interpolations against call-site arguments

### DIFF
--- a/hydra/_internal/instantiate/_instantiate2.py
+++ b/hydra/_internal/instantiate/_instantiate2.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import copy
 import functools
 import inspect
 import os
@@ -674,6 +675,58 @@ def _instantiate_override(
     return value
 
 
+def _contains_interpolation(node: Any) -> bool:
+    if node is None:
+        return False
+    if node._is_interpolation():
+        return True
+    if not OmegaConf.is_config(node) or node._is_none() or node._is_missing():
+        return False
+    keys: Any = range(len(node)) if OmegaConf.is_sequence(node) else node.keys()
+    return any(_contains_interpolation(node._get_node(key)) for key in keys)
+
+
+def _has_surviving_interpolation(node: Any, overrides: ConfigOverlay) -> bool:
+    """Whether a configured interpolation outlives the call-site arguments.
+
+    A configured value that a call-site argument replaces entirely is not
+    processed, so an interpolation inside it does not need to be resolved.
+    """
+    return any(
+        key not in overrides and _contains_interpolation(node._get_node(key))
+        for key in node.keys()
+    )
+
+
+def _effective_node(node: Any, overrides: ConfigOverlay) -> Any:
+    """A copy of node with the call-site arguments layered over it.
+
+    Configured interpolations are resolved against this copy so that they see
+    the values being passed to the target. The input configuration is never
+    modified. Call-site values are inserted as raw nodes, because assigning
+    them would coerce or reject them against an input Structured Config, and
+    container flags such as struct and readonly would reject them outright.
+    """
+    effective = copy.deepcopy(node)
+    for flag, value in (("readonly", False), ("struct", False)):
+        effective._set_flag(flag, value)
+    content = effective.__dict__["_content"]
+    for key in overrides:
+        override = overrides[key]
+        child = (
+            copy.deepcopy(override)
+            if OmegaConf.is_config(override)
+            else AnyNode(override, flags={"allow_objects": True})
+        )
+        child._set_parent(effective)
+        child._set_key(key)
+        content[key] = child
+    # Keep ancestor context so interpolations reaching outside node still work.
+    effective._set_parent(node._get_parent())
+    effective._set_key(node._key())
+    return effective
+
+
 def _instantiate_effective_value(
     node: Any,
     key: str,
@@ -682,6 +735,7 @@ def _instantiate_effective_value(
     convert: Union[str, ConvertMode],
     recursive: bool,
     target_whitelist: NormalizedTargetWhitelist,
+    effective: Any = None,
 ) -> Any:
     if overrides is not None and key in overrides:
         override = overrides[key]
@@ -704,7 +758,13 @@ def _instantiate_effective_value(
             target_whitelist=target_whitelist,
         )
 
-    value = node[key]
+    # The effective configuration only matters for values Hydra resolves here.
+    # A container passed through without recursion is resolved later by the
+    # caller, so it is handed over as the configured node itself.
+    source = node
+    if effective is not None and (recursive or node._get_node(key)._is_interpolation()):
+        source = effective
+    value = source[key]
     if recursive:
         value = instantiate_node(
             value,
@@ -792,6 +852,13 @@ def instantiate_node(
             raise InstantiationException(_with_full_key(msg, full_key))
 
         exclude_keys = set({"_target_", "_convert_", "_recursive_", "_partial_"})
+        # Only pay for the effective copy when a configured interpolation
+        # survives the call-site arguments and could depend on one of them.
+        effective = (
+            _effective_node(node, overrides)
+            if overrides and _has_surviving_interpolation(node, overrides)
+            else None
+        )
         if (overrides is not None and _Keys.TARGET in overrides) or _is_target(node):
             target = (
                 overrides[_Keys.TARGET]
@@ -812,6 +879,7 @@ def instantiate_node(
                         convert=convert,
                         recursive=recursive,
                         target_whitelist=target_whitelist,
+                        effective=effective,
                     )
                     kwargs[key] = _convert_node(value, convert)
 
@@ -841,6 +909,7 @@ def instantiate_node(
                         convert=convert,
                         recursive=recursive,
                         target_whitelist=target_whitelist,
+                        effective=effective,
                     )
                 return dict_items
             else:
@@ -857,6 +926,7 @@ def instantiate_node(
                             convert=convert,
                             recursive=recursive,
                             target_whitelist=target_whitelist,
+                            effective=effective,
                         )
                     )
                 cfg._set_parent(node)

--- a/tests/instantiate/test_instantiate.py
+++ b/tests/instantiate/test_instantiate.py
@@ -224,13 +224,13 @@ def register_test_resolver(name: str, value: Any) -> Any:
         param(
             {"_target_": "tests.instantiate.AClass", "b": 200, "c": "${b}"},
             {"a": 10, "b": 99, "d": 40},
-            AClass(10, 99, 200, 40),
+            AClass(10, 99, 99, 40),
             id="class+override+interpolation",
         ),
         param(
             {"_target_": "tests.instantiate.AClass", "b": 200, "c": "${b}"},
             {"a": 10, "b": 99, "_partial_": True},
-            partial(AClass, a=10, b=99, c=200),
+            partial(AClass, a=10, b=99, c=99),
             id="class+override+interpolation+partial1",
         ),
         param(
@@ -241,7 +241,7 @@ def register_test_resolver(name: str, value: Any) -> Any:
                 "c": "${b}",
             },
             {"a": 10, "b": 99},
-            partial(AClass, a=10, b=99, c=200),
+            partial(AClass, a=10, b=99, c=99),
             id="class+override+interpolation+partial2",
         ),
         # Check class and static methods
@@ -669,6 +669,79 @@ def test_instantiate_does_not_copy_unrelated_root_siblings(
     )
 
     assert instantiate_func(cfg.node) == AClass(a=10, b=20, c=30)
+
+
+@mark.parametrize("is_partial", [True, False])
+def test_callsite_argument_is_visible_to_nested_interpolation(
+    instantiate_func: Any, is_partial: bool
+) -> None:
+    """
+    In 3353, a configured interpolation resolved against the input value
+    instead of the value being passed to the target.
+    """
+    cfg = OmegaConf.create(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "b": 200,
+            "sibling": "${b}",
+            "nested": {"deep": "${b}", "relative": "${.deep}"},
+        }
+    )
+    original_config = str(cfg)
+
+    result = instantiate_func(cfg, b=99, _partial_=is_partial)
+    kwargs = result.keywords if is_partial else result.kwargs
+
+    assert kwargs["b"] == 99
+    assert kwargs["sibling"] == 99
+    assert kwargs["nested"] == {"deep": 99, "relative": 99}
+    assert str(cfg) == original_config
+
+
+def test_callsite_argument_does_not_resolve_a_replaced_value(
+    instantiate_func: Any,
+) -> None:
+    """
+    A configured value that a call-site argument replaces entirely is not
+    resolved, so an unresolvable interpolation inside it is not an error.
+    """
+    result = instantiate_func(
+        {
+            "_target_": "tests.instantiate.ArgsClass",
+            "value": "${nonexistent}",
+        },
+        value=10,
+    )
+
+    assert result.kwargs["value"] == 10
+
+
+def test_non_recursive_config_argument_keeps_identity_with_callsite_argument(
+    instantiate_func: Any,
+) -> None:
+    """
+    A non-recursive container is resolved by the caller rather than by Hydra,
+    so a call-site argument elsewhere must not cost it its identity.
+    """
+    cfg = OmegaConf.create(
+        {
+            "node": {
+                "_target_": "tests.instantiate.ArgsClass",
+                "_recursive_": False,
+                "b": 200,
+                "sibling": "${.b}",
+                "payload": {"value": 10, "alias": "${.value}"},
+            },
+        },
+        flags={"allow_objects": True},
+    )
+    source_payload = cfg.node.payload
+
+    result = instantiate_func(cfg.node, b=99)
+
+    assert result.kwargs["sibling"] == 99
+    assert result.kwargs["payload"] is source_payload
+    assert source_payload._get_parent() is cfg.node
 
 
 def test_non_recursive_config_argument_is_passed_directly_without_resolving(

--- a/website/docs/advanced/instantiate_objects/overview.md
+++ b/website/docs/advanced/instantiate_objects/overview.md
@@ -159,8 +159,10 @@ Named arguments in the config can be overridden by passing named argument with t
 
 Call-site arguments are applied separately from the input configuration. They
 replace the corresponding arguments passed to the target without modifying the
-input configuration. They therefore do not affect interpolation resolution or
-Structured Config coercion in the input configuration. Configuration values are
+input configuration, and without being coerced against a Structured Config
+field. A configured interpolation that survives still resolves against the
+values being passed to the target, so overriding an argument also updates the
+interpolations that depend on it. Configuration values are
 resolved lazily as instantiation proceeds instead of resolving and copying the
 full configuration tree up front. This avoids processing unrelated configuration
 values and allows runtime state established by an earlier target to be used

--- a/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
+++ b/website/docs/upgrades/1.3_to_1.4/instantiate_resolution.md
@@ -32,8 +32,10 @@ This has several benefits:
 ## Compatibility impact
 
 Call-site arguments are now a separate runtime overlay. They determine the
-arguments passed to the target, but they do not modify the input configuration
-or affect how its interpolations resolve.
+arguments passed to the target without modifying the input configuration. A
+configured interpolation that survives the overlay still resolves against the
+values being passed to the target, so an argument the call-site replaces is
+seen by the interpolations that depend on it.
 
 They are also no longer coerced or validated against the corresponding field
 in an input Structured Config. Primitive values, native `list`, `tuple`, and
@@ -82,7 +84,8 @@ config_result = instantiate(
 assert config_result["child"] == {"value": 10}
 ```
 
-For example:
+The input configuration is left unchanged, while the interpolation still sees
+the value passed at the call-site:
 
 ```python
 from omegaconf import OmegaConf
@@ -98,13 +101,14 @@ cfg = OmegaConf.create(
 )
 
 result = instantiate(cfg, b=99, _target_whitelist_="builtins.dict")
-assert result == {"b": 99, "c": 200}
+assert result == {"b": 99, "c": 99}
+assert cfg.b == 200
 ```
 
-Hydra 1.3 merged `b=99` into a copied configuration before resolving `${b}`,
-so `c` also became `99`. Hydra 1.4 leaves `cfg` unchanged, resolves `${b}`
-against the original configuration, and independently passes the call-site
-value `b=99` to the target.
+Hydra 1.3 achieved this by merging `b=99` into a copied configuration before
+resolving `${b}`. Hydra 1.4 resolves the interpolation against the effective
+configuration being instantiated instead, so `cfg` itself is never modified and
+a configured value that the call-site replaces is not resolved at all.
 
 With `_recursive_=False` and `_convert_="none"`, OmegaConf containers are also
 no longer copied and detached before the target call. The target receives the
@@ -143,14 +147,7 @@ independent = OmegaConf.create(
 )
 ```
 
-If another argument should use the call-site value, pass that argument
-explicitly as well:
-
-```python
-result = instantiate(
-    cfg,
-    b=99,
-    c=99,
-    _target_whitelist_="builtins.dict",
-)
-```
+A container passed through without recursion is resolved by the caller rather
+than by Hydra, so it keeps its identity and its own ancestor context even when
+another argument is overridden at the call-site. Its interpolations therefore
+resolve against the input configuration.


### PR DESCRIPTION
## Motivation

Fixes #3353.

Keeping call-site arguments out of the input configuration also kept them out of
interpolation resolution, so a configured interpolation resolved against the value it was
overriding:

```python
cfg = {"_target_": "builtins.dict", "b": 200, "c": "${b}"}
instantiate(cfg, b=99)
# before: {'b': 99, 'c': 200}
# after:  {'b': 99, 'c': 99}
```

OmegaConf resolves an interpolation by walking `_get_parent()` to the root of the tree and
selecting from there (`base.py::_resolve_node_interpolation` → `_resolve_key_and_root`), so
`${b}` always resolved against the untouched input. Nothing done at the point where the
value is read can change that; the overrides have to be visible in the *resolution context*.

Configured values are therefore resolved against an effective configuration: a copy of the
node with the call-site arguments layered over it. Three details make it fit the
constraints in the issue:

1. The copy keeps the original's parent and key, so interpolations that reach outside the
   node still resolve.
2. Call-site values are inserted as raw nodes rather than assigned. Assigning goes through
   validation, which defeats the purpose — see below.
3. The copy is only built when a configured interpolation actually survives the call-site
   arguments (`_has_surviving_interpolation`). A value the call-site replaces entirely is
   never resolved, so an unresolvable interpolation inside it is still not an error.

A container passed through without recursion is resolved by the caller rather than by
Hydra, so it is still handed over as the configured node itself and keeps its identity,
flags and ancestor context. That preserves the guarantees added in #3325.

### Why the values are inserted as raw nodes

The obvious implementation — copy the node, then `effective[key] = value` — does not work.
Measured on all three:

| attempt | result |
|---|---|
| assignment on a copy of a Structured Config | `ValidationError`, coercing/rejecting the runtime value |
| same, with `allow_objects=True` | still `ValidationError`; the flag does not bypass a typed field |
| same, on a `readonly`/`struct` config | `ReadonlyConfigError` |

Coercing call-site values against an input Structured Config is exactly what #3316 removed,
so the effective copy must not reintroduce it.

### Two things I would like your call on

**1. `_content` insertion is a new internal dependency.** Hydra already relies on a number
of OmegaConf internals (`_get_node`, `_set_parent`, `_metadata`, `_is_none`, `_set_flag`,
`_is_interpolation`, …), but not on `_content`. A working alternative is to strip
`object_type`/`element_type` from the copy's metadata, delete the key, and assign normally;
I did not use it because it mutates the copy's schema and needs an extra guard for
call-site-only keys. Happy to switch, or to move this behind a small OmegaConf-side API if
you would rather have one.

**2. This brings back a copy, gated.** Not copying was a stated benefit of #3216. The copy
here is per-node, only on nodes that actually receive call-site arguments (nested recursion
passes no overrides, so it does not compound), and only when a surviving interpolation
exists — but it is still a partial trade against that benefit, so it should be a deliberate
decision rather than something that slips through.

### Known limitation

An *absolute* interpolation that routes through the real tree root still resolves against
the input — e.g. `instantiate(cfg.trainer, lr=...)` where `cfg.trainer.x` is
`"${trainer.lr}"`. That follows from deliberately keeping the copy's ancestor chain, which
the issue asks for. Relative (`${.lr}`) and root-level cases both work.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebookresearch/hydra/blob/main/CONTRIBUTING.md)?

Yes.

### For non-trivial features, API changes, or behavior changes: is there an issue or design discussion where maintainers agreed on the direction?

Yes — #3353 specifies both the expected behavior and the four properties the fix has to
retain. This PR implements that issue and nothing beyond it.

## Test Plan

The three expectations that #3302 changed from `c=99` to `c=200` are restored, which is the
regression itself (12 cases: 3 params × 2 config fixtures × 2 recursive flags).

Four tests added:

- `test_callsite_argument_is_visible_to_nested_interpolation` — parametrized over normal and
  partial instantiation; covers sibling `${b}`, nested `${b}`, relative `${.deep}`, and
  asserts the source config is unchanged.
- `test_callsite_argument_does_not_resolve_a_replaced_value` — a value the call-site
  replaces is not resolved, so an unresolvable interpolation inside it is not an error.
- `test_non_recursive_config_argument_keeps_identity_with_callsite_argument` — a
  non-recursive container keeps its identity and parent even when another argument is
  overridden.

Three of the four fail before the change (verified by reverting only `hydra/`); the
replaced-value one passes before and after, since it guards a property the fix must not
break.

```
pytest tests/instantiate/                  # 485 passed (481 before + 4 new)
pytest --ignore=tests/test_completion.py   # 2164 passed, 0 failed
```

Two environment notes, both reproduced identically on pristine `main` here:

- `tests/test_completion.py` has 130 failures on macOS (zsh/bash shell integration). The
  list of failing ids is identical to the one `main` produces.
- On Python 3.14, 7 tests in `tests/test_hydra.py` fail because tracebacks are colorized and
  the assertions are plain substring checks (`assert "ZeroDivisionError: division by zero"
  in ret` vs `\x1b[1;35mZeroDivisionError\x1b[0m`). With `PYTHON_COLORS=0` the suite is
  fully green, and they fail the same way on `main`. Unrelated to this change, but possibly
  worth its own issue.

Lint clean: `ruff format --check .`, `ruff check .`, `yamllint --strict .`,
`bandit -ll -r .`. `pyrefly check --config pyproject.toml` reports one error in
`build_helpers/build_helpers.py`, untouched here and identical on `main`.

Docs: #3302 documented the behavior this restores, including a worked example asserting
`c == 200`, and `instantiate_objects/overview.md` stated that call-site arguments "do not
affect interpolation resolution". Both are corrected, and the new upgrade-guide example was
executed to confirm it asserts as written. No news fragment, since the regression only
exists on the unreleased 1.4 line and `3216.api_change` already describes the call-site
model — same reasoning as #3355, happy to add one if you prefer.

## Related Issues and PRs

- Fixes #3353
- Regression from #3302; extends the migration notes added for #3216 and preserves the
  pass-through guarantees from #3325.
- Touches the same file as #3352 and #3355 but different functions
  (`_instantiate_effective_value` / `_is_missing_parameter`), and the same upgrade-guide
  page as #3352 but a different section. Should not conflict meaningfully in any merge
  order.
